### PR TITLE
Fix sin_cos

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,7 +3,6 @@ use wide::*;
 fn main() {
   // /*
   let mut f = 0.0;
-  #[cfg(feature = "extern_crate_std")]
   while f <= 1.5 {
     println!("rad {:.2}: s/c {:?}", f, f32x4::from(f).sin_cos());
     f += 0.1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ pub fn sqrt_f32(x: f32) -> f32 {
 /// A `sin` for just one `f32`.
 #[inline(always)]
 #[must_use]
-#[cfg(feature = "extern_crate_std")]
 pub fn sin_f32(x: f32) -> f32 {
   magic! {
     if #[cfg(target_feature = "sse")] {
@@ -159,7 +158,6 @@ pub fn sin_f32(x: f32) -> f32 {
 /// A `cos` for just one `f32`.
 #[inline(always)]
 #[must_use]
-#[cfg(feature = "extern_crate_std")]
 pub fn cos_f32(x: f32) -> f32 {
   magic! {
     if #[cfg(target_feature = "sse")] {
@@ -173,7 +171,6 @@ pub fn cos_f32(x: f32) -> f32 {
 /// A `tan` for just one `f32`.
 #[inline(always)]
 #[must_use]
-#[cfg(feature = "extern_crate_std")]
 pub fn tan_f32(x: f32) -> f32 {
   magic! {
     if #[cfg(target_feature = "sse")] {

--- a/src/m_f32x4/wide_methods.rs
+++ b/src/m_f32x4/wide_methods.rs
@@ -395,7 +395,6 @@ impl f32x4 {
   /// Lanewise cosine
   #[inline]
   #[must_use]
-  #[cfg(feature = "extern_crate_std")]
   pub fn cos(self) -> Self {
     // Gonna TRUST that optimizer to skip the final `sin` computations
     self.sin_cos().1
@@ -431,7 +430,6 @@ impl f32x4 {
   /// "We called it '[Sin](https://vignette.wikia.nocookie.net/finalfantasy/images/d/de/10sin-a.jpg)'."
   #[inline]
   #[must_use]
-  #[cfg(feature = "extern_crate_std")]
   pub fn sin(self) -> Self {
     // Gonna TRUST that optimizer to skip the final `cos` computations
     self.sin_cos().0
@@ -606,7 +604,6 @@ impl f32x4 {
   /// Lanewise tangent
   #[inline]
   #[must_use]
-  #[cfg(feature = "extern_crate_std")]
   pub fn tan(self) -> Self {
     let (s, c) = self.sin_cos();
     s / c
@@ -638,24 +635,7 @@ impl f32x4 {
   #[allow(bad_style)]
   #[allow(clippy::missing_inline_in_public_items)]
   #[must_use]
-  #[cfg(feature = "extern_crate_std")]
   pub fn sin_cos(self) -> (Self, Self) {
-    // the code below has a bug somewhere, so as a quick fix to at least get
-    // accurate results we have "un-wided" this method:
-    let mut arr_sin = [0.0; 4];
-    let mut arr_cos = [0.0; 4];
-    let arr_self: [f32; 4] = cast(self);
-    arr_self
-      .iter()
-      .copied()
-      .zip(arr_sin.iter_mut().zip(arr_cos.iter_mut()))
-      .for_each(|(f, (s_mut, c_mut))| {
-        let (s, c) = f.sin_cos();
-        *s_mut = s;
-        *c_mut = c;
-      });
-    (f32x4::from(arr_sin), f32x4::from(arr_cos))
-    /*
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
 
@@ -713,7 +693,6 @@ impl f32x4 {
     cos1 ^= sign_cos.cast_f32x4();
 
     (sin1, cos1)
-    */
   }
 
   /// Lanewise radians -> degrees.

--- a/src/m_i32x4.rs
+++ b/src/m_i32x4.rs
@@ -34,7 +34,7 @@ unsafe impl Zeroable for i32x4 {}
 unsafe impl Pod for i32x4 {}
 
 /// Allows us to declare `i32x4` values in a `const` context. Uninteresting otherwise.
-/// 
+///
 /// See the [`const_i32_as_i32x4`] macro for usage.
 #[allow(non_camel_case_types)]
 #[repr(C, align(16))]
@@ -250,13 +250,23 @@ impl From<i32> for i32x4 {
   }
 }
 
+impl Index<usize> for i32x4 {
+  type Output = i32;
+  #[inline(always)]
+  #[must_use]
+  fn index(&self, index: usize) -> &i32 {
+    let r: &[i32; 4] = cast_ref(self);
+    &r[index]
+  }
+}
+
 impl Shl<i32> for i32x4 {
   type Output = Self;
   #[inline]
   #[must_use]
   fn shl(self, rhs: i32) -> Self {
     magic! {if #[cfg(target_feature="sse2")] {
-      Self { sse: self.sse.shift_left_i32(Self::from(rhs).sse) }
+      Self { sse: self.sse.shift_left_i32(Self::new(rhs, 0, 0, 0).sse) }
     } else {
       Self { arr: [
         self.arr[0] << rhs,

--- a/tests/f32x4.rs
+++ b/tests/f32x4.rs
@@ -117,7 +117,6 @@ fn f32x4_trunc() {
 }
 
 #[test]
-#[cfg(feature = "extern_crate_std")]
 fn f32x4_sin_cos() {
   for x in -2500..2500 {
     let base = (x * 4) as f32;

--- a/tests/f32x4.rs
+++ b/tests/f32x4.rs
@@ -93,7 +93,7 @@ fn f32x4_fract() {
   assert_eq!(a[1], 5.0_f32.fract());
   assert_eq!(a[2], 0.1_f32.fract());
   assert_eq!(a[3], (-1.5_f32).fract());
-  
+
   let a = f32x4::new(-0.1, -0.53, -1.25, 0.25).fract();
   assert_eq!(a[0], (-0.1_f32).fract());
   assert_eq!(a[1], (-0.53_f32).fract());
@@ -108,10 +108,32 @@ fn f32x4_trunc() {
   assert_eq!(a[1], 5.0_f32.trunc());
   assert_eq!(a[2], 0.1_f32.trunc());
   assert_eq!(a[3], (-1.5_f32).trunc());
-  
+
   let a = f32x4::new(-0.1, -0.53, -1.25, 0.25).trunc();
   assert_eq!(a[0], (-0.1_f32).trunc());
   assert_eq!(a[1], (-0.53_f32).trunc());
   assert_eq!(a[2], (-1.25_f32).trunc());
   assert_eq!(a[3], 0.25_f32.trunc());
+}
+
+#[test]
+#[cfg(feature = "extern_crate_std")]
+fn f32x4_sin_cos() {
+  for x in -2500..2500 {
+    let base = (x * 4) as f32;
+    let angles = [base, base + 1_f32, base + 2_f32, base + 3_f32];
+    let (actual_sins, actual_coses) = f32x4::from(angles).sin_cos();
+
+    for i in 0..4 {
+      let angle = angles[i];
+
+      let check = |name: &str, actuals: &f32x4, expected: f32| {
+        let actual = actuals[i];
+        assert!((actual - expected).abs() < 0.00000006, "Wanted {}({}) to be {} but got {}", name, angle, expected, actual);
+      };
+
+      check("sin", &actual_sins, angle.sin());
+      check("cos", &actual_coses, angle.cos());
+    }
+  }
 }

--- a/tests/i32x4.rs
+++ b/tests/i32x4.rs
@@ -14,3 +14,26 @@ fn declaration_tests_ConstUnionHack_i32x4() {
   assert_eq!(size_of::<ConstUnionHack_i32x4>(), size_of::<i32x4>());
   assert_eq!(align_of::<ConstUnionHack_i32x4>(), align_of::<i32x4>());
 }
+
+#[test]
+fn shift_left_i32() {
+  let nums = i32x4::new(1, 2, 3, 4);
+
+  let shifted_one = nums << 1;
+  assert_eq!(shifted_one[0], 2);
+  assert_eq!(shifted_one[1], 4);
+  assert_eq!(shifted_one[2], 6);
+  assert_eq!(shifted_one[3], 8);
+
+  let shifted_18 = nums << 18;
+  assert_eq!(shifted_18[0], 262144);
+  assert_eq!(shifted_18[1], 524288);
+  assert_eq!(shifted_18[2], 786432);
+  assert_eq!(shifted_18[3], 1048576);
+
+  let shifted_32 = nums << 32;
+  assert_eq!(shifted_32[0], 0);
+  assert_eq!(shifted_32[1], 0);
+  assert_eq!(shifted_32[2], 0);
+  assert_eq!(shifted_32[3], 0);
+}


### PR DESCRIPTION
Tracked down the reason why `sin_cos` was giving incorrect results for some angles (#26). The issue was with the `i32x4` left shift function. The amount to be shifted was constructed in a wrong way and as a result it always just zeroed the to-be-shifted value (by shifting the bits way too much, and "out" of 
the left end of the value).

Also added tests for all these related parts.

Fixes #26.