### PR TITLE
Implement Support for WebAssembly SIMD

### DIFF
--- a/.cargo-ci/config
+++ b/.cargo-ci/config
@@ -7,3 +7,7 @@
 # This can cause weirdness!
 rustflags = ["-Ctarget-cpu=native"]
 rustdocflags = ["-Ctarget-cpu=native"]
+
+[target.wasm32-wasi]
+runner = "wasmtime run --wasm-features all --dir ."
+rustflags = ["-Ctarget-feature=+simd128,+bulk-memory,+nontrapping-fptoint,+sign-ext"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,40 +6,40 @@ on:
 
 jobs:
   build_test:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.rust.os }}
     strategy:
       matrix:
         rust:
         # x86 without sse/sse2 on by default
-        - { target: i586-pc-windows-msvc, toolchain: 1.52.0 }
-        - { target: i586-pc-windows-msvc, toolchain: stable }
-        - { target: i586-pc-windows-msvc, toolchain: beta }
-        - { target: i586-pc-windows-msvc, toolchain: nightly }
+        - { target: i586-pc-windows-msvc, toolchain: 1.52.0, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: stable, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: beta, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86
-        - { target: i686-pc-windows-msvc, toolchain: 1.52.0 }
-        - { target: i686-pc-windows-msvc, toolchain: stable }
-        - { target: i686-pc-windows-msvc, toolchain: beta }
-        - { target: i686-pc-windows-msvc, toolchain: nightly }
+        - { target: i686-pc-windows-msvc, toolchain: 1.52.0, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: stable, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: beta, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86_64
-        - { target: x86_64-pc-windows-msvc, toolchain: 1.52.0 }
-        - { target: x86_64-pc-windows-msvc, toolchain: stable }
-        - { target: x86_64-pc-windows-msvc, toolchain: beta }
-        - { target: x86_64-pc-windows-msvc, toolchain: nightly }
+        - { target: x86_64-pc-windows-msvc, toolchain: 1.52.0, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         ## arm
-        #- { target: arm-unknown-linux-gnueabihf, toolchain: 1.52.0 }
-        #- { target: arm-unknown-linux-gnueabihf, toolchain: stable }
-        #- { target: arm-unknown-linux-gnueabihf, toolchain: beta }
-        #- { target: arm-unknown-linux-gnueabihf, toolchain: nightly }
+        #- { target: arm-unknown-linux-gnueabihf, toolchain: 1.52.0, os: ubuntu-latest }
+        #- { target: arm-unknown-linux-gnueabihf, toolchain: stable, os: ubuntu-latest }
+        #- { target: arm-unknown-linux-gnueabihf, toolchain: beta, os: ubuntu-latest }
+        #- { target: arm-unknown-linux-gnueabihf, toolchain: nightly, os: ubuntu-latest }
         ## aarch64
-        #- { target: aarch64-unknown-linux-gnu, toolchain: 1.52.0 }
-        #- { target: aarch64-unknown-linux-gnu, toolchain: stable }
-        #- { target: aarch64-unknown-linux-gnu, toolchain: beta }
-        #- { target: aarch64-unknown-linux-gnu, toolchain: nightly }
-        ## wasm32
-        #- { target: wasm32-unknown-unknown, toolchain: 1.52.0 }
-        #- { target: wasm32-unknown-unknown, toolchain: stable }
-        #- { target: wasm32-unknown-unknown, toolchain: beta }
-        #- { target: wasm32-unknown-unknown, toolchain: nightly }
+        #- { target: aarch64-unknown-linux-gnu, toolchain: 1.52.0, os: ubuntu-latest }
+        #- { target: aarch64-unknown-linux-gnu, toolchain: stable, os: ubuntu-latest }
+        #- { target: aarch64-unknown-linux-gnu, toolchain: beta, os: ubuntu-latest }
+        #- { target: aarch64-unknown-linux-gnu, toolchain: nightly, os: ubuntu-latest }
+        # wasm32
+        - { target: wasm32-wasi, toolchain: 1.54.0, os: ubuntu-latest }
+        - { target: wasm32-wasi, toolchain: stable, os: ubuntu-latest }
+        - { target: wasm32-wasi, toolchain: beta, os: ubuntu-latest }
+        - { target: wasm32-wasi, toolchain: nightly, os: ubuntu-latest }
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
@@ -48,19 +48,33 @@ jobs:
         target:  ${{ matrix.rust.target }}
         profile: minimal
         default: true
+
+    - name: Install wasmtime
+      if: matrix.rust.target == 'wasm32-wasi'
+      run: |
+        curl https://wasmtime.dev/install.sh -sSf | bash
+        echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
+
     - name: Build the crate
       run: cargo build --target ${{ matrix.rust.target }}
+
     - name: Test with default CPU features.
-      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc'
+      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
+      env:
+        CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime run --wasm-features all --dir .
       run: cargo test --target ${{ matrix.rust.target }}
     - name: Test with default CPU features + All Cargo Features
-      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc'
+      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
+      env:
+        CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime run --wasm-features all --dir .
       run: cargo test --target ${{ matrix.rust.target }} --all-features
+
     - name: switch over to native cpu features
       run: mv .cargo-ci .cargo
+
     - name: Test with 'native' CPU features.
-      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc'
+      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
       run: cargo test --target ${{ matrix.rust.target }}
     - name: Test with 'native' CPU features + All Cargo Features
-      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc'
+      if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
       run: cargo test --target ${{ matrix.rust.target }} --all-features

--- a/README.md
+++ b/README.md
@@ -9,5 +9,4 @@ A crate to help you go wide.
 
 Specifically, this has portable "wide" data types that do their best to be SIMD when possible.
 
-On `x86` and `x86_64` this is done with explicit intrinsic usage (via [safe_arch](https://docs.rs/safe_arch)), and on other architectures this is done by carefully writing functions so that LLVM hopefully does the right thing. When Rust stabilizes more explicit intrinsics then they can go into `safe_arch` and then they can get used here.
-
+On `x86`, `x86_64` and `wasm32` this is done with explicit intrinsic usage (via [safe_arch](https://docs.rs/safe_arch)), and on other architectures this is done by carefully writing functions so that LLVM hopefully does the right thing. When Rust stabilizes more explicit intrinsics then they can go into `safe_arch` and then they can get used here.

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -5,6 +5,24 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
     pub struct f32x4 { sse: m128 }
+  } else if #[cfg(target_feature="simd128")] {
+    use core::arch::wasm32::*;
+
+    #[derive(Clone, Copy)]
+    #[repr(transparent)]
+    pub struct f32x4 { simd: v128 }
+
+    impl Default for f32x4 {
+      fn default() -> Self {
+        Self::splat(0.0)
+      }
+    }
+
+    impl PartialEq for f32x4 {
+      fn eq(&self, other: &Self) -> bool {
+        u32x4_all_true(f32x4_eq(self.simd, other.simd))
+      }
+    }
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
@@ -55,6 +73,8 @@ impl Add for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: add_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_add(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0] + rhs.arr[0],
@@ -75,6 +95,8 @@ impl Sub for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: sub_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_sub(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0] - rhs.arr[0],
@@ -95,6 +117,8 @@ impl Mul for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: mul_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_mul(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0] * rhs.arr[0],
@@ -115,6 +139,8 @@ impl Div for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: div_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_div(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0] / rhs.arr[0],
@@ -207,6 +233,8 @@ impl BitAnd for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: bitand_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_and(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           f32::from_bits(self.arr[0].to_bits() & rhs.arr[0].to_bits()),
@@ -227,6 +255,8 @@ impl BitOr for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: bitor_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_or(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           f32::from_bits(self.arr[0].to_bits() | rhs.arr[0].to_bits()),
@@ -247,6 +277,8 @@ impl BitXor for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: bitxor_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_xor(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           f32::from_bits(self.arr[0].to_bits() ^ rhs.arr[0].to_bits()),
@@ -267,6 +299,8 @@ impl CmpEq for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_eq_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_eq(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] == rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -287,6 +321,8 @@ impl CmpGe for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_ge_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_ge(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] >= rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -307,6 +343,8 @@ impl CmpGt for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_gt_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_gt(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] > rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -327,6 +365,8 @@ impl CmpNe for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_neq_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_ne(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] != rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -347,6 +387,8 @@ impl CmpLe for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_le_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_le(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] <= rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -367,6 +409,8 @@ impl CmpLt for f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_lt_mask_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_lt(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] < rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -386,6 +430,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_m128(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else {
         generic_bit_blend(self, t, f)
       }
@@ -394,15 +440,66 @@ impl f32x4 {
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-    let non_sign_bits = f32x4::from(f32::from_bits(i32::MAX as u32));
-    self & non_sign_bits
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_abs(self.simd) }
+      } else {
+        let non_sign_bits = f32x4::from(f32::from_bits(i32::MAX as u32));
+        self & non_sign_bits
+      }
+    }
   }
+
+  /// Calculates the lanewise maximum of both vectors. This is a faster
+  /// implementation than `max`, but it doesn't specify any behavior if NaNs are
+  /// involved.
+  #[inline]
+  #[must_use]
+  pub fn fast_max(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse")] {
+        Self { sse: max_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self {
+          simd: f32x4_pmax(self.simd, rhs.simd),
+        }
+      } else {
+        Self { arr: [
+          if self.arr[0] < rhs.arr[0] { rhs.arr[0] } else { self.arr[0] },
+          if self.arr[1] < rhs.arr[1] { rhs.arr[1] } else { self.arr[1] },
+          if self.arr[2] < rhs.arr[2] { rhs.arr[2] } else { self.arr[2] },
+          if self.arr[3] < rhs.arr[3] { rhs.arr[3] } else { self.arr[3] },
+        ]}
+      }
+    }
+  }
+
+  /// Calculates the lanewise maximum of both vectors. If either lane is NaN,
+  /// the other lane gets chosen. Use `fast_max` for a faster implementation
+  /// that doesn't handle NaNs.
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        Self { sse: max_m128(self.sse, rhs.sse) }
+        // max_m128 seems to do rhs < self ? self : rhs. So if there's any NaN
+        // involved, it chooses rhs, so we need to specifically check rhs for
+        // NaN.
+        rhs.is_nan().blend(self, Self { sse: max_m128(self.sse, rhs.sse) })
+      } else if #[cfg(target_feature="simd128")] {
+        // WASM has two max intrinsics:
+        // - max: This propagates NaN, that's the opposite of what we need.
+        // - pmax: This is defined as self < rhs ? rhs : self, which basically
+        //   chooses self if either is NaN.
+        //
+        // pmax is what we want, but we need to specifically check self for NaN.
+        Self {
+          simd: v128_bitselect(
+            rhs.simd,
+            f32x4_pmax(self.simd, rhs.simd),
+            f32x4_ne(self.simd, self.simd), // NaN check
+          )
+        }
       } else {
         Self { arr: [
           self.arr[0].max(rhs.arr[0]),
@@ -413,12 +510,57 @@ impl f32x4 {
       }
     }
   }
+
+  /// Calculates the lanewise minimum of both vectors. This is a faster
+  /// implementation than `min`, but it doesn't specify any behavior if NaNs are
+  /// involved.
+  #[inline]
+  #[must_use]
+  pub fn fast_min(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse")] {
+        Self { sse: min_m128(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self {
+          simd: f32x4_pmin(self.simd, rhs.simd),
+        }
+      } else {
+        Self { arr: [
+          if self.arr[0] < rhs.arr[0] { self.arr[0] } else { rhs.arr[0] },
+          if self.arr[1] < rhs.arr[1] { self.arr[1] } else { rhs.arr[1] },
+          if self.arr[2] < rhs.arr[2] { self.arr[2] } else { rhs.arr[2] },
+          if self.arr[3] < rhs.arr[3] { self.arr[3] } else { rhs.arr[3] },
+        ]}
+      }
+    }
+  }
+
+  /// Calculates the lanewise minimum of both vectors. If either lane is NaN,
+  /// the other lane gets chosen. Use `fast_min` for a faster implementation
+  /// that doesn't handle NaNs.
   #[inline]
   #[must_use]
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        Self { sse: min_m128(self.sse, rhs.sse) }
+        // min_m128 seems to do self < rhs ? self : rhs. So if there's any NaN
+        // involved, it chooses rhs, so we need to specifically check rhs for
+        // NaN.
+        rhs.is_nan().blend(self, Self { sse: min_m128(self.sse, rhs.sse) })
+      } else if #[cfg(target_feature="simd128")] {
+        // WASM has two min intrinsics:
+        // - min: This propagates NaN, that's the opposite of what we need.
+        // - pmin: This is defined as rhs < self ? rhs : self, which basically
+        //   chooses self if either is NaN.
+        //
+        // pmin is what we want, but we need to specifically check self for NaN.
+        Self {
+          simd: v128_bitselect(
+            rhs.simd,
+            f32x4_pmin(self.simd, rhs.simd),
+            f32x4_ne(self.simd, self.simd), // NaN check
+          )
+        }
       } else {
         Self { arr: [
           self.arr[0].min(rhs.arr[0]),
@@ -435,6 +577,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: cmp_unord_mask_m128(self.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_ne(self.simd, self.simd) }
       } else {
         Self { arr: [
           if self.arr[0].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
@@ -476,6 +620,8 @@ impl f32x4 {
         let i: i32x4 = cast(mi);
         let mask: f32x4 = cast(i.cmp_eq(i32x4::from(0x80000000_u32 as i32)));
         mask.blend(self, f)
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_nearest(self.simd) }
       } else {
         // Note(Lokathor): This software fallback is probably very slow compared
         // to having a hardware option available, even just the sse2 version is
@@ -506,46 +652,89 @@ impl f32x4 {
       }
     }
   }
+
+  /// Rounds each lane into an integer. This is a faster implementation than
+  /// `round_int`, but it doesn't handle out of range values or NaNs. For those
+  /// values you get implementation defined behavior.
+  #[inline]
+  #[must_use]
+  pub fn fast_round_int(self) -> i32x4 {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        cast(convert_to_i32_m128i_from_m128(self.sse))
+      } else {
+        self.round_int()
+      }
+    }
+  }
+
+  /// Rounds each lane into an integer. This saturates out of range values and
+  /// turns NaNs into 0. Use `fast_round_int` for a faster implementation that
+  /// doesn't handle out of range values or NaNs.
   #[inline]
   #[must_use]
   pub fn round_int(self) -> i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        cast(convert_to_i32_m128i_from_m128(self.sse))
+        // Based on: https://github.com/v8/v8/blob/121df413a3abb5272e971e61bebf0e84efa175f2/src/compiler/backend/ia32/code-generator-ia32.cc#L2457
+        let non_nan_mask = self.cmp_eq(self);
+        let non_nan = self & non_nan_mask;
+        let scratch: i32x4 = cast(non_nan_mask ^ non_nan);
+        let dst: i32x4 = cast(convert_to_i32_m128i_from_m128(non_nan.sse));
+        dst ^ ((scratch & dst) >> 31)
+      } else if #[cfg(target_feature="simd128")] {
+        cast(Self { simd: i32x4_trunc_sat_f32x4(f32x4_nearest(self.simd)) })
       } else {
-        let rounded: [f32;4] = cast(self.round());
-        let rounded_ints: i32x4 = cast([
+        let rounded: [f32; 4] = cast(self.round());
+        cast([
           rounded[0] as i32,
           rounded[1] as i32,
           rounded[2] as i32,
           rounded[3] as i32,
-        ]);
-        cast::<f32x4, i32x4>(self.is_finite()).blend(
-          rounded_ints,
-          i32x4::from(i32::MIN)
-        )
+        ])
       }
     }
   }
