### PR TITLE
Implement constants for signed and unsigned integer types

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -527,7 +527,7 @@ impl f32x4 {
       }
     }
   }
-  #[cfg(any(target_feature="sse", feature="std"))]
+  #[cfg(any(target_feature = "sse", feature = "std"))]
   #[inline]
   #[must_use]
   pub fn trunc_int(self) -> i32x4 {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -15,7 +15,7 @@ pick! {
 macro_rules! const_f32_as_f32x4 {
   ($i:ident, $f:expr) => {
     pub const $i: f32x4 =
-      unsafe { ConstUnionHack128bit { f32a4: [$f, $f, $f, $f] }.f32x4 };
+      unsafe { ConstUnionHack128bit { f32a4: [$f; 4] }.f32x4 };
   };
 }
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -18,9 +18,8 @@ pick! {
 
 macro_rules! const_f32_as_f32x8 {
   ($i:ident, $f:expr) => {
-    pub const $i: f32x8 = unsafe {
-      ConstUnionHack128bit { f32a8: [$f, $f, $f, $f, $f, $f, $f, $f] }.f32x8
-    };
+    pub const $i: f32x8 =
+      unsafe { ConstUnionHack256bit { f32a8: [$f; 8] }.f32x8 };
   };
 }
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -632,7 +632,7 @@ impl f32x8 {
       }
     }
   }
-  #[cfg(any(target_feature="avx", feature="std"))]
+  #[cfg(any(target_feature = "avx", feature = "std"))]
   #[inline]
   #[must_use]
   pub fn trunc_int(self) -> i32x8 {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -15,7 +15,7 @@ pick! {
 macro_rules! const_f64_as_f64x2 {
   ($i:ident, $f:expr) => {
     pub const $i: f64x2 =
-      unsafe { ConstUnionHack128bit { f64a2: [$f, $f] }.f64x2 };
+      unsafe { ConstUnionHack128bit { f64a2: [$f; 2] }.f64x2 };
   };
 }
 

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -20,7 +20,7 @@ pick! {
 macro_rules! const_f64_as_f64x4 {
   ($i:ident, $f:expr) => {
     pub const $i: f64x4 =
-      unsafe { ConstUnionHack128bit { f64a4: [$f, $f, $f, $f] }.f64x4 };
+      unsafe { ConstUnionHack256bit { f64a4: [$f; 4] }.f64x4 };
   };
 }
 

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i16, 8, i16x8, i16x8, i16a8, const_i16_as_i16x8, 128);
+int_uint_consts!(i16, 8, i16x8, i16x8, i16a8, const_i16_as_i16x8, 128);
 
 unsafe impl Zeroable for i16x8 {}
 unsafe impl Pod for i16x8 {}

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_i16_as_i16x8 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i16x8 =
-      unsafe { ConstUnionHack128bit { i16a8: [$f; 8] }.i16x8 };
-  };
-}
-
-impl i16x8 {
-  const_i16_as_i16x8!(ONE, 1);
-  const_i16_as_i16x8!(ZERO, 0);
-  const_i16_as_i16x8!(MAX, i16::MAX);
-  const_i16_as_i16x8!(MIN, i16::MIN);
-}
+impl_nonfloat_consts!(i16, 8, i16x8, i16x8, i16a8, const_i16_as_i16x8, 128);
 
 unsafe impl Zeroable for i16x8 {}
 unsafe impl Pod for i16x8 {}

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_i16_as_i16x8 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i16x8 =
+      unsafe { ConstUnionHack128bit { i16a8: [$f; 8] }.i16x8 };
+  };
+}
+
+impl i16x8 {
+  const_i16_as_i16x8!(ONE, 1);
+  const_i16_as_i16x8!(ZERO, 0);
+  const_i16_as_i16x8!(MAX, i16::MAX);
+  const_i16_as_i16x8!(MIN, i16::MIN);
+}
+
 unsafe impl Zeroable for i16x8 {}
 unsafe impl Pod for i16x8 {}
 

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i32, 4, i32x4, i32x4, i32a4, const_i32_as_i32x4, 128);
+int_uint_consts!(i32, 4, i32x4, i32x4, i32a4, const_i32_as_i32x4, 128);
 
 unsafe impl Zeroable for i32x4 {}
 unsafe impl Pod for i32x4 {}

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_i32_as_i32x4 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i32x4 =
-      unsafe { ConstUnionHack128bit { i32a4: [$f; 4] }.i32x4 };
-  };
-}
-
-impl i32x4 {
-  const_i32_as_i32x4!(ONE, 1);
-  const_i32_as_i32x4!(ZERO, 0);
-  const_i32_as_i32x4!(MAX, i32::MAX);
-  const_i32_as_i32x4!(MIN, i32::MIN);
-}
+impl_nonfloat_consts!(i32, 4, i32x4, i32x4, i32a4, const_i32_as_i32x4, 128);
 
 unsafe impl Zeroable for i32x4 {}
 unsafe impl Pod for i32x4 {}

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_i32_as_i32x4 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i32x4 =
+      unsafe { ConstUnionHack128bit { i32a4: [$f; 4] }.i32x4 };
+  };
+}
+
+impl i32x4 {
+  const_i32_as_i32x4!(ONE, 1);
+  const_i32_as_i32x4!(ZERO, 0);
+  const_i32_as_i32x4!(MAX, i32::MAX);
+  const_i32_as_i32x4!(MIN, i32::MIN);
+}
+
 unsafe impl Zeroable for i32x4 {}
 unsafe impl Pod for i32x4 {}
 

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -16,6 +16,20 @@ pick! {
   }
 }
 
