### PR TITLE
Return value from sin_cos

### DIFF
--- a/src/m_f32x4/wide_methods.rs
+++ b/src/m_f32x4/wide_methods.rs
@@ -654,6 +654,7 @@ impl f32x4 {
         *s_mut = s;
         *c_mut = c;
       });
+    (f32x4::from(arr_sin), f32x4::from(arr_cos))
     /*
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h


### PR DESCRIPTION
Commit 04355fb963f1 changed the implementation of `sin_cos` but forgot to specify a return value. This commit fixes that.