-  #[cfg(any(target_feature = "sse", feature = "std"))]
+
+  /// Truncates each lane into an integer. This is a faster implementation than
+  /// `trunc_int`, but it doesn't handle out of range values or NaNs. For those
+  /// values you get implementation defined behavior.
+  #[inline]
+  #[must_use]
+  pub fn fast_trunc_int(self) -> i32x4 {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        cast(truncate_m128_to_m128i(self.sse))
+      } else {
+        self.trunc_int()
+      }
+    }
+  }
+
+  /// Truncates each lane into an integer. This saturates out of range values
+  /// and turns NaNs into 0. Use `fast_trunc_int` for a faster implementation
+  /// that doesn't handle out of range values or NaNs.
   #[inline]
   #[must_use]
   pub fn trunc_int(self) -> i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        cast(truncate_m128_to_m128i(self.sse))
+        // Based on: https://github.com/v8/v8/blob/121df413a3abb5272e971e61bebf0e84efa175f2/src/compiler/backend/ia32/code-generator-ia32.cc#L2457
+        let non_nan_mask = self.cmp_eq(self);
+        let non_nan = self & non_nan_mask;
+        let scratch: i32x4 = cast(non_nan_mask ^ non_nan);
+        let dst: i32x4 = cast(truncate_m128_to_m128i(non_nan.sse));
+        dst ^ ((scratch & dst) >> 31)
+      } else if #[cfg(target_feature="simd128")] {
+        cast(Self { simd: i32x4_trunc_sat_f32x4(self.simd) })
       } else {
         let n: [f32;4] = cast(self);
-        let ints: i32x4 = cast([
-          n[0].trunc() as i32,
-          n[1].trunc() as i32,
-          n[2].trunc() as i32,
-          n[3].trunc() as i32,
-        ]);
-        cast::<f32x4, i32x4>(self.is_finite()).blend(
-          ints,
-          i32x4::from(i32::MIN)
-        )
+        cast([
+          n[0] as i32,
+          n[1] as i32,
+          n[2] as i32,
+          n[3] as i32,
+        ])
       }
     }
   }
