### PR TITLE
Use the `TAU` constant

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -41,7 +41,7 @@ impl f32x4 {
   const_f32_as_f32x4!(LOG2_10, core::f32::consts::LOG2_10);
   const_f32_as_f32x4!(PI, core::f32::consts::PI);
   const_f32_as_f32x4!(SQRT_2, core::f32::consts::SQRT_2);
-  const_f32_as_f32x4!(TAU, 6.28318530717958647692528676655900577_f32);
+  const_f32_as_f32x4!(TAU, core::f32::consts::TAU);
 }
 
 unsafe impl Zeroable for f32x4 {}

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -45,7 +45,7 @@ impl f32x8 {
   const_f32_as_f32x8!(LOG2_10, core::f32::consts::LOG2_10);
   const_f32_as_f32x8!(PI, core::f32::consts::PI);
   const_f32_as_f32x8!(SQRT_2, core::f32::consts::SQRT_2);
-  const_f32_as_f32x8!(TAU, 6.28318530717958647692528676655900577_f32);
+  const_f32_as_f32x8!(TAU, core::f32::consts::TAU);
 }
 
 unsafe impl Zeroable for f32x8 {}

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -41,7 +41,7 @@ impl f64x2 {
   const_f64_as_f64x2!(LOG2_10, core::f64::consts::LOG2_10);
   const_f64_as_f64x2!(PI, core::f64::consts::PI);
   const_f64_as_f64x2!(SQRT_2, core::f64::consts::SQRT_2);
-  const_f64_as_f64x2!(TAU, 6.28318530717958647692528676655900577_f64);
+  const_f64_as_f64x2!(TAU, core::f64::consts::TAU);
 }
 
 unsafe impl Zeroable for f64x2 {}

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -46,7 +46,7 @@ impl f64x4 {
   const_f64_as_f64x4!(LOG2_10, core::f64::consts::LOG2_10);
   const_f64_as_f64x4!(PI, core::f64::consts::PI);
   const_f64_as_f64x4!(SQRT_2, core::f64::consts::SQRT_2);
-  const_f64_as_f64x4!(TAU, 6.28318530717958647692528676655900577_f64);
+  const_f64_as_f64x4!(TAU, core::f64::consts::TAU);
 }
 
 unsafe impl Zeroable for f64x4 {}


### PR DESCRIPTION
The minimal Rust version of this crate is `1.52.0` and this constant got stabilized in `1.47.0`.