+macro_rules! const_i32_as_i32x8 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i32x8 =
+      unsafe { ConstUnionHack256bit { i32a8: [$f; 8] }.i32x8 };
+  };
+}
+
+impl i32x8 {
+  const_i32_as_i32x8!(ONE, 1);
+  const_i32_as_i32x8!(ZERO, 0);
+  const_i32_as_i32x8!(MAX, i32::MAX);
+  const_i32_as_i32x8!(MIN, i32::MIN);
+}
+
 unsafe impl Zeroable for i32x8 {}
 unsafe impl Pod for i32x8 {}
 

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -16,7 +16,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i32, 8, i32x8, i32x8, i32a8, const_i32_as_i32x8, 256);
+int_uint_consts!(i32, 8, i32x8, i32x8, i32a8, const_i32_as_i32x8, 256);
 
 unsafe impl Zeroable for i32x8 {}
 unsafe impl Pod for i32x8 {}

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -16,19 +16,7 @@ pick! {
   }
 }
 
-macro_rules! const_i32_as_i32x8 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i32x8 =
-      unsafe { ConstUnionHack256bit { i32a8: [$f; 8] }.i32x8 };
-  };
-}
-
-impl i32x8 {
-  const_i32_as_i32x8!(ONE, 1);
-  const_i32_as_i32x8!(ZERO, 0);
-  const_i32_as_i32x8!(MAX, i32::MAX);
-  const_i32_as_i32x8!(MIN, i32::MIN);
-}
+impl_nonfloat_consts!(i32, 8, i32x8, i32x8, i32a8, const_i32_as_i32x8, 256);
 
 unsafe impl Zeroable for i32x8 {}
 unsafe impl Pod for i32x8 {}

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_i64_as_i64x2 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i64x2 =
-      unsafe { ConstUnionHack128bit { i64a2: [$f; 2] }.i64x2 };
-  };
-}
-
-impl i64x2 {
-  const_i64_as_i64x2!(ONE, 1);
-  const_i64_as_i64x2!(ZERO, 0);
-  const_i64_as_i64x2!(MAX, i64::MAX);
-  const_i64_as_i64x2!(MIN, i64::MIN);
-}
+impl_nonfloat_consts!(i64, 2, i64x2, i64x2, i64a2, const_i64_as_i64x2, 128);
 
 unsafe impl Zeroable for i64x2 {}
 unsafe impl Pod for i64x2 {}

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_i64_as_i64x2 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i64x2 =
+      unsafe { ConstUnionHack128bit { i64a2: [$f; 2] }.i64x2 };
+  };
+}
+
+impl i64x2 {
+  const_i64_as_i64x2!(ONE, 1);
+  const_i64_as_i64x2!(ZERO, 0);
+  const_i64_as_i64x2!(MAX, i64::MAX);
+  const_i64_as_i64x2!(MIN, i64::MIN);
+}
+
 unsafe impl Zeroable for i64x2 {}
 unsafe impl Pod for i64x2 {}
 

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i64, 2, i64x2, i64x2, i64a2, const_i64_as_i64x2, 128);
+int_uint_consts!(i64, 2, i64x2, i64x2, i64a2, const_i64_as_i64x2, 128);
 
 unsafe impl Zeroable for i64x2 {}
 unsafe impl Pod for i64x2 {}

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -16,7 +16,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i64, 4, i64x4, i64x4, i64a4, const_i64_as_i64x4, 256);
+int_uint_consts!(i64, 4, i64x4, i64x4, i64a4, const_i64_as_i64x4, 256);
 
 unsafe impl Zeroable for i64x4 {}
 unsafe impl Pod for i64x4 {}

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -16,19 +16,7 @@ pick! {
   }
 }
 
