### PR TITLE
Activate `std` by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,11 +58,11 @@ jobs:
     - name: Build the crate
       run: cargo build --target ${{ matrix.rust.target }}
 
-    - name: Test with default CPU features.
+    - name: Test with default CPU features + No Default Cargo Features
       if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
       env:
         CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime run --wasm-features all --dir .
-      run: cargo test --target ${{ matrix.rust.target }}
+      run: cargo test --target ${{ matrix.rust.target }} --no-default-features
     - name: Test with default CPU features + All Cargo Features
       if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
       env:
@@ -72,9 +72,9 @@ jobs:
     - name: switch over to native cpu features
       run: mv .cargo-ci .cargo
 
-    - name: Test with 'native' CPU features.
+    - name: Test with 'native' CPU features + No Default Cargo Features
       if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
-      run: cargo test --target ${{ matrix.rust.target }}
+      run: cargo test --target ${{ matrix.rust.target }} --no-default-features
     - name: Test with 'native' CPU features + All Cargo Features
       if: matrix.rust.target == 'i586-pc-windows-msvc' || matrix.rust.target == 'i686-pc-windows-msvc' || matrix.rust.target == 'x86_64-pc-windows-msvc' || matrix.rust.target == 'wasm32-wasi'
       run: cargo test --target ${{ matrix.rust.target }} --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 
 [features]
-default = []
+default = ["std"]
 
 # Activate `std` within the crate. Currently this gives a much faster `sqrt`
 # impl when an explicit hardware sqrt isn't available.


### PR DESCRIPTION
It's too risky to have it be deactivated by default as all users of this crate seem to have missed it. This is a breaking change.

Resolves #98 