@@ -903,6 +1092,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: reciprocal_m128(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_div(f32x4_splat(1.0), self.simd) }
       } else {
         Self { arr: [
           1.0 / self.arr[0],
@@ -919,6 +1110,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: reciprocal_sqrt_m128(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_div(f32x4_splat(1.0), f32x4_sqrt(self.simd)) }
       } else if #[cfg(feature="std")] {
         Self { arr: [
           1.0 / self.arr[0].sqrt(),
@@ -942,6 +1135,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         Self { sse: sqrt_m128(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_sqrt(self.simd) }
       } else if #[cfg(feature="std")] {
         Self { arr: [
           self.arr[0].sqrt(),
@@ -965,6 +1160,8 @@ impl f32x4 {
     pick! {
       if #[cfg(target_feature="sse")] {
         move_mask_m128(self.sse)
+      } else if #[cfg(target_feature="simd128")] {
+        u32x4_bitmask(self.simd) as i32
       } else {
         (((self.arr[0].to_bits() as i32) < 0) as i32) << 0 |
         (((self.arr[1].to_bits() as i32) < 0) as i32) << 1 |
@@ -976,13 +1173,25 @@ impl f32x4 {
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {
-    self.move_mask() != 0
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        v128_any_true(self.simd)
+      } else {
+        self.move_mask() != 0
+      }
+    }
   }
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
-    // four lanes
-    self.move_mask() == 0b1111
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        u32x4_all_true(self.simd)
+      } else {
+        // four lanes
+        self.move_mask() == 0b1111
+      }
+    }
   }
   #[inline]
   #[must_use]
@@ -1076,14 +1285,8 @@ impl f32x4 {
   }
 
   pub fn reduce_add(self) -> f32 {
-    pick! {
-    if #[cfg(target_feature="sse")] {
-          let v = self.sse.to_array();
-          v.iter().sum()
-        } else {
-          self.arr.iter().sum()
-        }
-      }
+    let arr: [f32; 4] = cast(self);
+    arr.iter().sum()
   }
 
   /// Natural log (ln(x))

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -5,6 +5,26 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
     pub struct i32x4 { sse: m128i }
+  } else if #[cfg(target_feature="simd128")] {
+    use core::arch::wasm32::*;
+
+    #[derive(Clone, Copy)]
+    #[repr(transparent)]
+    pub struct i32x4 { simd: v128 }
+
+    impl Default for i32x4 {
+      fn default() -> Self {
+        Self::splat(0)
+      }
+    }
+
+    impl PartialEq for i32x4 {
+      fn eq(&self, other: &Self) -> bool {
+        u32x4_all_true(i32x4_eq(self.simd, other.simd))
+      }
+    }
+
+    impl Eq for i32x4 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
@@ -25,6 +45,8 @@ impl Add for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: add_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_add(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_add(rhs.arr[0]),
@@ -45,6 +67,8 @@ impl Sub for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: sub_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_sub(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_sub(rhs.arr[0]),
@@ -65,6 +89,8 @@ impl Mul for i32x4 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: mul_i32_keep_low_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_mul(self.simd, rhs.simd) }
       } else {
         let arr1: [i32; 4] = cast(self);
         let arr2: [i32; 4] = cast(rhs);
@@ -114,6 +140,8 @@ impl BitAnd for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitand_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_and(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitand(rhs.arr[0]),
@@ -134,6 +162,8 @@ impl BitOr for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitor_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_or(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitor(rhs.arr[0]),
@@ -154,6 +184,8 @@ impl BitXor for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitxor_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_xor(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitxor(rhs.arr[0]),
@@ -174,12 +206,14 @@ macro_rules! impl_shl_t_for_i32x4 {
       #[inline]
       #[must_use]
       fn shl(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { sse: shl_all_u32_m128i(self.sse, shift) }
+          } else if #[cfg(target_feature="simd128")] {
+            Self { simd: i32x4_shl(self.simd, rhs as u32) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] << u,
               self.arr[1] << u,
@@ -202,12 +236,14 @@ macro_rules! impl_shr_t_for_i32x4 {
       #[inline]
       #[must_use]
       fn shr(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { sse: shr_all_i32_m128i(self.sse, shift) }
+          } else if #[cfg(target_feature="simd128")] {
+            Self { simd: i32x4_shr(self.simd, rhs as u32) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] >> u,
               self.arr[1] >> u,
@@ -230,6 +266,8 @@ impl CmpEq for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: cmp_eq_mask_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_eq(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] == rhs.arr[0] { -1 } else { 0 },
@@ -250,6 +288,8 @@ impl CmpGt for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: cmp_gt_mask_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_gt(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] > rhs.arr[0] { -1 } else { 0 },
@@ -270,6 +310,8 @@ impl CmpLt for i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: cmp_lt_mask_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_lt(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] < rhs.arr[0] { -1 } else { 0 },
@@ -289,6 +331,8 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else {
         generic_bit_blend(self, t, f)
       }
@@ -300,6 +344,8 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="ssse3")] {
         Self { sse: abs_i32_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_abs(self.simd) }
       } else {
         let arr: [i32; 4] = cast(self);
         cast([
@@ -317,6 +363,8 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: max_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_max(self.simd, rhs.simd) }
       } else {
         self.cmp_lt(rhs).blend(rhs, self)
       }
@@ -328,6 +376,8 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: min_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i32x4_min(self.simd, rhs.simd) }
       } else {
         self.cmp_lt(rhs).blend(self, rhs)
       }
@@ -339,6 +389,8 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         cast(convert_to_m128_from_i32_m128i(self.sse))
+      } else if #[cfg(target_feature="simd128")] {
+        cast(Self { simd: f32x4_convert_i32x4(self.simd) })
       } else {
         let arr: [i32; 4] = cast(self);
         cast([
@@ -357,8 +409,9 @@ impl i32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         move_mask_i8_m128i(self.sse)
-      }
-      else {
+      } else if #[cfg(target_feature="simd128")] {
+        i32x4_bitmask(self.simd) as i32
+      } else {
         ((self.arr[0] < 0) as i32) << 0 |
         ((self.arr[1] < 0) as i32) << 1 |
         ((self.arr[2] < 0) as i32) << 2 |
@@ -369,13 +422,25 @@ impl i32x4 {
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {
-    self.move_mask() != 0
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        v128_any_true(self.simd)
+      } else {
+        self.move_mask() != 0
+      }
+    }
   }
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
-    // eight lanes
-    self.move_mask() == 0b1111
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        u32x4_all_true(self.simd)
+      } else {
+        // four lanes
+        self.move_mask() == 0b1111
+      }
+    }
   }
   #[inline]
   #[must_use]

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -9,6 +9,26 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct i32x8 { pub(crate) sse0: m128i, pub(crate) sse1: m128i }
+  } else if #[cfg(target_feature="simd128")] {
+    use core::arch::wasm32::*;
+
+    #[derive(Clone, Copy)]
+    #[repr(C, align(32))]
+    pub struct i32x8 { simd0: v128, simd1: v128 }
+
+    impl Default for i32x8 {
+      fn default() -> Self {
+        Self::splat(0)
+      }
+    }
+
+    impl PartialEq for i32x8 {
+      fn eq(&self, other: &Self) -> bool {
+        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
+      }
+    }
+
+    impl Eq for i32x8 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
@@ -31,6 +51,8 @@ impl Add for i32x8 {
         Self { avx2: add_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: add_i32_m128i(self.sse0, rhs.sse0), sse1: add_i32_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_add(self.simd0, rhs.simd0), simd1: i32x4_add(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_add(rhs.arr[0]),
@@ -57,6 +79,8 @@ impl Sub for i32x8 {
         Self { avx2: sub_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: sub_i32_m128i(self.sse0, rhs.sse0), sse1: sub_i32_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_sub(self.simd0, rhs.simd0), simd1: i32x4_sub(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_sub(rhs.arr[0]),
@@ -83,6 +107,8 @@ impl Mul for i32x8 {
         Self { avx2: mul_i32_keep_low_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: mul_i32_keep_low_m128i(self.sse0, rhs.sse0), sse1: mul_i32_keep_low_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_mul(self.simd0, rhs.simd0), simd1: i32x4_mul(self.simd1, rhs.simd1) }
       } else {
         let arr1: [i32; 8] = cast(self);
         let arr2: [i32; 8] = cast(rhs);
@@ -165,6 +191,8 @@ impl BitAnd for i32x8 {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].bitand(rhs.arr[0]),
@@ -191,6 +219,8 @@ impl BitOr for i32x8 {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: bitor_m128i(self.sse0, rhs.sse0), sse1: bitor_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].bitor(rhs.arr[0]),
@@ -217,6 +247,8 @@ impl BitXor for i32x8 {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].bitxor(rhs.arr[0]),
@@ -241,15 +273,18 @@ macro_rules! impl_shl_t_for_i32x8 {
       #[inline]
       #[must_use]
       fn shl(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
           } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { sse0: shl_all_u32_m128i(self.sse0, shift), sse1: shl_all_u32_m128i(self.sse1, shift)}
+          } else if #[cfg(target_feature="simd128")] {
+            let u = rhs as u32;
+            Self { simd0: i32x4_shl(self.simd0, u), simd1: i32x4_shl(self.simd1, u) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] << u,
               self.arr[1] << u,
@@ -276,15 +311,18 @@ macro_rules! impl_shr_t_for_i32x8 {
       #[inline]
       #[must_use]
       fn shr(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([u, 0]);
-            Self { avx2: shr_all_u32_m256i(self.avx2, shift) }
+            let shift = cast([rhs as u64, 0]);
+            Self { avx2: shr_all_i32_m256i(self.avx2, shift) }
           } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
-            Self { sse0: shr_all_u32_m128i(self.sse0, shift), sse1: shr_all_u32_m128i(self.sse1, shift)}
+            let shift = cast([rhs as u64, 0]);
+            Self { sse0: shr_all_i32_m128i(self.sse0, shift), sse1: shr_all_i32_m128i(self.sse1, shift)}
+          } else if #[cfg(target_feature="simd128")] {
+            let u = rhs as u32;
+            Self { simd0: i32x4_shr(self.simd0, u), simd1: i32x4_shr(self.simd1, u) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] >> u,
               self.arr[1] >> u,
@@ -314,6 +352,8 @@ impl CmpEq for i32x8 {
         Self { avx2: cmp_eq_mask_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: cmp_eq_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_eq_mask_i32_m128i(self.sse1,rhs.sse1), }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_eq(self.simd0, rhs.simd0), simd1: i32x4_eq(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           if self.arr[0] == rhs.arr[0] { -1 } else { 0 },
@@ -340,6 +380,8 @@ impl CmpGt for i32x8 {
         Self { avx2: cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: cmp_gt_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_gt_mask_i32_m128i(self.sse1,rhs.sse1), }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_gt(self.simd0, rhs.simd0), simd1: i32x4_gt(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           if self.arr[0] > rhs.arr[0] { -1 } else { 0 },
@@ -366,6 +408,8 @@ impl CmpLt for i32x8 {
         Self { avx2: !cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2)  ^ cmp_eq_mask_i32_m256i(self.avx2,rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: cmp_lt_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_lt_mask_i32_m128i(self.sse1,rhs.sse1), }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_lt(self.simd0, rhs.simd0), simd1: i32x4_lt(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           if self.arr[0] < rhs.arr[0] { -1 } else { 0 },
@@ -390,6 +434,8 @@ impl i32x8 {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
         generic_bit_blend(self, t, f)
       }
@@ -403,6 +449,8 @@ impl i32x8 {
         Self { avx2: abs_i32_m256i(self.avx2) }
       } else if #[cfg(target_feature="ssse3")] {
         Self { sse0: abs_i32_m128i(self.sse0), sse1: abs_i32_m128i(self.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_abs(self.simd0), simd1: i32x4_abs(self.simd1) }
       } else {
         let arr: [i32; 8] = cast(self);
         cast([
@@ -426,6 +474,8 @@ impl i32x8 {
         Self { avx2: max_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: max_i32_m128i(self.sse0, rhs.sse0), sse1: max_i32_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_max(self.simd0, rhs.simd0), simd1: i32x4_max(self.simd1, rhs.simd1) }
       } else {
         self.cmp_lt(rhs).blend(rhs, self)
       }
@@ -439,6 +489,8 @@ impl i32x8 {
         Self { avx2: min_i32_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: min_i32_m128i(self.sse0, rhs.sse0), sse1: min_i32_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: i32x4_min(self.simd0, rhs.simd0), simd1: i32x4_min(self.simd1, rhs.simd1) }
       } else {
         self.cmp_lt(rhs).blend(self, rhs)
       }
@@ -452,6 +504,8 @@ impl i32x8 {
         cast(convert_to_m256_from_i32_m256i(self.avx2))
       } else if #[cfg(target_feature="sse2")] {
         cast(Self { sse0 : cast(convert_to_m128_from_i32_m128i(self.sse0)), sse1 : cast(convert_to_m128_from_i32_m128i(self.sse1)) })
+      } else if #[cfg(target_feature="simd128")] {
+        cast(Self { simd0: f32x4_convert_i32x4(self.simd0), simd1: f32x4_convert_i32x4(self.simd1) })
       } else {
         let arr: [i32; 8] = cast(self);
         cast([
@@ -475,11 +529,12 @@ impl i32x8 {
       if #[cfg(target_feature="avx2")] {
         move_mask_i8_m256i(self.avx2)
       } else if #[cfg(target_feature="sse2")] {
-        move_mask_i8_m128i(self.sse0) << 16 | move_mask_i8_m128i(self.sse1)
-      }
-      else {
+        move_mask_i8_m128i(self.sse1) << 4 | move_mask_i8_m128i(self.sse0)
+      } else if #[cfg(target_feature="simd128")] {
+        (i32x4_bitmask(self.simd1) as i32) << 4 | i32x4_bitmask(self.simd0) as i32
+      } else {
         let mut out = 0;
-        for (index, i_eight) in unsafe { core::mem::transmute::<_, [i8; 32]>(self.arr) }.iter().copied().enumerate() {
+        for (index, i_eight) in self.arr.iter().copied().enumerate() {
           if i_eight < 0 {
             out |= 1 << index;
           }
@@ -491,12 +546,25 @@ impl i32x8 {
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {
-    self.move_mask() != 0
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        v128_any_true(self.simd0) | v128_any_true(self.simd1)
+      } else {
+        self.move_mask() != 0
+      }
+    }
   }
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
-    self.move_mask() == (u32::MAX as i32)
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        u32x4_all_true(self.simd0) & u32x4_all_true(self.simd1)
+      } else {
+        // eight lanes
+        self.move_mask() == 0b1111_1111
+      }
+    }
   }
   #[inline]
   #[must_use]
@@ -513,6 +581,8 @@ impl Not for i32x8 {
         Self { avx2: self.avx2.not()  }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: self.sse0.not(), sse1: self.sse1.not() }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
         Self { arr: [
           !self.arr[0],

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -9,6 +9,26 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct u64x4 { sse0: m128i, sse1: m128i }
+  } else if #[cfg(target_feature="simd128")] {
+    use core::arch::wasm32::*;
+
+    #[derive(Clone, Copy)]
+    #[repr(C, align(32))]
+    pub struct u64x4 { simd0: v128, simd1: v128 }
+
+    impl Default for u64x4 {
+      fn default() -> Self {
+        Self::splat(0)
+      }
+    }
+
+    impl PartialEq for u64x4 {
+      fn eq(&self, other: &Self) -> bool {
+        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
+      }
+    }
+
+    impl Eq for u64x4 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
@@ -31,6 +51,8 @@ impl Add for u64x4 {
         Self { avx2: add_i64_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: add_i64_m128i(self.sse0, rhs.sse0), sse1: add_i64_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: u64x2_add(self.simd0, rhs.simd0), simd1: u64x2_add(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_add(rhs.arr[0]),
@@ -53,6 +75,8 @@ impl Sub for u64x4 {
         Self { avx2: sub_i64_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: sub_i64_m128i(self.sse0, rhs.sse0), sse1: sub_i64_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: u64x2_sub(self.simd0, rhs.simd0), simd1: u64x2_sub(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_sub(rhs.arr[0]),
@@ -75,6 +99,8 @@ impl BitAnd for u64x4 {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].bitand(rhs.arr[0]),
@@ -94,18 +120,20 @@ impl BitOr for u64x4 {
   fn bitor(self, rhs: Self) -> Self::Output {
     pick! {
     if #[cfg(target_feature="avx2")] {
-            Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-          } else  if #[cfg(target_feature="sse2")] {
-            Self { sse0: bitor_m128i(self.sse0, rhs.sse0) , sse1: bitor_m128i(self.sse1, rhs.sse1)}
-          } else {
-            Self { arr: [
-              self.arr[0].bitor(rhs.arr[0]),
-              self.arr[1].bitor(rhs.arr[1]),
-              self.arr[2].bitor(rhs.arr[2]),
-              self.arr[3].bitor(rhs.arr[3]),
-                ]}
-          }
-        }
+        Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
+      } else  if #[cfg(target_feature="sse2")] {
+        Self { sse0: bitor_m128i(self.sse0, rhs.sse0) , sse1: bitor_m128i(self.sse1, rhs.sse1)}
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
+      } else {
+        Self { arr: [
+          self.arr[0].bitor(rhs.arr[0]),
+          self.arr[1].bitor(rhs.arr[1]),
+          self.arr[2].bitor(rhs.arr[2]),
+          self.arr[3].bitor(rhs.arr[3]),
+        ]}
+      }
+    }
   }
 }
 
@@ -119,6 +147,8 @@ impl BitXor for u64x4 {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
         Self { arr: [
           self.arr[0].bitxor(rhs.arr[0]),
@@ -139,15 +169,18 @@ macro_rules! impl_shl_t_for_u64x4 {
       #[inline]
       #[must_use]
       fn shl(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
           } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { sse0: shl_all_u64_m128i(self.sse0, shift), sse1: shl_all_u64_m128i(self.sse1, shift) }
+          } else if #[cfg(target_feature="simd128")] {
+            let u = rhs as u32;
+            Self { simd0: u64x2_shl(self.simd0, u), simd1: u64x2_shl(self.simd1, u) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] << u,
               self.arr[1] << u,
@@ -170,15 +203,18 @@ macro_rules! impl_shr_t_for_u64x4 {
       #[inline]
       #[must_use]
       fn shr(self, rhs: $shift_type) -> Self::Output {
-        let u = rhs as u64;
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { avx2: shr_all_u64_m256i(self.avx2, shift) }
           } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([u, 0]);
+            let shift = cast([rhs as u64, 0]);
             Self { sse0: shr_all_u64_m128i(self.sse0, shift), sse1: shr_all_u64_m128i(self.sse1, shift) }
+          } else if #[cfg(target_feature="simd128")] {
+            let u = rhs as u32;
+            Self { simd0: u64x2_shr(self.simd0, u), simd1: u64x2_shr(self.simd1, u) }
           } else {
+            let u = rhs as u64;
             Self { arr: [
               self.arr[0] >> u,
               self.arr[1] >> u,
@@ -202,6 +238,8 @@ impl u64x4 {
         Self { avx2: cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: cmp_eq_mask_i64_m128i(self.sse0, rhs.sse0),sse1: cmp_eq_mask_i64_m128i(self.sse1, rhs.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: u64x2_eq(self.simd0, rhs.simd0), simd1: u64x2_eq(self.simd1, rhs.simd1) }
       } else {
         let s: [i64;4] = cast(self);
         let r: [i64;4] = cast(rhs);
@@ -223,8 +261,9 @@ impl u64x4 {
       } else if #[cfg(target_feature="sse4.2")] {
         Self { sse0: cmp_gt_mask_i64_m128i(self.sse0, rhs.sse0), sse1: cmp_gt_mask_i64_m128i(self.sse1, rhs.sse1) }
       } else {
-        let s: [i64;4] = cast(self);
-        let r: [i64;4] = cast(rhs);
+        // u64x2_gt on WASM is not a thing. https://github.com/WebAssembly/simd/pull/414
+        let s: [u64;4] = cast(self);
+        let r: [u64;4] = cast(rhs);
         cast([
           if s[0] > r[0] { -1_i64 } else { 0 },
           if s[1] > r[1] { -1_i64 } else { 0 },
@@ -243,6 +282,8 @@ impl u64x4 {
         Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
         Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
         generic_bit_blend(self, t, f)
       }
@@ -258,6 +299,8 @@ impl Not for u64x4 {
         Self { avx2: self.avx2.not()  }
       } else if #[cfg(target_feature="sse2")] {
         Self { sse0: self.sse0.not() , sse1: self.sse1.not() }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd0: v128_not(self.simd0) , simd1: v128_not(self.simd1) }
       } else {
         Self { arr: [
           !self.arr[0],

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -5,6 +5,26 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
     pub struct u8x16 { sse: m128i }
+  } else if #[cfg(target_feature="simd128")] {
+    use core::arch::wasm32::*;
+
+    #[derive(Clone, Copy)]
+    #[repr(transparent)]
+    pub struct u8x16 { simd: v128 }
+
+    impl Default for u8x16 {
+      fn default() -> Self {
+        Self::splat(0)
+      }
+    }
+
+    impl PartialEq for u8x16 {
+      fn eq(&self, other: &Self) -> bool {
+        u8x16_all_true(u8x16_eq(self.simd, other.simd))
+      }
+    }
+
+    impl Eq for u8x16 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
@@ -25,6 +45,8 @@ impl Add for u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: add_i8_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_add(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_add(rhs.arr[0]),
@@ -57,6 +79,8 @@ impl Sub for u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: sub_i8_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_sub(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].wrapping_sub(rhs.arr[0]),
@@ -89,6 +113,8 @@ impl BitAnd for u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitand_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_and(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitand(rhs.arr[0]),
@@ -121,6 +147,8 @@ impl BitOr for u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitor_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_or(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitor(rhs.arr[0]),
@@ -153,6 +181,8 @@ impl BitXor for u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: bitxor_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_xor(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].bitxor(rhs.arr[0]),
@@ -184,6 +214,8 @@ impl u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: cmp_eq_mask_i8_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_eq(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           if self.arr[0] == rhs.arr[0] { u8::MAX } else { 0 },
@@ -212,6 +244,8 @@ impl u8x16 {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else {
         generic_bit_blend(self, t, f)
       }
@@ -223,6 +257,8 @@ impl u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: max_u8_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_max(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].max(rhs.arr[0]),
@@ -251,6 +287,8 @@ impl u8x16 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: min_u8_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_min(self.simd, rhs.simd) }
       } else {
         Self { arr: [
           self.arr[0].min(rhs.arr[0]),

--- a/tests/t_f64x2.rs
+++ b/tests/t_f64x2.rs
@@ -216,19 +216,73 @@ fn impl_f64x2_abs() {
 }
 
 #[test]
+fn impl_f64x2_fast_max() {
+  let a = f64x2::from([-0.0, -5.0]);
+  let b = f64x2::from([0.0, 3.0]);
+  let expected = f64x2::from([0.0, 3.0]);
+  let actual = a.fast_max(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let b = f64x2::from([2.0, f64::INFINITY]);
+  let expected = f64x2::from([2.0, f64::INFINITY]);
+  let actual = a.fast_max(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_f64x2_max() {
+  let a = f64x2::from([-0.0, -5.0]);
+  let b = f64x2::from([0.0, 3.0]);
+  let expected = f64x2::from([0.0, 3.0]);
+  let actual = a.max(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let b = f64x2::from([2.0, f64::INFINITY]);
+  let expected = f64x2::from([2.0, f64::INFINITY]);
+  let actual = a.max(b);
+  assert_eq!(expected, actual);
+
   let a = f64x2::from([f64::NAN, 5.0]);
-  let b = f64x2::from([2.0, f64::NEG_INFINITY]);
+  let b = f64x2::from([2.0, f64::NAN]);
   let expected = f64x2::from([2.0, 5.0]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
+fn impl_f64x2_fast_min() {
+  let a = f64x2::from([-0.0, -5.0]);
+  let b = f64x2::from([0.0, 3.0]);
+  let expected = f64x2::from([-0.0, -5.0]);
+  let actual = a.fast_min(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let b = f64x2::from([2.0, f64::INFINITY]);
+  let expected = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let actual = a.fast_min(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_f64x2_min() {
+  let a = f64x2::from([-0.0, -5.0]);
+  let b = f64x2::from([0.0, 3.0]);
+  let expected = f64x2::from([-0.0, -5.0]);
+  let actual = a.min(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let b = f64x2::from([2.0, f64::INFINITY]);
+  let expected = f64x2::from([f64::NEG_INFINITY, 5.0]);
+  let actual = a.min(b);
+  assert_eq!(expected, actual);
+
   let a = f64x2::from([f64::NAN, 5.0]);
-  let b = f64x2::from([2.0, f64::NEG_INFINITY]);
-  let expected = f64x2::from([2.0, f64::NEG_INFINITY]);
+  let b = f64x2::from([2.0, f64::NAN]);
+  let expected = f64x2::from([2.0, 5.0]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }
@@ -306,8 +360,8 @@ fn impl_f64x2_round_int() {
     (2.5, 2),
     (0.0, 0),
     (-0.0, 0),
-    (f64::NAN, i64::MIN),
-    (f64::INFINITY, i64::MIN),
+    (f64::NAN, 0),
+    (f64::INFINITY, i64::MAX),
     (f64::NEG_INFINITY, i64::MIN),
   ]
   .iter()
@@ -633,28 +687,28 @@ fn impl_f64x2_exp() {
 
 #[test]
 fn test_f64x2_any() {
-  let a = f64x2::from([-1.0, 0.0]);
+  let a = f64x2::from([-1.0, f64::NAN]).is_nan();
   assert!(a.any());
   //
-  let a = f64x2::from([1.0, 0.0]);
+  let a = f64x2::from([1.0, 0.0]).is_nan();
   assert!(!a.any());
 }
 
 #[test]
 fn test_f64x2_all() {
-  let a = f64x2::from([-1.0, -0.0]);
+  let a = f64x2::from([f64::NAN, f64::NAN]).is_nan();
   assert!(a.all());
   //
-  let a = f64x2::from([1.0, -0.0]);
+  let a = f64x2::from([1.0, f64::NAN]).is_nan();
   assert!(!a.all());
 }
 
 #[test]
 fn test_f64x2_none() {
-  let a = f64x2::from([1.0, 0.0]);
+  let a = f64x2::from([1.0, 0.0]).is_nan();
   assert!(a.none());
   //
-  let a = f64x2::from([1.0, -0.0]);
+  let a = f64x2::from([1.0, f64::NAN]).is_nan();
   assert!(!a.none());
 }
 

--- a/tests/t_f64x4.rs
+++ b/tests/t_f64x4.rs
@@ -184,19 +184,49 @@ fn impl_f64x4_abs() {
 }
 
 #[test]
+fn impl_f64x4_fast_max() {
+  let a = f64x4::from([1.0, 5.0, 3.0, -0.0]);
+  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 0.0]);
+  let expected = f64x4::from([2.0, 5.0, f64::INFINITY, 0.0]);
+  let actual = a.fast_max(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_f64x4_max() {
-  let a = f64x4::from([1.0, 5.0, 3.0, f64::NAN]);
-  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 10.0]);
-  let expected = f64x4::from([2.0, 5.0, f64::INFINITY, 10.0]);
+  let a = f64x4::from([1.0, 5.0, 3.0, -0.0]);
+  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 0.0]);
+  let expected = f64x4::from([2.0, 5.0, f64::INFINITY, 0.0]);
+  let actual = a.max(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x4::from([f64::NAN, 5.0, f64::INFINITY, f64::NAN]);
+  let b = f64x4::from([2.0, f64::NAN, f64::NAN, f64::INFINITY]);
+  let expected = f64x4::from([2.0, 5.0, f64::INFINITY, f64::INFINITY]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
+fn impl_f64x4_fast_min() {
+  let a = f64x4::from([1.0, 5.0, 3.0, -0.0]);
+  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 0.0]);
+  let expected = f64x4::from([1.0, f64::NEG_INFINITY, 3.0, -0.0]);
+  let actual = a.fast_min(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_f64x4_min() {
-  let a = f64x4::from([1.0, 5.0, 3.0, f64::NAN]);
-  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 10.0]);
-  let expected = f64x4::from([1.0, f64::NEG_INFINITY, 3.0, 10.0]);
+  let a = f64x4::from([1.0, 5.0, 3.0, -0.0]);
+  let b = f64x4::from([2.0, f64::NEG_INFINITY, f64::INFINITY, 0.0]);
+  let expected = f64x4::from([1.0, f64::NEG_INFINITY, 3.0, -0.0]);
+  let actual = a.min(b);
+  assert_eq!(expected, actual);
+
+  let a = f64x4::from([f64::NAN, 5.0, f64::INFINITY, f64::NAN]);
+  let b = f64x4::from([2.0, f64::NAN, f64::NAN, f64::INFINITY]);
+  let expected = f64x4::from([2.0, 5.0, f64::INFINITY, f64::INFINITY]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }
@@ -254,8 +284,8 @@ fn impl_f64x4_round_int() {
     (2.5, 2),
     (0.0, 0),
     (-0.0, 0),
-    (f64::NAN, i64::MIN),
-    (f64::INFINITY, i64::MIN),
+    (f64::NAN, 0),
+    (f64::INFINITY, i64::MAX),
     (f64::NEG_INFINITY, i64::MIN),
   ]
   .iter()
@@ -561,28 +591,28 @@ fn test_f64x4_move_mask() {
 
 #[test]
 fn test_f64x4_any() {
-  let a = f64x4::from([-1.0, 0.0, -2.0, -3.0]);
+  let a = f64x4::from([-1.0, 0.0, -2.0, f64::NAN]).is_nan();
   assert!(a.any());
   //
-  let a = f64x4::from([1.0, 0.0, 2.0, 3.0]);
+  let a = f64x4::from([1.0, 0.0, 2.0, 3.0]).is_nan();
   assert!(!a.any());
 }
 
 #[test]
 fn test_f64x4_all() {
-  let a = f64x4::from([-1.0, -0.5, -2.0, -3.0]);
+  let a = f64x4::from([f64::NAN, f64::NAN, f64::NAN, f64::NAN]).is_nan();
   assert!(a.all());
   //
-  let a = f64x4::from([1.0, -0.0, 2.0, 3.0]);
+  let a = f64x4::from([1.0, -0.0, 2.0, f64::NAN]).is_nan();
   assert!(!a.all());
 }
 
 #[test]
 fn test_f64x4_none() {
-  let a = f64x4::from([1.0, 0.0, 2.0, 3.0]);
+  let a = f64x4::from([1.0, 0.0, 2.0, 3.0]).is_nan();
   assert!(a.none());
   //
-  let a = f64x4::from([1.0, -0.0, 2.0, 3.0]);
+  let a = f64x4::from([1.0, -0.0, 2.0, f64::NAN]).is_nan();
   assert!(!a.none());
 }
 

--- a/tests/t_i8x32.rs
+++ b/tests/t_i8x32.rs
@@ -1,14 +1,6 @@
 use wide::*;
 
 #[test]
-#[cfg(not(target_feature = "avx2"))]
-fn size_align() {
-  assert_eq!(core::mem::size_of::<i8x32>(), 32);
-  assert_eq!(core::mem::align_of::<i8x32>(), 16);
-}
-
-#[test]
-#[cfg(target_feature = "avx2")]
 fn size_align() {
   assert_eq!(core::mem::size_of::<i8x32>(), 32);
   assert_eq!(core::mem::align_of::<i8x32>(), 32);
@@ -179,8 +171,8 @@ fn impl_i8x32_cmp_lt() {
   assert_eq!(expected, actual);
 
   let expected = i8x32::from([
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
   ]);
   let actual = a.cmp_lt(a);
   assert_eq!(expected, actual);


### PR DESCRIPTION
This adds support for the `+simd128` target feature for WebAssembly. The SIMD intrinsics just got stabilized with Rust `1.54.0`.