-macro_rules! const_i64_as_i64x4 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i64x4 =
-      unsafe { ConstUnionHack256bit { i64a4: [$f; 4] }.i64x4 };
-  };
-}
-
-impl i64x4 {
-  const_i64_as_i64x4!(ONE, 1);
-  const_i64_as_i64x4!(ZERO, 0);
-  const_i64_as_i64x4!(MAX, i64::MAX);
-  const_i64_as_i64x4!(MIN, i64::MIN);
-}
+impl_nonfloat_consts!(i64, 4, i64x4, i64x4, i64a4, const_i64_as_i64x4, 256);
 
 unsafe impl Zeroable for i64x4 {}
 unsafe impl Pod for i64x4 {}

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -16,6 +16,20 @@ pick! {
   }
 }
 
+macro_rules! const_i64_as_i64x4 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i64x4 =
+      unsafe { ConstUnionHack256bit { i64a4: [$f; 4] }.i64x4 };
+  };
+}
+
+impl i64x4 {
+  const_i64_as_i64x4!(ONE, 1);
+  const_i64_as_i64x4!(ZERO, 0);
+  const_i64_as_i64x4!(MAX, i64::MAX);
+  const_i64_as_i64x4!(MIN, i64::MIN);
+}
+
 unsafe impl Zeroable for i64x4 {}
 unsafe impl Pod for i64x4 {}
 

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i8, 16, i8x16, i8x16, i8a16, const_i8_as_i8x16, 128);
+int_uint_consts!(i8, 16, i8x16, i8x16, i8a16, const_i8_as_i8x16, 128);
 
 unsafe impl Zeroable for i8x16 {}
 unsafe impl Pod for i8x16 {}

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_i8_as_i8x16 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i8x16 =
-      unsafe { ConstUnionHack128bit { i8a16: [$f; 16] }.i8x16 };
-  };
-}
-
-impl i8x16 {
-  const_i8_as_i8x16!(ONE, 1);
-  const_i8_as_i8x16!(ZERO, 0);
-  const_i8_as_i8x16!(MAX, i8::MAX);
-  const_i8_as_i8x16!(MIN, i8::MIN);
-}
+impl_nonfloat_consts!(i8, 16, i8x16, i8x16, i8a16, const_i8_as_i8x16, 128);
 
 unsafe impl Zeroable for i8x16 {}
 unsafe impl Pod for i8x16 {}

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_i8_as_i8x16 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i8x16 =
+      unsafe { ConstUnionHack128bit { i8a16: [$f; 16] }.i8x16 };
+  };
+}
+
+impl i8x16 {
+  const_i8_as_i8x16!(ONE, 1);
+  const_i8_as_i8x16!(ZERO, 0);
+  const_i8_as_i8x16!(MAX, i8::MAX);
+  const_i8_as_i8x16!(MIN, i8::MIN);
+}
+
 unsafe impl Zeroable for i8x16 {}
 unsafe impl Pod for i8x16 {}
 

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -16,19 +16,7 @@ pick! {
   }
 }
 
-macro_rules! const_i8_as_i8x32 {
-  ($i:ident, $f:expr) => {
-    pub const $i: i8x32 =
-      unsafe { ConstUnionHack256bit { i8a32: [$f; 32] }.i8x32 };
-  };
-}
-
-impl i8x32 {
-  const_i8_as_i8x32!(ONE, 1);
-  const_i8_as_i8x32!(ZERO, 0);
-  const_i8_as_i8x32!(MAX, i8::MAX);
-  const_i8_as_i8x32!(MIN, i8::MIN);
-}
+impl_nonfloat_consts!(i8, 32, i8x32, i8x32, i8a32, const_i8_as_i8x32, 256);
 
 unsafe impl Zeroable for i8x32 {}
 unsafe impl Pod for i8x32 {}

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -16,6 +16,20 @@ pick! {
   }
 }
 
