### PR TITLE
Implement {float}::atan(), and {float}::atan2()

### DIFF
--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -559,6 +559,16 @@ impl f32x8 {
   }
   #[inline]
   #[must_use]
+  pub fn is_inf(self) -> Self {
+    let shifted_inf = u32x8::from(0xFF000000);
+    let u: u32x8 = cast(self);
+    let shift_u = u << 1_u64;
+    let out = (shift_u).cmp_eq(shifted_inf);
+    cast(out)
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round(self) -> Self {
     pick! {
       // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out
@@ -822,6 +832,100 @@ impl f32x8 {
     let acos = big.blend(z3, z4);
 
     acos
+  }
+
+  #[allow(non_upper_case_globals)]
+  pub fn atan(self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x8!(P3atanf, 8.05374449538E-2);
+    const_f32_as_f32x8!(P2atanf, -1.38776856032E-1);
+    const_f32_as_f32x8!(P1atanf, 1.99777106478E-1);
+    const_f32_as_f32x8!(P0atanf, -3.33329491539E-1);
+
+    let t = self.abs();
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    // big:    z = -1.0 / t;
+    let notsmal = t.cmp_ge(Self::SQRT_2 - Self::ONE);
+    let notbig = t.cmp_le(Self::SQRT_2 + Self::ONE);
+
+    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    s = notsmal & s;
+
+    let mut a = notbig & t;
+    a = notsmal.blend(a - Self::ONE, a);
+    let mut b = notbig & Self::ONE;
+    b = notsmal.blend(b + t, b);
+    let z = a / b;
+
+    let zz = z * z;
+
+    // Taylor expansion
+    let mut re = polynomial_3!(zz, P0atanf, P1atanf, P2atanf, P3atanf);
+    re = re.mul_add(zz * z, z) + s;
+
+    // get sign bit
+    re = (self.sign_bit()).blend(-re, re);
+
+    re
+  }
+
+  #[allow(non_upper_case_globals)]
+  pub fn atan2(self, x: Self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x8!(P3atanf, 8.05374449538E-2);
+    const_f32_as_f32x8!(P2atanf, -1.38776856032E-1);
+    const_f32_as_f32x8!(P1atanf, 1.99777106478E-1);
+    const_f32_as_f32x8!(P0atanf, -3.33329491539E-1);
+
+    let y = self;
+
+    // move in first octant
+    let x1 = x.abs();
+    let y1 = y.abs();
+    let swapxy = y1.cmp_gt(x1);
+    // swap x and y if y1 > x1
+    let mut x2 = swapxy.blend(y1, x1);
+    let mut y2 = swapxy.blend(x1, y1);
+
+    // check for special case: x and y are both +/- INF
+    let both_infinite = x.is_inf() & y.is_inf();
+    if both_infinite.any() {
+      let mone = -Self::ONE;
+      x2 = both_infinite.blend(x2 & mone, x2);
+      y2 = both_infinite.blend(y2 & mone, y2);
+    }
+
+    // x = y = 0 will produce NAN. No problem, fixed below
+    let t = y2 / x2;
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    let notsmal = t.cmp_ge(Self::SQRT_2 - Self::ONE);
+
+    let a = notsmal.blend(t - Self::ONE, t);
+    let b = notsmal.blend(t + Self::ONE, Self::ONE);
+    let s = notsmal & Self::FRAC_PI_4;
+    let z = a / b;
+
+    let zz = z * z;
+
+    // Taylor expansion
+    let mut re = polynomial_3!(zz, P0atanf, P1atanf, P2atanf, P3atanf);
+    re = re.mul_add(zz * z, z) + s;
+
+    // move back in place
+    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).cmp_eq(Self::ZERO)).blend(Self::ZERO, re);
+    re = (x.sign_bit()).blend(Self::PI - re, re);
+
+    // get sign bit
+    re = (y.sign_bit()).blend(-re, re);
+
+    re
   }
 
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -427,6 +427,16 @@ impl f64x2 {
   }
   #[inline]
   #[must_use]
+  pub fn is_inf(self) -> Self {
+    let shifted_inf = u64x2::from(0xFFE0000000000000);
+    let u: u64x2 = cast(self);
+    let shift_u = u << 1_u64;
+    let out = (shift_u).cmp_eq(shifted_inf);
+    cast(out)
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
@@ -765,6 +775,142 @@ impl f64x2 {
     asin
   }
 
+  #[allow(non_upper_case_globals)]
+  pub fn atan(self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f64_as_f64x2!(MOREBITS, 6.123233995736765886130E-17);
+    const_f64_as_f64x2!(MOREBITSO2, 6.123233995736765886130E-17 * 0.5);
+    const_f64_as_f64x2!(T3PO8, core::f64::consts::SQRT_2 + 1.0);
+
+    const_f64_as_f64x2!(P4atan, -8.750608600031904122785E-1);
+    const_f64_as_f64x2!(P3atan, -1.615753718733365076637E1);
+    const_f64_as_f64x2!(P2atan, -7.500855792314704667340E1);
+    const_f64_as_f64x2!(P1atan, -1.228866684490136173410E2);
+    const_f64_as_f64x2!(P0atan, -6.485021904942025371773E1);
+
+    const_f64_as_f64x2!(Q4atan, 2.485846490142306297962E1);
+    const_f64_as_f64x2!(Q3atan, 1.650270098316988542046E2);
+    const_f64_as_f64x2!(Q2atan, 4.328810604912902668951E2);
+    const_f64_as_f64x2!(Q1atan, 4.853903996359136964868E2);
+    const_f64_as_f64x2!(Q0atan, 1.945506571482613964425E2);
+
+    let t = self.abs();
+
+    // small:  t < 0.66
+    // medium: t <= t <= 2.4142 (1+sqrt(2))
+    // big:    t > 2.4142
+    let notbig = t.cmp_le(T3PO8);
+    let notsmal = t.cmp_ge(Self::splat(0.66));
+
+    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    s = notsmal & s;
+    let mut fac = notbig.blend(MOREBITSO2, MOREBITS);
+    fac = notsmal & fac;
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    // big:    z = -1.0 / t;
+    let mut a = notbig & t;
+    a = notsmal.blend(a - Self::ONE, a);
+    let mut b = notbig & Self::ONE;
+    b = notsmal.blend(b + t, b);
+    let z = a / b;
+
+    let zz = z * z;
+
+    let px = polynomial_4!(zz, P0atan, P1atan, P2atan, P3atan, P4atan);
+    let qx = polynomial_5n!(zz, Q0atan, Q1atan, Q2atan, Q3atan, Q4atan);
+
+    let mut re = (px / qx).mul_add(z * zz, z);
+    re += s + fac;
+
+    // get sign bit
+    re = (self.sign_bit()).blend(-re, re);
+
+    re
+  }
+
+  #[allow(non_upper_case_globals)]
+  pub fn atan2(self, x: Self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f64_as_f64x2!(MOREBITS, 6.123233995736765886130E-17);
+    const_f64_as_f64x2!(MOREBITSO2, 6.123233995736765886130E-17 * 0.5);
+    const_f64_as_f64x2!(T3PO8, core::f64::consts::SQRT_2 + 1.0);
+
+    const_f64_as_f64x2!(P4atan, -8.750608600031904122785E-1);
+    const_f64_as_f64x2!(P3atan, -1.615753718733365076637E1);
+    const_f64_as_f64x2!(P2atan, -7.500855792314704667340E1);
+    const_f64_as_f64x2!(P1atan, -1.228866684490136173410E2);
+    const_f64_as_f64x2!(P0atan, -6.485021904942025371773E1);
+
+    const_f64_as_f64x2!(Q4atan, 2.485846490142306297962E1);
+    const_f64_as_f64x2!(Q3atan, 1.650270098316988542046E2);
+    const_f64_as_f64x2!(Q2atan, 4.328810604912902668951E2);
+    const_f64_as_f64x2!(Q1atan, 4.853903996359136964868E2);
+    const_f64_as_f64x2!(Q0atan, 1.945506571482613964425E2);
+
+    let y = self;
+
+    // move in first octant
+    let x1 = x.abs();
+    let y1 = y.abs();
+    let swapxy = y1.cmp_gt(x1);
+    // swap x and y if y1 > x1
+    let mut x2 = swapxy.blend(y1, x1);
+    let mut y2 = swapxy.blend(x1, y1);
+
+    // check for special case: x and y are both +/- INF
+    let both_infinite = x.is_inf() & y.is_inf();
+    if both_infinite.any() {
+      let mone = -Self::ONE;
+      x2 = both_infinite.blend(x2 & mone, x2);
+      y2 = both_infinite.blend(y2 & mone, y2);
+    }
+
+    // x = y = 0 gives NAN here
+    let t = y2 / x2;
+
+    // small:  t < 0.66
+    // medium: t <= t <= 2.4142 (1+sqrt(2))
+    // big:    t > 2.4142
+    let notbig = t.cmp_le(T3PO8);
+    let notsmal = t.cmp_ge(Self::splat(0.66));
+
+    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    s = notsmal & s;
+    let mut fac = notbig.blend(MOREBITSO2, MOREBITS);
+    fac = notsmal & fac;
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    // big:    z = -1.0 / t;
+    let mut a = notbig & t;
+    a = notsmal.blend(a - Self::ONE, a);
+    let mut b = notbig & Self::ONE;
+    b = notsmal.blend(b + t, b);
+    let z = a / b;
+
+    let zz = z * z;
+
+    let px = polynomial_4!(zz, P0atan, P1atan, P2atan, P3atan, P4atan);
+    let qx = polynomial_5n!(zz, Q0atan, Q1atan, Q2atan, Q3atan, Q4atan);
+
+    let mut re = (px / qx).mul_add(z * zz, z);
+    re += s + fac;
+
+    // move back in place
+    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).cmp_eq(Self::ZERO)).blend(Self::ZERO, re);
+    re = (x.sign_bit()).blend(Self::PI - re, re);
+
+    // get sign bit
+    re = (y.sign_bit()).blend(-re, re);
+
+    re
+  }
+
   #[inline]
   #[must_use]
   #[allow(non_upper_case_globals)]
