### PR TITLE
V next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wide"
 description = "A crate to help you go wide."
-version = "0.2.7-alpha.0"
+version = "0.3.0-alpha"
 authors = ["Lokathor <zefria@gmail.com>"]
 repository = "https://github.com/Lokathor/wide"
 readme = "README.md"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,12 @@
+use wide::*;
+
+fn main() {
+  // /*
+  let mut f = 0.0;
+  while f <= 1.5 {
+    println!("rad {:.2}: s/c {:?}", f, f32x4::from(f).sin_cos());
+    f += 0.1;
+  }
+  // */
+  //println!("s/c {:?}", f32x4::new(1.0, 2.0, 4.0, 5.0).sin_cos());
+}

--- a/src/arch/fma.rs
+++ b/src/arch/fma.rs
@@ -1,0 +1,17 @@
+#![cfg(target_feature = "fma")]
+
+use super::*;
+
+impl m128 {
+  /// fused `(self * b) + c`
+  #[inline(always)]
+  pub fn fmadd(self, b: Self, c: Self) -> Self {
+    Self(unsafe { _mm_fmadd_ps(self.0, b.0, c.0) })
+  }
+
+  /// fused `-(self * b) + c`
+  #[inline(always)]
+  pub fn fnmadd(self, b: Self, c: Self) -> Self {
+    Self(unsafe { _mm_fnmadd_ps(self.0, b.0, c.0) })
+  }
+}

--- a/src/arch/sse4_1.rs
+++ b/src/arch/sse4_1.rs
@@ -1,8 +1,8 @@
-#![cfg(target_feature="sse")]
-#![cfg(target_feature="sse2")]
-#![cfg(target_feature="sse3")]
-#![cfg(target_feature="ssse3")]
-#![cfg(target_feature="sse4.1")]
+#![cfg(target_feature = "sse")]
+#![cfg(target_feature = "sse2")]
+#![cfg(target_feature = "sse3")]
+#![cfg(target_feature = "ssse3")]
+#![cfg(target_feature = "sse4.1")]
 
 use super::*;
 
@@ -46,6 +46,10 @@ impl m128 {
   #[inline(always)]
   pub fn floor_rhs0(self, rhs: Self) -> Self {
     Self(unsafe { _mm_floor_ss(self.0, rhs.0) })
+  }
+
+  pub fn round_nearest(self) -> Self {
+    Self(unsafe { _mm_round_ps(self.0, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC) })
   }
 }
 

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -46,6 +46,12 @@ mod sse4_2;
 #[cfg(target_feature = "sse4.2")]
 pub use sse4_2::*;
 
+#[cfg(target_feature = "fma")]
+#[path = "fma.rs"]
+mod fma;
+#[cfg(target_feature = "fma")]
+pub use fma::*;
+
 /// As [`_rdtsc`](https://doc.rust-lang.org/core/arch/x86/fn._rdtsc.html).
 #[inline]
 pub fn rdtsc() -> u64 {

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -46,6 +46,12 @@ mod sse4_2;
 #[cfg(target_feature = "sse4.2")]
 pub use sse4_2::*;
 
+#[cfg(target_feature = "fma")]
+#[path = "fma.rs"]
+mod fma;
+#[cfg(target_feature = "fma")]
+pub use fma::*;
+
 /// As [`_rdtsc`](https://doc.rust-lang.org/core/arch/x86_64/fn._rdtsc.html).
 #[inline]
 pub fn rdtsc() -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,12 +50,15 @@ pub mod arch;
 
 cfg_if! {
   if #[cfg(all(target_arch="x86", target_feature="sse"))] {
-    pub(crate) use arch::x86::m128;
+    pub(crate) use arch::x86::{m128, m128i};
   } else if #[cfg(all(target_arch="x86_64", target_feature="sse"))] {
-    pub(crate) use arch::x86_64::m128;
+    pub(crate) use arch::x86_64::{m128, m128i};
   }
   // TODO: arm, aarch64, wasm32, maybe more?
 }
 
 mod m_f32x4;
 pub use m_f32x4::*;