+macro_rules! const_i8_as_i8x32 {
+  ($i:ident, $f:expr) => {
+    pub const $i: i8x32 =
+      unsafe { ConstUnionHack256bit { i8a32: [$f; 32] }.i8x32 };
+  };
+}
+
+impl i8x32 {
+  const_i8_as_i8x32!(ONE, 1);
+  const_i8_as_i8x32!(ZERO, 0);
+  const_i8_as_i8x32!(MAX, i8::MAX);
+  const_i8_as_i8x32!(MIN, i8::MIN);
+}
+
 unsafe impl Zeroable for i8x32 {}
 unsafe impl Pod for i8x32 {}
 

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -16,7 +16,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(i8, 32, i8x32, i8x32, i8a32, const_i8_as_i8x32, 256);
+int_uint_consts!(i8, 32, i8x32, i8x32, i8a32, const_i8_as_i8x32, 256);
 
 unsafe impl Zeroable for i8x32 {}
 unsafe impl Pod for i8x32 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,18 +253,56 @@ pub use u64x4_::*;
 
 #[allow(non_camel_case_types)]
 #[repr(C, align(16))]
+#[rustfmt::skip]
 union ConstUnionHack128bit {
-  f64a4: [f64; 4],
-  f32a8: [f32; 8],
   f32a4: [f32; 4],
-  i32a4: [i32; 4],
-  i64a4: [i64; 4],
   f64a2: [f64; 2],
-  f32x8: f32x8,
+  i8a16: [i8; 16],
+  i16a8: [i16; 8],
+  i32a4: [i32; 4],
+  i64a2: [i64; 2],
+  u8a16: [u8; 16],
+  u16a8: [u16; 8],
+  u32a4: [u32; 4],
+  u64a2: [u64; 2],
   f32x4: f32x4,
   f64x2: f64x2,
-  f64x4: f64x4,
-  u128: u128,
+  i8x16: i8x16,
+  i16x8: i16x8,
+  i32x4: i32x4,
+  i64x2: i64x2,
+  u8x16: u8x16,
+  u16x8: u16x8,
+  u32x4: u32x4,
+  u64x2: u64x2,
+  u128:  u128,
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C, align(16))]
+#[rustfmt::skip]
+union ConstUnionHack256bit {
+  f32a8:  [f32; 8],
+  f64a4:  [f64; 4],
+  i8a32:  [i8; 32],
+  i16a16: [i16; 16],
+  i32a8:  [i32; 8],
+  i64a4:  [i64; 4],
+  u8a32:  [u8; 32],
+  u16a16: [u16; 16],
+  u32a8:  [u32; 8],
+  u64a4:  [u64; 4],
+  u128x2: [u128; 2],
+  f32x8:  f32x8,
+  f64x4:  f64x4,
+  i8x32:  i8x32,
+  // i16x16: i16x16,
+  i32x8:  i32x8,
+  i64x4:  i64x4,
+  // u8x32:  u8x32,
+  // u16x16: u16x16,
+  u32x8:  u32x8,
+  u64x4:  u64x4,
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ use safe_arch::*;
 
 use bytemuck::*;
 
+#[macro_use]
+mod macros;
+
 macro_rules! pick {
   ($(if #[cfg($($test:meta),*)] {
       $($if_tokens:tt)*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,35 @@
+macro_rules! impl_nonfloat_consts_inner_impl {
+  ($type:ty, $simd:ty, $macro_name:ident) => {
+    impl $simd {
+      $macro_name!(ONE, 1);
+      $macro_name!(ZERO, 0);
+      $macro_name!(MAX, <$type>::MAX);
+      $macro_name!(MIN, <$type>::MIN);
+    }
+  };
+}
+
+macro_rules! impl_nonfloat_consts {
+  ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 128) => {
+    macro_rules! $macro_name {
+      ($i: ident, $f: expr) => {
+        pub const $i: $simd_type = unsafe {
+          ConstUnionHack128bit { $aligned: [$f; $lanes] }.$simd_ident
+        };
+      };
+    }
+
+    impl_nonfloat_consts_inner_impl!($type, $simd_type, $macro_name);
+  };
+  ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 256) => {
+    macro_rules! $macro_name {
+      ($i: ident, $f: expr) => {
+        pub const $i: $simd_type = unsafe {
+          ConstUnionHack256bit { $aligned: [$f; $lanes] }.$simd_ident
+        };
+      };
+    }
+
+    impl_nonfloat_consts_inner_impl!($type, $simd_type, $macro_name);
+  };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,15 +1,21 @@
-macro_rules! impl_nonfloat_consts_inner_impl {
-  ($type:ty, $simd:ty, $macro_name:ident) => {
+macro_rules! int_uint_consts_inner {
+  ($type:ty, $lanes:expr, $simd:ty, $macro_name:ident, $bits:expr) => {
     impl $simd {
       $macro_name!(ONE, 1);
       $macro_name!(ZERO, 0);
       $macro_name!(MAX, <$type>::MAX);
       $macro_name!(MIN, <$type>::MIN);
+
+      /// The number of lanes in this SIMD vector.
+      pub const LANES: u16 = $lanes;
+
+      /// The size of this SIMD vector in bits.
+      pub const BITS: u16 = $bits;
     }
   };
 }
 
-macro_rules! impl_nonfloat_consts {
+macro_rules! int_uint_consts {
   ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 128) => {
     macro_rules! $macro_name {
       ($i: ident, $f: expr) => {
@@ -19,7 +25,7 @@ macro_rules! impl_nonfloat_consts {
       };
     }
 
-    impl_nonfloat_consts_inner_impl!($type, $simd_type, $macro_name);
+    int_uint_consts_inner!($type, $lanes, $simd_type, $macro_name, 128);
   };
   ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 256) => {
     macro_rules! $macro_name {
@@ -30,6 +36,6 @@ macro_rules! impl_nonfloat_consts {
       };
     }
 
-    impl_nonfloat_consts_inner_impl!($type, $simd_type, $macro_name);
+    int_uint_consts_inner!($type, $lanes, $simd_type, $macro_name, 256);
   };
 }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_u16_as_u16x8 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u16x8 =
-      unsafe { ConstUnionHack128bit { u16a8: [$f; 8] }.u16x8 };
-  };
-}
-
-impl u16x8 {
-  const_u16_as_u16x8!(ONE, 1);
-  const_u16_as_u16x8!(ZERO, 0);
-  const_u16_as_u16x8!(MAX, u16::MAX);
-  const_u16_as_u16x8!(MIN, u16::MIN);
-}
+impl_nonfloat_consts!(u16, 8, u16x8, u16x8, u16a8, const_u16_as_u16x8, 128);
 
 unsafe impl Zeroable for u16x8 {}
 unsafe impl Pod for u16x8 {}

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_u16_as_u16x8 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u16x8 =
+      unsafe { ConstUnionHack128bit { u16a8: [$f; 8] }.u16x8 };
+  };
+}
+
+impl u16x8 {
+  const_u16_as_u16x8!(ONE, 1);
+  const_u16_as_u16x8!(ZERO, 0);
+  const_u16_as_u16x8!(MAX, u16::MAX);
+  const_u16_as_u16x8!(MIN, u16::MIN);
+}
+
 unsafe impl Zeroable for u16x8 {}
 unsafe impl Pod for u16x8 {}
 

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u16, 8, u16x8, u16x8, u16a8, const_u16_as_u16x8, 128);
+int_uint_consts!(u16, 8, u16x8, u16x8, u16a8, const_u16_as_u16x8, 128);
 
 unsafe impl Zeroable for u16x8 {}
 unsafe impl Pod for u16x8 {}

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_u32_as_u32x4 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u32x4 =
+      unsafe { ConstUnionHack128bit { u32a4: [$f; 4] }.u32x4 };
+  };
+}
+
+impl u32x4 {
+  const_u32_as_u32x4!(ONE, 1);
+  const_u32_as_u32x4!(ZERO, 0);
+  const_u32_as_u32x4!(MAX, u32::MAX);
+  const_u32_as_u32x4!(MIN, u32::MIN);
+}
+
 unsafe impl Zeroable for u32x4 {}
 unsafe impl Pod for u32x4 {}
 

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_u32_as_u32x4 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u32x4 =
-      unsafe { ConstUnionHack128bit { u32a4: [$f; 4] }.u32x4 };
-  };
-}
-
-impl u32x4 {
-  const_u32_as_u32x4!(ONE, 1);
-  const_u32_as_u32x4!(ZERO, 0);
-  const_u32_as_u32x4!(MAX, u32::MAX);
-  const_u32_as_u32x4!(MIN, u32::MIN);
-}
+impl_nonfloat_consts!(u32, 4, u32x4, u32x4, u32a4, const_u32_as_u32x4, 128);
 
 unsafe impl Zeroable for u32x4 {}
 unsafe impl Pod for u32x4 {}

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u32, 4, u32x4, u32x4, u32a4, const_u32_as_u32x4, 128);
+int_uint_consts!(u32, 4, u32x4, u32x4, u32a4, const_u32_as_u32x4, 128);
 
 unsafe impl Zeroable for u32x4 {}
 unsafe impl Pod for u32x4 {}

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -16,7 +16,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u32, 8, u32x8, u32x8, u32a8, const_u32_as_u32x8, 256);
+int_uint_consts!(u32, 8, u32x8, u32x8, u32a8, const_u32_as_u32x8, 256);
 
 unsafe impl Zeroable for u32x8 {}
 unsafe impl Pod for u32x8 {}

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -16,6 +16,20 @@ pick! {
   }
 }
 