@@ -1038,7 +1184,7 @@ impl f64x2 {
     let px = polynomial_5!(x, P0, P1, P2, P3, P4, P5);
     let x2 = x * x;
     let px = x2 * x * px;
-    let qx = polynomial_5n!(x, Q0, Q1, Q2, Q3, Q4, Q5);
+    let qx = polynomial_5n!(x, Q0, Q1, Q2, Q3, Q4);
     let res = px / qx;
     let res = fe.mul_add(LN2F_LO, res);
     let res = res + x2.mul_neg_add(f64x2::HALF, x);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,14 @@ macro_rules! polynomial_2 {
   }};
 }
 
+macro_rules! polynomial_3 {
+  ($x:expr, $c0:expr, $c1:expr, $c2:expr, $c3:expr $(,)?) => {{
+    let x = $x;
+    let x2 = x * x;
+    $c3.mul_add(x, $c2).mul_add(x2, $c1.mul_add(x, $c0))
+  }};
+}
+
 macro_rules! polynomial_4 {
   ($x:expr, $c0:expr, $c1:expr, $c2:expr ,$c3:expr, $c4:expr $(,)?) => {{
     let x = $x;
@@ -106,7 +114,7 @@ macro_rules! polynomial_5 {
 }
 
 macro_rules! polynomial_5n {
-  ($x:expr, $c0:expr, $c1:expr, $c2:expr, $c3:expr, $c4:expr, $c5:expr $(,)?) => {{
+  ($x:expr, $c0:expr, $c1:expr, $c2:expr, $c3:expr, $c4:expr $(,)?) => {{
     let x = $x;
     let x2 = x * x;
     let x4 = x2 * x2;

--- a/tests/t_f32x8.rs
+++ b/tests/t_f32x8.rs
@@ -476,6 +476,99 @@ fn impl_f32x8_acos() {
     }
   }
 }
+
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "avx")]
+#[test]
+fn impl_f32x8_atan() {
+  let inc = 1.0 / 2501.0 / 8.0;
+  for x in -2500..=2500 {
+    let base = (x * 8) as f32 * inc;
+    let origs = [
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+    ];
+    let actual_atans = f32x8::from(origs).atan();
+    for i in 0..8 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f32x8, expected: f32| {
+        let actual_arr: [f32; 8] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("atan", actual_atans, orig.atan());
+    }
+  }
+}
+
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "avx")]
+#[test]
+fn impl_f32x8_atan2() {
+  let inc_y = 1.0 / 51.0 / 8.0;
+  let inc_x = 1.0 / 2501.0 / 8.0;
+  for y in -50..=50 {
+    let base_y = (y * 8) as f32 * inc_y;
+    let origs_y = [
+      base_y,
+      base_y + inc_y,
+      base_y + 2.0 * inc_y,
+      base_y + 3.0 * inc_y,
+      base_y + 4.0 * inc_y,
+      base_y + 5.0 * inc_y,
+      base_y + 6.0 * inc_y,
+      base_y + 7.0 * inc_y,
+    ];
+    let actual_y = f32x8::from(origs_y);
+    for x in -2500..=2500 {
+      let base_x = (x * 8) as f32 * inc_x;
+      let origs_x = [
+        base_x,
+        base_x + inc_x,
+        base_x + 2.0 * inc_x,
+        base_x + 3.0 * inc_x,
+        base_x + 4.0 * inc_x,
+        base_x + 5.0 * inc_x,
+        base_x + 6.0 * inc_x,
+        base_x + 7.0 * inc_x,
+      ];
+      let actual_x = f32x8::from(origs_x);
+      let actual_atan2s = actual_y.atan2(actual_x);
+      for i in 0..8 {
+        let orig_y = origs_y[i];
+        let orig_x = origs_x[i];
+        let check = |name: &str, vals: f32x8, expected: f32| {
+          let actual_arr: [f32; 8] = cast(vals);
+          let actual = actual_arr[i];
+          assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig_y}, {orig_x}) to be {expected} but got {actual}",
+          name = name,
+          orig_y = orig_y,
+          orig_x = orig_x,
+          expected = expected,
+          actual = actual
+        );
+        };
+        check("atan2", actual_atan2s, orig_y.atan2(orig_x));
+      }
+    }
+  }
+}
+
 #[test]
 fn impl_f32x8_sin_cos() {
   for x in -2500..=2500 {

--- a/tests/t_f64x2.rs
+++ b/tests/t_f64x2.rs
@@ -460,6 +460,72 @@ fn impl_f64x2_acos() {
     }
   }
 }
