### PR TITLE
Fix compile error on targets with sse4.1 and no avx2

### DIFF
--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -415,7 +415,7 @@ impl i8x32 {
         if #[cfg(target_feature="avx2")] {
             Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
         } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse),  sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0),  sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
       } else {
         generic_bit_blend(self, t, f)
       }


### PR DESCRIPTION
It appears I've found a little copy-paste error created at some point in time. I'm guessing most developers for this crate are on new enough hardware that they have avx2. My crate builds with `rustflags = ["-C", "target-cpu=sandybridge"]` as I target hardware with sse4.1 and AVX, but not AVX2, and pulling in ultraviolet triggered a compilation error in this crate.

I'm assuming this is the correct behavior for the function, please correct me if I'm wrong but the snippet:
```rust
Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse),  sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
```
Should actually be:
```rust
Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0),  sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
```

Easy fix either way, hopefully it can get through quickly so I can go back to using a cargo release of ultraviolet