+macro_rules! const_u32_as_u32x8 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u32x8 =
+      unsafe { ConstUnionHack256bit { u32a8: [$f; 8] }.u32x8 };
+  };
+}
+
+impl u32x8 {
+  const_u32_as_u32x8!(ONE, 1);
+  const_u32_as_u32x8!(ZERO, 0);
+  const_u32_as_u32x8!(MAX, u32::MAX);
+  const_u32_as_u32x8!(MIN, u32::MIN);
+}
+
 unsafe impl Zeroable for u32x8 {}
 unsafe impl Pod for u32x8 {}
 

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -16,19 +16,7 @@ pick! {
   }
 }
 
-macro_rules! const_u32_as_u32x8 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u32x8 =
-      unsafe { ConstUnionHack256bit { u32a8: [$f; 8] }.u32x8 };
-  };
-}
-
-impl u32x8 {
-  const_u32_as_u32x8!(ONE, 1);
-  const_u32_as_u32x8!(ZERO, 0);
-  const_u32_as_u32x8!(MAX, u32::MAX);
-  const_u32_as_u32x8!(MIN, u32::MIN);
-}
+impl_nonfloat_consts!(u32, 8, u32x8, u32x8, u32a8, const_u32_as_u32x8, 256);
 
 unsafe impl Zeroable for u32x8 {}
 unsafe impl Pod for u32x8 {}

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u64, 2, u64x2, u64x2, u64a2, const_u64_as_u64x2, 128);
+int_uint_consts!(u64, 2, u64x2, u64x2, u64a2, const_u64_as_u64x2, 128);
 
 unsafe impl Zeroable for u64x2 {}
 unsafe impl Pod for u64x2 {}

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_u64_as_u64x2 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u64x2 =
+      unsafe { ConstUnionHack128bit { u64a2: [$f; 2] }.u64x2 };
+  };
+}
+
+impl u64x2 {
+  const_u64_as_u64x2!(ONE, 1);
+  const_u64_as_u64x2!(ZERO, 0);
+  const_u64_as_u64x2!(MAX, u64::MAX);
+  const_u64_as_u64x2!(MIN, u64::MIN);
+}
+
 unsafe impl Zeroable for u64x2 {}
 unsafe impl Pod for u64x2 {}
 

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_u64_as_u64x2 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u64x2 =
-      unsafe { ConstUnionHack128bit { u64a2: [$f; 2] }.u64x2 };
-  };
-}
-
-impl u64x2 {
-  const_u64_as_u64x2!(ONE, 1);
-  const_u64_as_u64x2!(ZERO, 0);
-  const_u64_as_u64x2!(MAX, u64::MAX);
-  const_u64_as_u64x2!(MIN, u64::MIN);
-}
+impl_nonfloat_consts!(u64, 2, u64x2, u64x2, u64a2, const_u64_as_u64x2, 128);
 
 unsafe impl Zeroable for u64x2 {}
 unsafe impl Pod for u64x2 {}

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -16,7 +16,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u64, 4, u64x4, u64x4, u64a4, const_u64_as_u64x4, 256);
+int_uint_consts!(u64, 4, u64x4, u64x4, u64a4, const_u64_as_u64x4, 256);
 
 unsafe impl Zeroable for u64x4 {}
 unsafe impl Pod for u64x4 {}

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -16,6 +16,20 @@ pick! {
   }
 }
 