+
+mod m_i32x4;
+pub use m_i32x4::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,14 @@ pub(crate) use bytemuck::{cast, cast_mut, cast_ref, Pod, Zeroable};
 pub(crate) use cfg_if::cfg_if;
 pub(crate) use core::{convert::*, fmt::*, ops::*};
 
+/// debug_assertions only: `file!():line!() expr: expr_value`, one per line
+#[macro_export]
+macro_rules! dump {
+  ($($n:expr),*) => (if cfg!(debug_assertions) {
+    $(println!(concat!("{}:{} ",stringify!($n),": {:?}"),file!(),line!(),$n);)*
+  })
+}
+
 pub mod arch;
 
 cfg_if! {

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -568,7 +568,7 @@ impl f32x4 {
       let mut out = 0_i32;
       for i in 0..4 {
         if cast::<f32, i32>(self.arr[i]) < 0 {
-          out |= (1<<i);
+          out |= 1<<i;
         }
       }
       out
@@ -1364,6 +1364,7 @@ impl f32x4 {
   //   c3.mul_add(self, c2).mul_add(self2, c1.mul_add(self, c0))
   // }
 
+  /// Sine and Cosine as a single operation.
   #[allow(clippy::unreadable_literal)]
   #[allow(clippy::excessive_precision)]
   #[allow(clippy::many_single_char_names)]

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -269,18 +269,18 @@ impl f32x4 {
       // yes it's weird, yes it's correct.
       Self { sse: self.sse.cmp_nan(self.sse) }
     } else {
-      let op = |a:f32, b:f32| {
-        if a.is_nan() | b.is_nan() {
+      let op = |a:f32| {
+        if a.is_nan() {
           f32::from_bits(u32::max_value())
         } else {
           0.0
         }
       };
       Self { arr: [
-        op(self.arr[0], rhs.arr[0]),
-        op(self.arr[1], rhs.arr[1]),
-        op(self.arr[2], rhs.arr[2]),
-        op(self.arr[3], rhs.arr[3]),
+        op(self.arr[0]),
+        op(self.arr[1]),
+        op(self.arr[2]),
+        op(self.arr[3]),
       ] }
     }}
   }
@@ -290,18 +290,18 @@ impl f32x4 {
       // yes it's weird, yes it's correct.
       Self { sse: self.sse.cmp_ordinary(self.sse) }
     } else {
-      let op = |a:f32, b:f32| {
-        if (!a.is_nan()) & (!b.is_nan()) {
+      let op = |a:f32| {
+        if !a.is_nan() {
           f32::from_bits(u32::max_value())
         } else {
           0.0
         }
       };
       Self { arr: [
-        op(self.arr[0], rhs.arr[0]),
-        op(self.arr[1], rhs.arr[1]),
-        op(self.arr[2], rhs.arr[2]),
-        op(self.arr[3], rhs.arr[3]),
+        op(self.arr[0]),
+        op(self.arr[1]),
+        op(self.arr[2]),
+        op(self.arr[3]),
       ] }
     }}
   }

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -264,6 +264,27 @@ impl f32x4 {
     }}
   }
 
+  pub fn is_nan(self) -> Self {
+    cfg_if! {if #[cfg(target_feature="sse")] {
+      // yes it's weird, yes it's correct.
+      Self { sse: self.sse.cmp_nan(self.sse) }
+    } else {
+      let op = |a:f32, b:f32| {
+        if a.is_nan() | b.is_nan() {
+          f32::from_bits(u32::max_value())
+        } else {
+          0.0
+        }
+      };
+      Self { arr: [
+        op(self.arr[0], rhs.arr[0]),
+        op(self.arr[1], rhs.arr[1]),
+        op(self.arr[2], rhs.arr[2]),
+        op(self.arr[3], rhs.arr[3]),
+      ] }
+    }}
+  }
+
   /// Use `self` (a boolish value) to merge `a` and `b`.
   ///
   /// For each lane index, if the `self` lane is "true" then the `a` value will

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -1137,7 +1137,7 @@ impl f32x4 {
         .cmp_eq_i32(m128i::splat_i32(EXPONENT_MASKi));
       Self { sse: t3.cast_m128() }
     } else {
-      let op |f: f32| {
+      let op = |f: f32| {
         let t1 = f.to_bits();
         let t2 = t1 << 1;
         let t3 = (t2 & EXPONENT_MASKu) != EXPONENT_MASKu;
@@ -1791,5 +1791,16 @@ impl From<[u16; 4]> for f32x4 {
   #[inline]
   fn from([a, b, c, d]: [u16; 4]) -> Self {
     Self::new(f32::from(a), f32::from(b), f32::from(c), f32::from(d))
+  }
+}
+
+impl Not for f32x4 {
+  type Output = Self;
+  /// Bitwise negation
+  #[inline(always)]
+  fn not(self) -> Self {
+    let f: f32 = f32::from_bits(u32::max_value());
+    let b = Self::from(f);
+    self ^ b
   }
 }

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -275,7 +275,7 @@ impl f32x4 {
   /// all 1s or all 0s anyway.
   #[inline]
   pub fn merge(self, a: Self, b: Self) -> Self {
-    cfg_if! {if #[cfg(target_feature="sse")] {
+    cfg_if! {if #[cfg(target_feature="sse4.1")] {
       Self { sse: b.sse.blend_var(a.sse, self.sse) }
     } else {
       (self & a) | self.andnot(b)

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -14,10 +14,204 @@ cfg_if! {
   }
 }
 #[test]
-fn declaration_tests() {
+fn declaration_tests_f32x4() {
   use core::mem::{align_of, size_of};
   assert_eq!(size_of::<f32x4>(), 16);
   assert_eq!(align_of::<f32x4>(), 16);
+}
+
+#[allow(non_camel_case_types)]
+pub union ConstUnionHack_f32x4 {
+  narrow_arr: [f32; 4],
+  wide_thing: f32x4,
+}
+#[test]
+#[allow(non_snake_case)]
+fn declaration_tests_ConstUnionHack_f32x4() {
+  use core::mem::{align_of, size_of};
+  assert_eq!(size_of::<ConstUnionHack_f32x4>(), size_of::<f32x4>());
+  assert_eq!(align_of::<ConstUnionHack_f32x4>(), align_of::<f32x4>());
+}
+
+/// Declares an `f32x4` const identifier.
+///
+/// ## Broadcast A Single Value
+///
+/// * **Usage:** `const_f32_as_f32x4!(#[meta]* vis ident, val);`
+///
+/// The value should be a single `f32` expression, which is then duplicated into
+/// all lanes of the constant declaration.
+///
+/// ```rust
+/// const_f32_as_f32x4!(
+///   /// Machine epsilon value for `f32`.
+///   pub EPSILON, core::f32::EPSILON
+/// );
+/// ```
+///
+/// ## Select Each Lane
+///
+/// * **Usage:** `const_f32_as_f32x4!(#[meta]* vis ident, a, b, c, d);`
+///
+/// Each of `a`, `b`, `c`, and `d` are an `f32` expression when are then placed
+/// into the constant declaration (low lane to high lane).
+///
+/// ```rust
+/// const_f32_as_f32x4!(
+///   /// 1, 2, 3, 4
+///   pub ONE_TWO_THREE_FOUR, 1.0, 2.0, 3.0, 4.0
+/// );
+/// ```
+#[macro_export]
+macro_rules! const_f32_as_f32x4 {
+  // broadcast a single value
+  ($(#[$attrs:meta])* $v:vis $i:ident, $val:expr) => {
+    $(#[$attrs])*
+    $v const $i: f32x4 = {
+      let cuh = ConstUnionHack_f32x4 {
+        narrow_arr: [$val, $val, $val, $val],
+      };
+      unsafe { cuh.wide_thing }
+    };
+  };
+  // select each lane's value
+  ($(#[$attrs:meta])* $v:vis $i:ident, $a:expr, $b:expr, $c:expr, $d:expr) => {
+    $(#[$attrs])*
+    $v const $i: f32x4 = {
+      let cuh = ConstUnionHack_f32x4 {
+        narrow_arr: [$a, $b, $c, $d],
+      };
+      unsafe { cuh.wide_thing }
+    };
+  };
+}
+
+impl f32x4 {
+  //
+  // core::f32
+  //
+
+  const_f32_as_f32x4!(
+    /// Machine epsilon value for `f32`.
+    pub EPSILON, core::f32::EPSILON
+  );
+
+  const_f32_as_f32x4!(
+    /// Positive Infinity (∞).
+    pub INFINITY, core::f32::INFINITY
+  );
+
+  const_f32_as_f32x4!(
+    /// Largest finite `f32` value.
+    pub MAX, core::f32::MAX
+  );
+
+  const_f32_as_f32x4!(
+    /// Smallest finite `f32` value.
+    pub MIN, core::f32::MIN
+  );
+
+  const_f32_as_f32x4!(
+    /// Smallest positive normal `f32` value.
+    pub MIN_POSITIVE, core::f32::MIN_POSITIVE
+  );
+
+  const_f32_as_f32x4!(
+    /// Not a Number (NaN).
+    ///
+    /// **Reminder:** This is one possible NaN value, but there are many NaN bit
+    /// patterns within the `f32` space.
+    pub NAN, core::f32::NAN
+  );
+
+  const_f32_as_f32x4!(
+    /// Negative infinity (-∞).
+    pub NEG_INFINITY, core::f32::NEG_INFINITY
+  );
+
+  //
+  // core::f32::consts
+  //
+
+  const_f32_as_f32x4!(
+    /// Euler's number (e)
+    pub E, core::f32::consts::E
+  );
+
+  const_f32_as_f32x4!(
+    /// 1/π
+    pub FRAC_1_PI, core::f32::consts::FRAC_1_PI
+  );
+
+  const_f32_as_f32x4!(
+    /// 2/π
+    pub FRAC_2_PI, core::f32::consts::FRAC_2_PI
+  );
+
+  const_f32_as_f32x4!(
+    /// 2/sqrt(π)
+    pub FRAC_2_SQRT_PI, core::f32::consts::FRAC_2_SQRT_PI
+  );
+
+  const_f32_as_f32x4!(
+    /// 1/sqrt(2)
+    pub FRAC_1_SQRT_2, core::f32::consts::FRAC_1_SQRT_2
+  );
+
+  const_f32_as_f32x4!(
+    /// π/2
+    pub FRAC_PI_2, core::f32::consts::FRAC_PI_2
+  );
+
+  const_f32_as_f32x4!(
+    /// π/3
+    pub FRAC_PI_3, core::f32::consts::FRAC_PI_3
+  );
+
+  const_f32_as_f32x4!(
+    /// π/4
+    pub FRAC_PI_4, core::f32::consts::FRAC_PI_4
+  );
+
+  const_f32_as_f32x4!(
+    /// π/6
+    pub FRAC_PI_6, core::f32::consts::FRAC_PI_6
+  );
+
+  const_f32_as_f32x4!(
+    /// π/8
+    pub FRAC_PI_8, core::f32::consts::FRAC_PI_8
+  );
+
+  const_f32_as_f32x4!(
+    /// ln(2)
+    pub LN_2, core::f32::consts::LN_2
+  );
+
+  const_f32_as_f32x4!(
+    /// ln(10)
+    pub LN_10, core::f32::consts::LN_10
+  );
+
+  const_f32_as_f32x4!(
+    /// log2(e)
+    pub LOG2_E, core::f32::consts::LOG2_E
+  );
+
+  const_f32_as_f32x4!(
+    /// log10(e)
+    pub LOG10_E, core::f32::consts::LOG10_E
+  );
+
+  const_f32_as_f32x4!(
+    /// Archimedes' constant (π)
+    pub PI, core::f32::consts::PI
+  );
+
+  const_f32_as_f32x4!(
+    /// sqrt(2)
+    pub SQRT_2, core::f32::consts::SQRT_2
+  );
 }
 
 impl f32x4 {
@@ -1465,191 +1659,4 @@ impl From<[u16; 4]> for f32x4 {
   fn from([a, b, c, d]: [u16; 4]) -> Self {
     Self::new(f32::from(a), f32::from(b), f32::from(c), f32::from(d))
   }
-}
-
-/// Various `f32` related consts, duplicated into x4 array form.
-///
-/// Rust doesn't let you declare SIMD values in a `const` context, so you have
-/// to use something like `let c = f32x4::from(CONST_NAME);`
-pub mod consts {
-  pub const EPSILON: [f32; 4] = [
-    core::f32::EPSILON,
-    core::f32::EPSILON,
-    core::f32::EPSILON,
-    core::f32::EPSILON,
-  ];
-  pub const INFINITY: [f32; 4] = [
-    core::f32::INFINITY,
-    core::f32::INFINITY,
-    core::f32::INFINITY,
-    core::f32::INFINITY,
-  ];
-  pub const MAX: [f32; 4] = [
-    core::f32::MAX,
-    core::f32::MAX,
-    core::f32::MAX,
-    core::f32::MAX,
-  ];
-  pub const MIN: [f32; 4] = [
-    core::f32::MIN,
-    core::f32::MIN,
-    core::f32::MIN,
-    core::f32::MIN,
-  ];
-  pub const MIN_POSITIVE: [f32; 4] = [
-    core::f32::MIN_POSITIVE,
-    core::f32::MIN_POSITIVE,
-    core::f32::MIN_POSITIVE,
-    core::f32::MIN_POSITIVE,
-  ];
-  pub const NAN: [f32; 4] = [
-    core::f32::NAN,
-    core::f32::NAN,
-    core::f32::NAN,
-    core::f32::NAN,
-  ];
-  pub const NEG_INFINITY: [f32; 4] = [
-    core::f32::NEG_INFINITY,
-    core::f32::NEG_INFINITY,
-    core::f32::NEG_INFINITY,
-    core::f32::NEG_INFINITY,
-  ];
-  pub const DIGITS: [u32; 4] = [
-    core::f32::DIGITS,
-    core::f32::DIGITS,
-    core::f32::DIGITS,
-    core::f32::DIGITS,
-  ];
-  pub const MANTISSA_DIGITS: [u32; 4] = [
-    core::f32::MANTISSA_DIGITS,
-    core::f32::MANTISSA_DIGITS,
-    core::f32::MANTISSA_DIGITS,
-    core::f32::MANTISSA_DIGITS,
-  ];
-  pub const RADIX: [u32; 4] = [
-    core::f32::RADIX,
-    core::f32::RADIX,
-    core::f32::RADIX,
-    core::f32::RADIX,
-  ];
-  pub const MAX_10_EXP: [i32; 4] = [
-    core::f32::MAX_10_EXP,
-    core::f32::MAX_10_EXP,
-    core::f32::MAX_10_EXP,
-    core::f32::MAX_10_EXP,
-  ];
-  pub const MAX_EXP: [i32; 4] = [
-    core::f32::MAX_EXP,
-    core::f32::MAX_EXP,
-    core::f32::MAX_EXP,
-    core::f32::MAX_EXP,
-  ];
-  pub const MIN_10_EXP: [i32; 4] = [
-    core::f32::MIN_10_EXP,
-    core::f32::MIN_10_EXP,
-    core::f32::MIN_10_EXP,
-    core::f32::MIN_10_EXP,
-  ];
-  pub const MIN_EXP: [i32; 4] = [
-    core::f32::MIN_EXP,
-    core::f32::MIN_EXP,
-    core::f32::MIN_EXP,
-    core::f32::MIN_EXP,
-  ];
-  pub const E: [f32; 4] = [
-    core::f32::consts::E,
-    core::f32::consts::E,
-    core::f32::consts::E,
-    core::f32::consts::E,
-  ];
-  pub const FRAC_1_PI: [f32; 4] = [
-    core::f32::consts::FRAC_1_PI,
-    core::f32::consts::FRAC_1_PI,
-    core::f32::consts::FRAC_1_PI,
-    core::f32::consts::FRAC_1_PI,
-  ];
-  pub const FRAC_2_PI: [f32; 4] = [
-    core::f32::consts::FRAC_2_PI,
-    core::f32::consts::FRAC_2_PI,
-    core::f32::consts::FRAC_2_PI,
-    core::f32::consts::FRAC_2_PI,
-  ];
-  pub const FRAC_2_SQRT_PI: [f32; 4] = [
-    core::f32::consts::FRAC_2_SQRT_PI,
-    core::f32::consts::FRAC_2_SQRT_PI,
-    core::f32::consts::FRAC_2_SQRT_PI,
-    core::f32::consts::FRAC_2_SQRT_PI,
-  ];
-  pub const FRAC_1_SQRT_2: [f32; 4] = [
-    core::f32::consts::FRAC_1_SQRT_2,
-    core::f32::consts::FRAC_1_SQRT_2,
-    core::f32::consts::FRAC_1_SQRT_2,
-    core::f32::consts::FRAC_1_SQRT_2,
-  ];
-  pub const FRAC_PI_2: [f32; 4] = [
-    core::f32::consts::FRAC_PI_2,
-    core::f32::consts::FRAC_PI_2,
-    core::f32::consts::FRAC_PI_2,
-    core::f32::consts::FRAC_PI_2,
-  ];
-  pub const FRAC_PI_3: [f32; 4] = [
-    core::f32::consts::FRAC_PI_3,
-    core::f32::consts::FRAC_PI_3,
-    core::f32::consts::FRAC_PI_3,
-    core::f32::consts::FRAC_PI_3,
-  ];
-  pub const FRAC_PI_4: [f32; 4] = [
-    core::f32::consts::FRAC_PI_4,
-    core::f32::consts::FRAC_PI_4,
-    core::f32::consts::FRAC_PI_4,
-    core::f32::consts::FRAC_PI_4,
-  ];
-  pub const FRAC_PI_6: [f32; 4] = [
-    core::f32::consts::FRAC_PI_6,
-    core::f32::consts::FRAC_PI_6,
-    core::f32::consts::FRAC_PI_6,
-    core::f32::consts::FRAC_PI_6,
-  ];
-  pub const FRAC_PI_8: [f32; 4] = [
-    core::f32::consts::FRAC_PI_8,
-    core::f32::consts::FRAC_PI_8,
-    core::f32::consts::FRAC_PI_8,
-    core::f32::consts::FRAC_PI_8,
-  ];
-  pub const LN_2: [f32; 4] = [
-    core::f32::consts::LN_2,
-    core::f32::consts::LN_2,
-    core::f32::consts::LN_2,
-    core::f32::consts::LN_2,
-  ];
-  pub const LN_10: [f32; 4] = [
-    core::f32::consts::LN_10,
-    core::f32::consts::LN_10,
-    core::f32::consts::LN_10,
-    core::f32::consts::LN_10,
-  ];
-  pub const LOG2_E: [f32; 4] = [
-    core::f32::consts::LOG2_E,
-    core::f32::consts::LOG2_E,
-    core::f32::consts::LOG2_E,
-    core::f32::consts::LOG2_E,
-  ];
-  pub const LOG10_E: [f32; 4] = [
-    core::f32::consts::LOG10_E,
-    core::f32::consts::LOG10_E,
-    core::f32::consts::LOG10_E,
-    core::f32::consts::LOG10_E,
-  ];
-  pub const PI: [f32; 4] = [
-    core::f32::consts::PI,
-    core::f32::consts::PI,
-    core::f32::consts::PI,
-    core::f32::consts::PI,
-  ];
-  pub const SQRT_2: [f32; 4] = [
-    core::f32::consts::SQRT_2,
-    core::f32::consts::SQRT_2,
-    core::f32::consts::SQRT_2,
-    core::f32::consts::SQRT_2,
-  ];
 }

--- a/src/m_f32x4.rs
+++ b/src/m_f32x4.rs
@@ -285,6 +285,27 @@ impl f32x4 {
     }}
   }
 
+  pub fn is_ordinary(self) -> Self {
+    cfg_if! {if #[cfg(target_feature="sse")] {
+      // yes it's weird, yes it's correct.
+      Self { sse: self.sse.cmp_ordinary(self.sse) }
+    } else {
+      let op = |a:f32, b:f32| {
+        if (!a.is_nan()) & (!b.is_nan()) {
+          f32::from_bits(u32::max_value())
+        } else {
+          0.0
+        }
+      };
+      Self { arr: [
+        op(self.arr[0], rhs.arr[0]),
+        op(self.arr[1], rhs.arr[1]),
+        op(self.arr[2], rhs.arr[2]),
+        op(self.arr[3], rhs.arr[3]),
+      ] }
+    }}
+  }
+
   /// Use `self` (a boolish value) to merge `a` and `b`.
   ///
   /// For each lane index, if the `self` lane is "true" then the `a` value will

--- a/src/m_i32x4.rs
+++ b/src/m_i32x4.rs
@@ -1,0 +1,132 @@
+use super::*;
+
+cfg_if! {
+  if #[cfg(target_feature="sse")] {
+    #[repr(C, align(16))]
+    pub struct i32x4 {
+      sse: m128i
+    }
+  } else {
+    #[repr(C, align(16))]
+    pub struct i32x4 {
+      arr: [i32; 4]
+    }
+  }
+}
+#[test]
+fn declaration_tests_i32x4() {
+  use core::mem::{align_of, size_of};
+  assert_eq!(size_of::<i32x4>(), 16);
+  assert_eq!(align_of::<i32x4>(), 16);
+}
+impl Clone for i32x4 {
+  #[inline(always)]
+  fn clone(&self) -> Self {
+    *self
+  }
+}
+impl Copy for i32x4 {}
+impl Default for i32x4 {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::zeroed()
+  }
+}
+unsafe impl Zeroable for i32x4 {}
+unsafe impl Pod for i32x4 {}
+
+#[allow(non_camel_case_types)]
+pub union ConstUnionHack_i32x4 {
+  narrow_arr: [i32; 4],
+  wide_thing: i32x4,
+}
+#[test]
+#[allow(non_snake_case)]
+fn declaration_tests_ConstUnionHack_i32x4() {
+  use core::mem::{align_of, size_of};
+  assert_eq!(size_of::<ConstUnionHack_i32x4>(), size_of::<i32x4>());
+  assert_eq!(align_of::<ConstUnionHack_i32x4>(), align_of::<i32x4>());
+}
+
+/// Declares an `i32x4` const identifier.
+///
+/// ## Broadcast A Single Value
+///
+/// * **Usage:** `const_i32_as_i32x4!(#[meta]* vis ident, val);`
+///
+/// The value should be a single `i32` expression, which is then duplicated into
+/// all lanes of the constant declaration.
+///
+/// ```rust
+/// const_i32_as_i32x4!(
+///   /// The maximum `i32` value
+///   pub MAX, core::i32::MAX
+/// );
+/// ```
+///
+/// ## Select Each Lane
+///
+/// * **Usage:** `const_i32_as_i32x4!(#[meta]* vis ident, a, b, c, d);`
+///
+/// Each of `a`, `b`, `c`, and `d` are an `i32` expression when are then placed
+/// into the constant declaration (low lane to high lane).
+///
+/// ```rust
+/// const_i32_as_i32x4!(
+///   /// 1, 2, 3, 4
+///   pub ONE_TWO_THREE_FOUR, 1, 2, 3, 4
+/// );
+/// ```
+#[macro_export]
+macro_rules! const_i32_as_i32x4 {
+  // broadcast a single value
+  ($(#[$attrs:meta])* $v:vis $i:ident, $val:expr) => {
+    $(#[$attrs])*
+    $v const $i: i32x4 = {
+      let cuh = ConstUnionHack_i32x4 {
+        narrow_arr: [$val, $val, $val, $val],
+      };
+      unsafe { cuh.wide_thing }
+    };
+  };
+  // select each lane's value
+  ($(#[$attrs:meta])* $v:vis $i:ident, $a:expr, $b:expr, $c:expr, $d:expr) => {
+    $(#[$attrs])*
+    $v const $i: i32x4 = {
+      let cuh = ConstUnionHack_i32x4 {
+        narrow_arr: [$a, $b, $c, $d],
+      };
+      unsafe { cuh.wide_thing }
+    };
+  };
+}
+
+impl i32x4 {
+  //
+  // core::i32
+  //
+
+  const_i32_as_i32x4!(
+    /// Maximum `i32` value.
+    pub MAX, core::i32::MAX
+  );
+
+  const_i32_as_i32x4!(
+    /// Minimum `i32` value.
+    pub MIN, core::i32::MIN
+  );
+
+  //
+  // others
+  //
+
+  const_i32_as_i32x4!(
+    /// 0
+    pub ZERO, 0_i32
+  );
+
+  const_i32_as_i32x4!(
+    /// 1
+    pub ONE, 1_i32
+  );
+}

--- a/src/m_i32x4.rs
+++ b/src/m_i32x4.rs
@@ -279,10 +279,10 @@ impl Add for i32x4 {
       Self { sse: self.sse.add_i32(rhs.sse) }
     } else {
       Self { arr: [
-        self.arr[0].add(rhs[0]),
-        self.arr[1].add(rhs[1]),
-        self.arr[2].add(rhs[2]),
-        self.arr[3].add(rhs[3]),
+        self.arr[0].add(rhs.arr[0]),
+        self.arr[1].add(rhs.arr[1]),
+        self.arr[2].add(rhs.arr[2]),
+        self.arr[3].add(rhs.arr[3]),
       ] }
     }}
   }

--- a/src/m_i32x4.rs
+++ b/src/m_i32x4.rs
@@ -263,10 +263,10 @@ impl BitXor for i32x4 {
       Self { sse: self.sse.bitxor(rhs.sse) }
     } else {
       Self { arr: [
-        self.arr[0].bitxor(rhs[0]),
-        self.arr[1].bitxor(rhs[1]),
-        self.arr[2].bitxor(rhs[2]),
-        self.arr[3].bitxor(rhs[3]),
+        self.arr[0].bitxor(rhs.arr[0]),
+        self.arr[1].bitxor(rhs.arr[1]),
+        self.arr[2].bitxor(rhs.arr[2]),
+        self.arr[3].bitxor(rhs.arr[3]),
       ] }
     }}
   }

--- a/tests/f32x4.rs
+++ b/tests/f32x4.rs
@@ -1,0 +1,50 @@
+#![allow(clippy::float_cmp)]
+use bytemuck::*;
+use wide::*;
+
+#[test]
+fn f32x4_new_order() {
+  let f = f32x4::new(0.0, 1.0, 2.0, 3.0);
+  assert_eq!(f[0], 0.0);
+  assert_eq!(f[1], 1.0);
+  assert_eq!(f[2], 2.0);
+  assert_eq!(f[3], 3.0);
+}
+
+#[test]
+fn f32x4_array_cast_order() {
+  let f = cast::<[f32; 4], f32x4>([0.0, 1.0, 2.0, 3.0]);
+  assert_eq!(f[0], 0.0);
+  assert_eq!(f[1], 1.0);
+  assert_eq!(f[2], 2.0);
+  assert_eq!(f[3], 3.0);
+}
+
+#[test]
+fn f32x4_merge() {
+  let f = f32x4::new(0.0, 1.0, 2.0, 3.0);
+
+  let mask = f.cmp_eq(f32x4::ZERO);
+  assert!(mask[0].is_nan());
+  assert_eq!(mask[1], 0.0);
+  assert_eq!(mask[2], 0.0);
+  assert_eq!(mask[3], 0.0);
+
+  let combined = mask.merge(f32x4::ONE, f32x4::ZERO);
+  assert_eq!(combined[0], 1.0);
+  assert_eq!(combined[1], 0.0);
+  assert_eq!(combined[2], 0.0);
+  assert_eq!(combined[3], 0.0);
+
+  let mask = f.cmp_gt(f32x4::from(1.5));
+  assert_eq!(mask[0], 0.0);
+  assert_eq!(mask[1], 0.0);
+  assert!(mask[2].is_nan());
+  assert!(mask[3].is_nan());
+
+  let combined = mask.merge(f32x4::ONE, f32x4::ZERO);
+  assert_eq!(combined[0], 0.0);
+  assert_eq!(combined[1], 0.0);
+  assert_eq!(combined[2], 1.0);
+  assert_eq!(combined[3], 1.0);
+}


### PR DESCRIPTION
* Makes wide `sin_cos`, which also allows wide `sin`, `cos`, and `tan`.
* Fixes a bug in `merge` (arguments were swapped from the order stated in the docs)
* Fixes `new` (now argument order matches the indexing order of the created f32x4)
* Introduces an anemic `i32x4` type (just enough to support `sin_cos`)
* Adds a few tests of the `f32x4` type _itself_, not just the `arch` module types.
* `is_nan`, `is_ordinary`

???