+
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "sse")]
+#[test]
+fn impl_f64x2_atan() {
+  let inc = 1.0 / 2501.0 / 2.0;
+  for x in -2500..=2500 {
+    let base = (x * 2) as f64 * inc;
+    let origs = [base, base + inc];
+    let actual_atans = f64x2::from(origs).atan();
+    for i in 0..2 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f64x2, expected: f64| {
+        let actual_arr: [f64; 2] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.000000000000001,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("atan", actual_atans, orig.atan());
+    }
+  }
+}
+
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "sse")]
+#[test]
+fn impl_f64x2_atan2() {
+  let inc_y = 1.0 / 51.0 / 2.0;
+  let inc_x = 1.0 / 2501.0 / 2.0;
+  for y in -50..=50 {
+    let base_y = (y * 2) as f64 * inc_y;
+    let origs_y = [base_y, base_y + inc_y];
+    let actual_y = f64x2::from(origs_y);
+    for x in -2500..=2500 {
+      let base_x = (x * 2) as f64 * inc_x;
+      let origs_x = [base_x, base_x + inc_x];
+      let actual_x = f64x2::from(origs_x);
+      let actual_atan2s = actual_y.atan2(actual_x);
+      for i in 0..2 {
+        let orig_y = origs_y[i];
+        let orig_x = origs_x[i];
+        let check = |name: &str, vals: f64x2, expected: f64| {
+          let actual_arr: [f64; 2] = cast(vals);
+          let actual = actual_arr[i];
+          assert!(
+            (actual - expected).abs() < 0.000000000000001,
+            "Wanted {name}({orig_y}, {orig_x}) to be {expected} but got {actual}",
+            name = name,
+            orig_y = orig_y,
+            orig_x = orig_x,
+            expected = expected,
+            actual = actual
+          );
+        };
+        check("atan2", actual_atan2s, orig_y.atan2(orig_x));
+      }
+    }
+  }
+}
+
 #[test]
 fn impl_f64x2_to_degrees() {
   let pi = core::f64::consts::PI;

--- a/tests/t_f64x4.rs
+++ b/tests/t_f64x4.rs
@@ -378,6 +378,73 @@ fn impl_f64x4_acos() {
   }
 }
 
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "avx")]
+#[test]
+fn impl_f64x4_atan() {
+  let inc = 1.0 / 2501.0 / 4.0;
+  for x in -2500..=2500 {
+    let base = (x * 4) as f64 * inc;
+    let origs = [base, base + inc, base + 2.0 * inc, base + 3.0 * inc];
+    let actual_atans = f64x4::from(origs).atan();
+    for i in 0..4 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f64x4, expected: f64| {
+        let actual_arr: [f64; 4] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.000000000000001,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("atan", actual_atans, orig.atan());
+    }
+  }
+}
+
+// FIXME: remove cfg requirement once masks as their own types are implemented
+#[cfg(target_feature = "avx")]
+#[test]
+fn impl_f64x4_atan2() {
+  let inc_y = 1.0 / 51.0 / 4.0;
+  let inc_x = 1.0 / 2501.0 / 4.0;
+  for y in -50..=50 {
+    let base_y = (y * 4) as f64 * inc_y;
+    let origs_y =
+      [base_y, base_y + inc_y, base_y + 2.0 * inc_y, base_y + 3.0 * inc_y];
+    let actual_y = f64x4::from(origs_y);
+    for x in -2500..=2500 {
+      let base_x = (x * 4) as f64 * inc_x;
+      let origs_x =
+        [base_x, base_x + inc_x, base_x + 2.0 * inc_x, base_x + 3.0 * inc_x];
+      let actual_x = f64x4::from(origs_x);
+      let actual_atan2s = actual_y.atan2(actual_x);
+      for i in 0..4 {
+        let orig_y = origs_y[i];
+        let orig_x = origs_x[i];
+        let check = |name: &str, vals: f64x4, expected: f64| {
+          let actual_arr: [f64; 4] = cast(vals);
+          let actual = actual_arr[i];
+          assert!(
+            (actual - expected).abs() < 0.000000000000001,
+            "Wanted {name}({orig_y}, {orig_x}) to be {expected} but got {actual}",
+            name = name,
+            orig_y = orig_y,
+            orig_x = orig_x,
+            expected = expected,
+            actual = actual
+          );
+        };
+        check("atan2", actual_atan2s, orig_y.atan2(orig_x));
+      }
+    }
+  }
+}
+
 #[test]
 fn impl_f64x4_sin_cos() {
   for x in -2500..=2500 {


### PR DESCRIPTION
Implements #56 

* Add {f64x4, f64x2, f32x8, f32x4}::{atan, atan2} functions

* Add tests for atan and atan2

* Add polynomial_3 macro

* Remove extraneous argument in polynomial_5n macro