+macro_rules! const_u64_as_u64x4 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u64x4 =
+      unsafe { ConstUnionHack256bit { u64a4: [$f; 4] }.u64x4 };
+  };
+}
+
+impl u64x4 {
+  const_u64_as_u64x4!(ONE, 1);
+  const_u64_as_u64x4!(ZERO, 0);
+  const_u64_as_u64x4!(MAX, u64::MAX);
+  const_u64_as_u64x4!(MIN, u64::MIN);
+}
+
 unsafe impl Zeroable for u64x4 {}
 unsafe impl Pod for u64x4 {}
 

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -16,19 +16,7 @@ pick! {
   }
 }
 
-macro_rules! const_u64_as_u64x4 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u64x4 =
-      unsafe { ConstUnionHack256bit { u64a4: [$f; 4] }.u64x4 };
-  };
-}
-
-impl u64x4 {
-  const_u64_as_u64x4!(ONE, 1);
-  const_u64_as_u64x4!(ZERO, 0);
-  const_u64_as_u64x4!(MAX, u64::MAX);
-  const_u64_as_u64x4!(MIN, u64::MIN);
-}
+impl_nonfloat_consts!(u64, 4, u64x4, u64x4, u64a4, const_u64_as_u64x4, 256);
 
 unsafe impl Zeroable for u64x4 {}
 unsafe impl Pod for u64x4 {}

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -12,6 +12,20 @@ pick! {
   }
 }
 
+macro_rules! const_u8_as_u8x16 {
+  ($i:ident, $f:expr) => {
+    pub const $i: u8x16 =
+      unsafe { ConstUnionHack128bit { u8a16: [$f; 16] }.u8x16 };
+  };
+}
+
+impl u8x16 {
+  const_u8_as_u8x16!(ONE, 1);
+  const_u8_as_u8x16!(ZERO, 0);
+  const_u8_as_u8x16!(MAX, u8::MAX);
+  const_u8_as_u8x16!(MIN, u8::MIN);
+}
+
 unsafe impl Zeroable for u8x16 {}
 unsafe impl Pod for u8x16 {}
 

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-impl_nonfloat_consts!(u8, 16, u8x16, u8x16, u8a16, const_u8_as_u8x16, 128);
+int_uint_consts!(u8, 16, u8x16, u8x16, u8a16, const_u8_as_u8x16, 128);
 
 unsafe impl Zeroable for u8x16 {}
 unsafe impl Pod for u8x16 {}

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -12,19 +12,7 @@ pick! {
   }
 }
 
-macro_rules! const_u8_as_u8x16 {
-  ($i:ident, $f:expr) => {
-    pub const $i: u8x16 =
-      unsafe { ConstUnionHack128bit { u8a16: [$f; 16] }.u8x16 };
-  };
-}
-
-impl u8x16 {
-  const_u8_as_u8x16!(ONE, 1);
-  const_u8_as_u8x16!(ZERO, 0);
-  const_u8_as_u8x16!(MAX, u8::MAX);
-  const_u8_as_u8x16!(MIN, u8::MIN);
-}
+impl_nonfloat_consts!(u8, 16, u8x16, u8x16, u8a16, const_u8_as_u8x16, 128);
 
 unsafe impl Zeroable for u8x16 {}
 unsafe impl Pod for u8x16 {}

--- a/tests/t_f32x4.rs
+++ b/tests/t_f32x4.rs
@@ -279,7 +279,7 @@ fn impl_f32x4_round_int() {
   }
 }
 
-#[cfg(any(target_feature="sse", feature="std"))]
+#[cfg(any(target_feature = "sse", feature = "std"))]
 #[test]
 fn impl_f32x4_trunc_int() {
   let a = f32x4::from([1.1, 2.5, 3.7, 4.0]);

--- a/tests/t_f32x8.rs
+++ b/tests/t_f32x8.rs
@@ -306,7 +306,7 @@ fn impl_f32x8_round_int() {
   }
 }
 
-#[cfg(any(target_feature="avx", feature="std"))]
+#[cfg(any(target_feature = "avx", feature = "std"))]
 #[test]
 fn impl_f32x8_trunc_int() {
   for (f, i) in [


### PR DESCRIPTION
This PR adds the `ZERO`, `ONE`, `MAX` and `MIN` constants to the current integer types.