### PR TITLE
Implement multiplication in most vectors that dont have it

### DIFF
--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -163,6 +163,60 @@ impl Mul for i16x16 {
   }
 }
 
+impl Add<i16> for i16x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i16) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i16> for i16x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i16) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<i16> for i16x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i16) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
+impl Add<i16x16> for i16 {
+  type Output = i16x16;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i16x16) -> Self::Output {
+    i16x16::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i16x16> for i16 {
+  type Output = i16x16;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i16x16) -> Self::Output {
+    i16x16::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<i16x16> for i16 {
+  type Output = i16x16;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i16x16) -> Self::Output {
+    i16x16::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for i16x16 {
   type Output = Self;
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -115,6 +115,60 @@ impl Mul for i16x8 {
   }
 }
 
+impl Add<i16> for i16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i16) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i16> for i16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i16) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<i16> for i16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i16) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
+impl Add<i16x8> for i16 {
+  type Output = i16x8;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i16x8) -> Self::Output {
+    i16x8::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i16x8> for i16 {
+  type Output = i16x8;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i16x8) -> Self::Output {
+    i16x8::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<i16x8> for i16 {
+  type Output = i16x8;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i16x8) -> Self::Output {
+    i16x8::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for i16x8 {
   type Output = Self;
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -132,6 +132,33 @@ impl Mul<i32> for i32x4 {
   }
 }
 
+impl Add<i32x4> for i32 {
+  type Output = i32x4;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i32x4) -> Self::Output {
+    i32x4::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i32x4> for i32 {
+  type Output = i32x4;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i32x4) -> Self::Output {
+    i32x4::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<i32x4> for i32 {
+  type Output = i32x4;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i32x4) -> Self::Output {
+    i32x4::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for i32x4 {
   type Output = Self;
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -87,7 +87,7 @@ impl Mul for i64x2 {
       if #[cfg(target_feature="simd128")] {
         Self { simd: i64x2_mul(self.simd, rhs.simd) }
       } else {
-        let arr1: [i64; 2] = cast(self); 
+        let arr1: [i64; 2] = cast(self);
         let arr2: [i64; 2] = cast(rhs);
         cast([
           arr1[0].wrapping_mul(arr2[0]),

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -125,6 +125,33 @@ impl Mul<i64> for i64x2 {
   }
 }
 
+impl Add<i64x2> for i64 {
+  type Output = i64x2;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i64x2) -> Self::Output {
+    i64x2::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i64x2> for i64 {
+  type Output = i64x2;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i64x2) -> Self::Output {
+    i64x2::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<i64x2> for i64 {
+  type Output = i64x2;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i64x2) -> Self::Output {
+    i64x2::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for i64x2 {
   type Output = Self;
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -77,6 +77,54 @@ impl Sub for i64x2 {
   }
 }
 
+//we should try to implement this on sse2
+impl Mul for i64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        Self { simd: i64x2_mul(self.simd, rhs.simd) }
+      } else {
+        let arr1: [i64; 2] = cast(self); 
+        let arr2: [i64; 2] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+        ])
+      }
+    }
+  }
+}
+
+impl Add<i64> for i64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i64) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i64> for i64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i64) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<i64> for i64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i64) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
 impl BitAnd for i64x2 {
   type Output = Self;
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -89,6 +89,55 @@ impl Sub for i64x4 {
   }
 }
 
+impl Mul for i64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        Self { simd0: i64x2_mul(self.simd0, rhs.simd0), simd1: i64x2_mul(self.simd1, rhs.simd1) }
+      } else {
+        let arr1: [i64; 4] = cast(self); 
+        let arr2: [i64; 4] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+          arr1[2].wrapping_mul(arr2[2]),
+          arr1[3].wrapping_mul(arr2[3]),
+        ])
+      }
+    }
+  }
+}
+
+impl Add<i64> for i64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i64) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i64> for i64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i64) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<i64> for i64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i64) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
 impl BitAnd for i64x4 {
   type Output = Self;
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -138,6 +138,33 @@ impl Mul<i64> for i64x4 {
   }
 }
 
+impl Add<i64x4> for i64 {
+  type Output = i64x4;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i64x4) -> Self::Output {
+    i64x4::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i64x4> for i64 {
+  type Output = i64x4;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i64x4) -> Self::Output {
+    i64x4::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<i64x4> for i64 {
+  type Output = i64x4;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: i64x4) -> Self::Output {
+    i64x4::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for i64x4 {
   type Output = Self;
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -98,7 +98,7 @@ impl Mul for i64x4 {
       if #[cfg(target_feature="simd128")] {
         Self { simd0: i64x2_mul(self.simd0, rhs.simd0), simd1: i64x2_mul(self.simd1, rhs.simd1) }
       } else {
-        let arr1: [i64; 4] = cast(self); 
+        let arr1: [i64; 4] = cast(self);
         let arr2: [i64; 4] = cast(rhs);
         cast([
           arr1[0].wrapping_mul(arr2[0]),

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -105,6 +105,42 @@ impl Sub for i8x16 {
   }
 }
 
+impl Add<i8> for i8x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i8) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i8> for i8x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i8) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Add<i8x16> for i8 {
+  type Output = i8x16;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i8x16) -> Self::Output {
+    i8x16::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i8x16> for i8 {
+  type Output = i8x16;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i8x16) -> Self::Output {
+    i8x16::splat(self).sub(rhs)
+  }
+}
+
 impl BitAnd for i8x16 {
   type Output = Self;
   #[inline]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -145,6 +145,42 @@ impl Sub for i8x32 {
   }
 }
 
+impl Add<i8> for i8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i8) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<i8> for i8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i8) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Add<i8x32> for i8 {
+  type Output = i8x32;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: i8x32) -> Self::Output {
+    i8x32::splat(self).add(rhs)
+  }
+}
+
+impl Sub<i8x32> for i8 {
+  type Output = i8x32;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: i8x32) -> Self::Output {
+    i8x32::splat(self).sub(rhs)
+  }
+}
+
 impl BitAnd for i8x32 {
   type Output = Self;
   #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,8 @@ macro_rules! polynomial_13 {
 }
 
 macro_rules! polynomial_13m {
-  // return  ((c8+c9*x) + (c10+c11*x)*x2 + (c12+c13*x)*x4)*x8 + (((c6+c7*x)*x2 + (c4+c5*x))*x4 + ((c2+c3*x)*x2 + x));
+  // return  ((c8+c9*x) + (c10+c11*x)*x2 + (c12+c13*x)*x4)*x8 + (((c6+c7*x)*x2 +
+  // (c4+c5*x))*x4 + ((c2+c3*x)*x2 + x));
   ($x:expr,  $c2:expr, $c3:expr, $c4:expr, $c5:expr,$c6:expr, $c7:expr, $c8:expr,$c9:expr, $c10:expr, $c11:expr, $c12:expr, $c13:expr  $(,)?) => {{
     let x = $x;
     let x2 = x * x;
@@ -932,4 +933,3 @@ bulk_impl_const_rhs_op!((CmpGt, cmp_gt) => [(f64x4, f64), (f64x2, f64), (f32x4,f
 bulk_impl_const_rhs_op!((CmpNe, cmp_ne) => [(f64x4, f64), (f64x2, f64), (f32x4,f32), (f32x8,f32),]);
 bulk_impl_const_rhs_op!((CmpLe, cmp_le) => [(f64x4, f64), (f64x2, f64), (f32x4,f32), (f32x8,f32),]);
 bulk_impl_const_rhs_op!((CmpGe, cmp_ge) => [(f64x4, f64), (f64x2, f64), (f32x4,f32), (f32x8,f32),]);
-

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -89,6 +89,86 @@ impl Sub for u16x8 {
   }
 }
 
+impl Mul for u16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: mul_i16_keep_low_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u16x8_mul(self.simd, rhs.simd) }
+      } else {
+        Self { arr: [
+          self.arr[0].wrapping_mul(rhs.arr[0]),
+          self.arr[1].wrapping_mul(rhs.arr[1]),
+          self.arr[2].wrapping_mul(rhs.arr[2]),
+          self.arr[3].wrapping_mul(rhs.arr[3]),
+          self.arr[4].wrapping_mul(rhs.arr[4]),
+          self.arr[5].wrapping_mul(rhs.arr[5]),
+          self.arr[6].wrapping_mul(rhs.arr[6]),
+          self.arr[7].wrapping_mul(rhs.arr[7]),
+        ]}
+      }
+    }
+  }
+}
+
+impl Add<u16> for u16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u16) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u16> for u16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u16) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<u16> for u16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u16) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
+impl Add<u16x8> for u16 {
+  type Output = u16x8;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u16x8) -> Self::Output {
+    u16x8::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u16x8> for u16 {
+  type Output = u16x8;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u16x8) -> Self::Output {
+    u16x8::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<u16x8> for u16 {
+  type Output = u16x8;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u16x8) -> Self::Output {
+    u16x8::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for u16x8 {
   type Output = Self;
   #[inline]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -92,7 +92,7 @@ impl Mul for u32x4 {
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u32x4_mul(self.simd, rhs.simd) }
       } else {
-        let arr1: [u32; 4] = cast(self); 
+        let arr1: [u32; 4] = cast(self);
         let arr2: [u32; 4] = cast(rhs);
         cast([
           arr1[0].wrapping_mul(arr2[0]),

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -81,6 +81,84 @@ impl Sub for u32x4 {
   }
 }
 
+impl Mul for u32x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: mul_i32_keep_low_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u32x4_mul(self.simd, rhs.simd) }
+      } else {
+        let arr1: [u32; 4] = cast(self); 
+        let arr2: [u32; 4] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+          arr1[2].wrapping_mul(arr2[2]),
+          arr1[3].wrapping_mul(arr2[3]),
+        ])
+      }
+    }
+  }
+}
+
+impl Add<u32> for u32x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u32) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u32> for u32x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u32) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<u32> for u32x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u32) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
+impl Add<u32x4> for u32 {
+  type Output = u32x4;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u32x4) -> Self::Output {
+    u32x4::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u32x4> for u32 {
+  type Output = u32x4;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u32x4) -> Self::Output {
+    u32x4::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<u32x4> for u32 {
+  type Output = u32x4;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u32x4) -> Self::Output {
+    u32x4::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for u32x4 {
   type Output = Self;
   #[inline]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -87,7 +87,7 @@ impl Mul for u64x2 {
       if #[cfg(target_feature="simd128")] {
         Self { simd: u64x2_mul(self.simd, rhs.simd) }
       } else {
-        let arr1: [u64; 2] = cast(self); 
+        let arr1: [u64; 2] = cast(self);
         let arr2: [u64; 2] = cast(rhs);
         cast([
           arr1[0].wrapping_mul(arr2[0]),

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -77,6 +77,54 @@ impl Sub for u64x2 {
   }
 }
 
+//we should try to implement this on sse2
+impl Mul for u64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        Self { simd: u64x2_mul(self.simd, rhs.simd) }
+      } else {
+        let arr1: [u64; 2] = cast(self); 
+        let arr2: [u64; 2] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+        ])
+      }
+    }
+  }
+}
+
+impl Add<u64> for u64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u64) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u64> for u64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u64) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<u64> for u64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u64) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
 impl BitAnd for u64x2 {
   type Output = Self;
   #[inline]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -125,6 +125,33 @@ impl Mul<u64> for u64x2 {
   }
 }
 
+impl Add<u64x2> for u64 {
+  type Output = u64x2;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u64x2) -> Self::Output {
+    u64x2::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u64x2> for u64 {
+  type Output = u64x2;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u64x2) -> Self::Output {
+    u64x2::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<u64x2> for u64 {
+  type Output = u64x2;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u64x2) -> Self::Output {
+    u64x2::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for u64x2 {
   type Output = Self;
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -138,6 +138,33 @@ impl Mul<u64> for u64x4 {
   }
 }
 
+impl Add<u64x4> for u64 {
+  type Output = u64x4;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u64x4) -> Self::Output {
+    u64x4::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u64x4> for u64 {
+  type Output = u64x4;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u64x4) -> Self::Output {
+    u64x4::splat(self).sub(rhs)
+  }
+}
+
+impl Mul<u64x4> for u64 {
+  type Output = u64x4;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u64x4) -> Self::Output {
+    u64x4::splat(self).mul(rhs)
+  }
+}
+
 impl BitAnd for u64x4 {
   type Output = Self;
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -98,7 +98,7 @@ impl Mul for u64x4 {
       if #[cfg(target_feature="simd128")] {
         Self { simd0: u64x2_mul(self.simd0, rhs.simd0), simd1: u64x2_mul(self.simd1, rhs.simd1) }
       } else {
-        let arr1: [u64; 4] = cast(self); 
+        let arr1: [u64; 4] = cast(self);
         let arr2: [u64; 4] = cast(rhs);
         cast([
           arr1[0].wrapping_mul(arr2[0]),

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -89,6 +89,55 @@ impl Sub for u64x4 {
   }
 }
 
+impl Mul for u64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        Self { simd0: u64x2_mul(self.simd0, rhs.simd0), simd1: u64x2_mul(self.simd1, rhs.simd1) }
+      } else {
+        let arr1: [u64; 4] = cast(self); 
+        let arr2: [u64; 4] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+          arr1[2].wrapping_mul(arr2[2]),
+          arr1[3].wrapping_mul(arr2[3]),
+        ])
+      }
+    }
+  }
+}
+
+impl Add<u64> for u64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u64) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u64> for u64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u64) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Mul<u64> for u64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn mul(self, rhs: u64) -> Self::Output {
+    self.mul(Self::splat(rhs))
+  }
+}
+
 impl BitAnd for u64x4 {
   type Output = Self;
   #[inline]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -105,6 +105,42 @@ impl Sub for u8x16 {
   }
 }
 
+impl Add<u8> for u8x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u8) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u8> for u8x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u8) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Add<u8x16> for u8 {
+  type Output = u8x16;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u8x16) -> Self::Output {
+    u8x16::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u8x16> for u8 {
+  type Output = u8x16;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u8x16) -> Self::Output {
+    u8x16::splat(self).sub(rhs)
+  }
+}
+
 impl BitAnd for u8x16 {
   type Output = Self;
   #[inline]

--- a/tests/t_i16x16.rs
+++ b/tests/t_i16x16.rs
@@ -8,61 +8,185 @@ fn size_align() {
 
 #[test]
 fn impl_add_for_i16x16() {
-  let a = i16x16::from([1, 2, i16::MAX - 1, i16::MAX - 1, 15, 20, 5000, 2990, 1, 2, i16::MAX - 1, i16::MAX - 1, 15, 20, 5000, 2990]);
-  let b = i16x16::from([17, 18, 1, 2, 20, 5, 900, 900, 17, 18, 1, 2, 20, 5, 900, 900]);
-  let expected = i16x16::from([18, 20, i16::MAX, i16::MIN, 35, 25, 5900, 3890, 18, 20, i16::MAX, i16::MIN, 35, 25, 5900, 3890]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    15,
+    20,
+    5000,
+    2990,
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    15,
+    20,
+    5000,
+    2990,
+  ]);
+  let b = i16x16::from([
+    17, 18, 1, 2, 20, 5, 900, 900, 17, 18, 1, 2, 20, 5, 900, 900,
+  ]);
+  let expected = i16x16::from([
+    18,
+    20,
+    i16::MAX,
+    i16::MIN,
+    35,
+    25,
+    5900,
+    3890,
+    18,
+    20,
+    i16::MAX,
+    i16::MIN,
+    35,
+    25,
+    5900,
+    3890,
+  ]);
   let actual = a + b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_sub_for_i16x16() {
-  let a = i16x16::from([1, 2, i16::MIN + 1, i16::MIN, 15, 20, 5000, 2990,1, 2, i16::MIN + 1, i16::MIN, 15, 20, 5000, 2990]);
-  let b = i16x16::from([17, -18, 1, 1, 20, 5, 900, 900,17, -18, 1, 1, 20, 5, 900, 900]);
-  let expected = i16x16::from([-16, 20, i16::MIN, i16::MAX, -5, 15, 4100, 2090,-16, 20, i16::MIN, i16::MAX, -5, 15, 4100, 2090]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    15,
+    20,
+    5000,
+    2990,
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    15,
+    20,
+    5000,
+    2990,
+  ]);
+  let b = i16x16::from([
+    17, -18, 1, 1, 20, 5, 900, 900, 17, -18, 1, 1, 20, 5, 900, 900,
+  ]);
+  let expected = i16x16::from([
+    -16,
+    20,
+    i16::MIN,
+    i16::MAX,
+    -5,
+    15,
+    4100,
+    2090,
+    -16,
+    20,
+    i16::MIN,
+    i16::MAX,
+    -5,
+    15,
+    4100,
+    2090,
+  ]);
   let actual = a - b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_mul_for_i16x16() {
-  let a = i16x16::from([1, 2, i16::MIN + 1, i16::MIN, 2, 3, 4, 5,1, 2, i16::MIN + 1, i16::MIN, 2, 3, 4, 5]);
-  let b = i16x16::from([17, -18, 1, 1, -1, -2, -6, 3,17, -18, 1, 1, -1, -2, -6, 3]);
-  let expected = i16x16::from([17, -36, i16::MIN + 1, i16::MIN, -2, -6, -24, 15,17, -36, i16::MIN + 1, i16::MIN, -2, -6, -24, 15]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    2,
+    3,
+    4,
+    5,
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    2,
+    3,
+    4,
+    5,
+  ]);
+  let b =
+    i16x16::from([17, -18, 1, 1, -1, -2, -6, 3, 17, -18, 1, 1, -1, -2, -6, 3]);
+  let expected = i16x16::from([
+    17,
+    -36,
+    i16::MIN + 1,
+    i16::MIN,
+    -2,
+    -6,
+    -24,
+    15,
+    17,
+    -36,
+    i16::MIN + 1,
+    i16::MIN,
+    -2,
+    -6,
+    -24,
+    15,
+  ]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_bitand_for_i16x16() {
-  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1,0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1,0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i16x16::from([0, 0, 0, 1, 0, 0, 0, 1,0, 0, 0, 1, 0, 0, 0, 1]);
+  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1]);
+  let expected = i16x16::from([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_bitor_for_i16x16() {
-  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1,0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1,0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i16x16::from([0, 1, 1, 1, 1, 1, 1, 1,0, 1, 1, 1, 1, 1, 1, 1]);
+  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1]);
+  let expected = i16x16::from([0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_bitxor_for_i16x16() {
-  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1,0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1,0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i16x16::from([0, 1, 1, 0, 1, 1, 1, 0,0, 1, 1, 0, 1, 1, 1, 0]);
+  let a = i16x16::from([0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = i16x16::from([0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1]);
+  let expected = i16x16::from([0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_shl_for_i16x16() {
-  let a = i16x16::from([1, 2, i16::MAX - 1, i16::MAX - 1, 128, 255, 590, 5667,1, 2, i16::MAX - 1, i16::MAX - 1, 128, 255, 590, 5667]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    128,
+    255,
+    590,
+    5667,
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    128,
+    255,
+    590,
+    5667,
+  ]);
   let b = 2;
   let expected = i16x16::from([
     1 << 2,
@@ -88,7 +212,24 @@ fn impl_shl_for_i16x16() {
 
 #[test]
 fn impl_shr_for_i16x16() {
-  let a = i16x16::from([1, 2, i16::MAX - 1, i16::MAX - 1, 128, 255, 590, 5667,1, 2, i16::MAX - 1, i16::MAX - 1, 128, 255, 590, 5667]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    128,
+    255,
+    590,
+    5667,
+    1,
+    2,
+    i16::MAX - 1,
+    i16::MAX - 1,
+    128,
+    255,
+    590,
+    5667,
+  ]);
   let b = 2;
   let expected = i16x16::from([
     1 >> 2,
@@ -114,27 +255,30 @@ fn impl_shr_for_i16x16() {
 
 #[test]
 fn impl_i16x16_cmp_eq() {
-  let a = i16x16::from([1, 2, 3, 4, 2, 1, 8, 2,1, 2, 3, 4, 2, 1, 8, 2]);
+  let a = i16x16::from([1, 2, 3, 4, 2, 1, 8, 2, 1, 2, 3, 4, 2, 1, 8, 2]);
   let b = i16x16::from([2_i16; 16]);
-  let expected = i16x16::from([0, -1, 0, 0, -1, 0, 0, -1,0, -1, 0, 0, -1, 0, 0, -1]);
+  let expected =
+    i16x16::from([0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0, -1, 0, 0, -1]);
   let actual = a.cmp_eq(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_i16x16_cmp_gt() {
-  let a = i16x16::from([1, 2, 9, 4, 1, 2, 8, 10,1, 2, 9, 4, 1, 2, 8, 10]);
+  let a = i16x16::from([1, 2, 9, 4, 1, 2, 8, 10, 1, 2, 9, 4, 1, 2, 8, 10]);
   let b = i16x16::from([5_i16; 16]);
-  let expected = i16x16::from([0, 0, -1, 0, 0, 0, -1, -1,0, 0, -1, 0, 0, 0, -1, -1]);
+  let expected =
+    i16x16::from([0, 0, -1, 0, 0, 0, -1, -1, 0, 0, -1, 0, 0, 0, -1, -1]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_i16x16_cmp_lt() {
-  let a = i16x16::from([1, 2, 9, 4, 1, 2, 8, 10,1, 2, 9, 4, 1, 2, 8, 10]);
+  let a = i16x16::from([1, 2, 9, 4, 1, 2, 8, 10, 1, 2, 9, 4, 1, 2, 8, 10]);
   let b = i16x16::from([5_i16; 16]);
-  let expected = i16x16::from([-1, -1, 0, -1, -1, -1, 0, 0,-1, -1, 0, -1, -1, -1, 0, 0]);
+  let expected =
+    i16x16::from([-1, -1, 0, -1, -1, -1, 0, 0, -1, -1, 0, -1, -1, -1, 0, 0]);
   let actual = a.cmp_lt(b);
   assert_eq!(expected, actual);
 
@@ -146,36 +290,131 @@ fn impl_i16x16_cmp_lt() {
 #[test]
 fn impl_i16x16_blend() {
   let use_t: i16 = -1;
-  let t = i16x16::from([1, 2, 3, 4, 5, 6, 7, 8,1, 2, 3, 4, 5, 6, 7, 8]);
-  let f = i16x16::from([17, 18, 19, 20, 25, 30, 50, 90,17, 18, 19, 20, 25, 30, 50, 90]);
-  let mask = i16x16::from([use_t, 0, use_t, 0, 0, 0, 0, use_t,use_t, 0, use_t, 0, 0, 0, 0, use_t]);
-  let expected = i16x16::from([1, 18, 3, 20, 25, 30, 50, 8,1, 18, 3, 20, 25, 30, 50, 8]);
+  let t = i16x16::from([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]);
+  let f = i16x16::from([
+    17, 18, 19, 20, 25, 30, 50, 90, 17, 18, 19, 20, 25, 30, 50, 90,
+  ]);
+  let mask = i16x16::from([
+    use_t, 0, use_t, 0, 0, 0, 0, use_t, use_t, 0, use_t, 0, 0, 0, 0, use_t,
+  ]);
+  let expected =
+    i16x16::from([1, 18, 3, 20, 25, 30, 50, 8, 1, 18, 3, 20, 25, 30, 50, 8]);
   let actual = mask.blend(t, f);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_i16x16_abs() {
-  let a = i16x16::from([-1, 2, -3, i16::MIN, 6, -15, -19, 9,-1, 2, -3, i16::MIN, 6, -15, -19, 9]);
-  let expected = i16x16::from([1, 2, 3, i16::MIN, 6, 15, 19, 9,1, 2, 3, i16::MIN, 6, 15, 19, 9]);
+  let a = i16x16::from([
+    -1,
+    2,
+    -3,
+    i16::MIN,
+    6,
+    -15,
+    -19,
+    9,
+    -1,
+    2,
+    -3,
+    i16::MIN,
+    6,
+    -15,
+    -19,
+    9,
+  ]);
+  let expected = i16x16::from([
+    1,
+    2,
+    3,
+    i16::MIN,
+    6,
+    15,
+    19,
+    9,
+    1,
+    2,
+    3,
+    i16::MIN,
+    6,
+    15,
+    19,
+    9,
+  ]);
   let actual = a.abs();
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_i16x16_max() {
-  let a = i16x16::from([1, 2, i16::MIN + 1, i16::MIN, 6, -8, 12, 9,1, 2, i16::MIN + 1, i16::MIN, 6, -8, 12, 9]);
-  let b = i16x16::from([17, -18, 1, 1, 19, -5, -1, -9,17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i16x16::from([17, 2, 1, 1, 19, -5, 12, 9,17, 2, 1, 1, 19, -5, 12, 9]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    12,
+    9,
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    12,
+    9,
+  ]);
+  let b = i16x16::from([
+    17, -18, 1, 1, 19, -5, -1, -9, 17, -18, 1, 1, 19, -5, -1, -9,
+  ]);
+  let expected =
+    i16x16::from([17, 2, 1, 1, 19, -5, 12, 9, 17, 2, 1, 1, 19, -5, 12, 9]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_i16x16_min() {
-  let a = i16x16::from([1, 2, i16::MIN + 1, i16::MIN, 6, -8, 12, 9,1, 2, i16::MIN + 1, i16::MIN, 6, -8, 12, 9]);
-  let b = i16x16::from([17, -18, 1, 1, 19, -5, -1, -9,17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i16x16::from([1, -18, i16::MIN + 1, i16::MIN, 6, -8, -1, -9, 1, -18, i16::MIN + 1, i16::MIN, 6, -8, -1, -9]);
+  let a = i16x16::from([
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    12,
+    9,
+    1,
+    2,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    12,
+    9,
+  ]);
+  let b = i16x16::from([
+    17, -18, 1, 1, 19, -5, -1, -9, 17, -18, 1, 1, 19, -5, -1, -9,
+  ]);
+  let expected = i16x16::from([
+    1,
+    -18,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    -1,
+    -9,
+    1,
+    -18,
+    i16::MIN + 1,
+    i16::MIN,
+    6,
+    -8,
+    -1,
+    -9,
+  ]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }

--- a/tests/t_i64x2.rs
+++ b/tests/t_i64x2.rs
@@ -25,6 +25,15 @@ fn impl_sub_for_i64x2() {
 }
 
 #[test]
+fn impl_mul_for_i64x2() {
+  let a = i64x2::from([i64::MIN + 1, 24]);
+  let b = i64x2::from([1, -26]);
+  let expected = i64x2::from([i64::MIN + 1, 24 * -26]);
+  let actual = a * b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_bitand_for_i64x2() {
   let a = i64x2::from([1, 1]);
   let b = i64x2::from([0, 1]);

--- a/tests/t_i64x4.rs
+++ b/tests/t_i64x4.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -21,6 +22,15 @@ fn impl_sub_for_i64x4() {
   let b = i64x4::from([1, 1, 3, 3]);
   let expected = i64x4::from([0, -1, 6, 9]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_i64x4() {
+  let a = i64x4::from([i64::MIN + 1, 24, 5402, i64::MAX]);
+  let b = i64x4::from([1, -26, -5402, 2]);
+  let expected = i64x4::from([i64::MIN + 1, 24 * -26, 5402 * -5402, (Wrapping(i64::MAX) * Wrapping(2)).0]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_i64x4.rs
+++ b/tests/t_i64x4.rs
@@ -29,7 +29,12 @@ fn impl_sub_for_i64x4() {
 fn impl_mul_for_i64x4() {
   let a = i64x4::from([i64::MIN + 1, 24, 5402, i64::MAX]);
   let b = i64x4::from([1, -26, -5402, 2]);
-  let expected = i64x4::from([i64::MIN + 1, 24 * -26, 5402 * -5402, (Wrapping(i64::MAX) * Wrapping(2)).0]);
+  let expected = i64x4::from([
+    i64::MIN + 1,
+    24 * -26,
+    5402 * -5402,
+    (Wrapping(i64::MAX) * Wrapping(2)).0,
+  ]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }

--- a/tests/t_i8x16.rs
+++ b/tests/t_i8x16.rs
@@ -119,8 +119,7 @@ fn impl_i8x16_cmp_lt() {
   let actual = a.cmp_lt(b);
   assert_eq!(expected, actual);
 
-  let expected =
-    i8x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  let expected = i8x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
   let actual = a.cmp_lt(a);
   assert_eq!(expected, actual);
 }

--- a/tests/t_u16x8.rs
+++ b/tests/t_u16x8.rs
@@ -29,8 +29,16 @@ fn impl_sub_for_u16x8() {
 fn impl_mul_for_u16x8() {
   let a = u16x8::from([1, 2, u16::MAX, 4, 5, 6, u16::MIN + 1, u16::MIN]);
   let b = u16x8::from([17, 18, 190, 20, 21, 22, 1, 1]);
-  let expected =
-    u16x8::from([17, 36, (Wrapping(u16::MAX) * Wrapping(190)).0, 80, 105, 132, u16::MIN + 1, u16::MIN]);
+  let expected = u16x8::from([
+    17,
+    36,
+    (Wrapping(u16::MAX) * Wrapping(190)).0,
+    80,
+    105,
+    132,
+    u16::MIN + 1,
+    u16::MIN,
+  ]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }

--- a/tests/t_u16x8.rs
+++ b/tests/t_u16x8.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -21,6 +22,16 @@ fn impl_sub_for_u16x8() {
   let b = u16x8::from([17, 180, 192, 200, 121, 22, 1, 1]);
   let expected = u16x8::from([1451, 40, 65347, 4256, 65420, 6875, 0, u16::MAX]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_u16x8() {
+  let a = u16x8::from([1, 2, u16::MAX, 4, 5, 6, u16::MIN + 1, u16::MIN]);
+  let b = u16x8::from([17, 18, 190, 20, 21, 22, 1, 1]);
+  let expected =
+    u16x8::from([17, 36, (Wrapping(u16::MAX) * Wrapping(190)).0, 80, 105, 132, u16::MIN + 1, u16::MIN]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_u32x4.rs
+++ b/tests/t_u32x4.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -21,6 +22,15 @@ fn impl_sub_for_u32x4() {
   let b = u32x4::from([17, 18, 1, 1]);
   let expected = u32x4::from([8984, 4294967280, 0, u32::MAX]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_u32x4() {
+  let a = u32x4::from([1, 2, u32::MIN + 1, u32::MAX]);
+  let b = u32x4::from([17, 18, 1, 32]);
+  let expected = u32x4::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_u32x4.rs
+++ b/tests/t_u32x4.rs
@@ -29,7 +29,8 @@ fn impl_sub_for_u32x4() {
 fn impl_mul_for_u32x4() {
   let a = u32x4::from([1, 2, u32::MIN + 1, u32::MAX]);
   let b = u32x4::from([17, 18, 1, 32]);
-  let expected = u32x4::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0]);
+  let expected =
+    u32x4::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }

--- a/tests/t_u32x8.rs
+++ b/tests/t_u32x8.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -22,6 +23,15 @@ fn impl_sub_for_u32x8() {
   let expected =
     u32x8::from([8984, 4294967280, 0, u32::MAX, 4294967293, 0, 7, 5]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_u32x8() {
+  let a = u32x8::from([1, 2, u32::MIN + 1, u32::MAX, 123, u32::MIN, 9, 3802]);
+  let b = u32x8::from([17, 18, 1, 32, 456, 4, 190, 100]);
+  let expected = u32x8::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0, 123 * 456, 0, 190 * 9, 380200]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_u32x8.rs
+++ b/tests/t_u32x8.rs
@@ -30,7 +30,16 @@ fn impl_sub_for_u32x8() {
 fn impl_mul_for_u32x8() {
   let a = u32x8::from([1, 2, u32::MIN + 1, u32::MAX, 123, u32::MIN, 9, 3802]);
   let b = u32x8::from([17, 18, 1, 32, 456, 4, 190, 100]);
-  let expected = u32x8::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0, 123 * 456, 0, 190 * 9, 380200]);
+  let expected = u32x8::from([
+    17,
+    36,
+    1,
+    (Wrapping(u32::MAX) * Wrapping(32)).0,
+    123 * 456,
+    0,
+    190 * 9,
+    380200,
+  ]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }

--- a/tests/t_u64x2.rs
+++ b/tests/t_u64x2.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -21,6 +22,15 @@ fn impl_sub_for_u64x2() {
   let b = u64x2::from([1, 1]);
   let expected = u64x2::from([0, u64::MAX]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_u64x2() {
+  let a = u64x2::from([u64::MIN + 1, u64::MAX]);
+  let b = u64x2::from([2, 2]);
+  let expected = u64x2::from([2, (Wrapping(u64::MAX) * Wrapping(2)).0]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_u64x4.rs
+++ b/tests/t_u64x4.rs
@@ -1,3 +1,4 @@
+use std::num::Wrapping;
 use wide::*;
 
 #[test]
@@ -21,6 +22,15 @@ fn impl_sub_for_u64x4() {
   let b = u64x4::from([1, 1, 3, 3]);
   let expected = u64x4::from([0, u64::MAX, 6, 9]);
   let actual = a - b;
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_for_u64x4() {
+  let a = u64x4::from([u64::MIN + 1, u64::MAX, 30, 70]);
+  let b = u64x4::from([2, 2, 10, 20]);
+  let expected = u64x4::from([2, (Wrapping(u64::MAX) * Wrapping(2)).0, 300, 1400]);
+  let actual = a * b;
   assert_eq!(expected, actual);
 }
 

--- a/tests/t_u64x4.rs
+++ b/tests/t_u64x4.rs
@@ -29,7 +29,8 @@ fn impl_sub_for_u64x4() {
 fn impl_mul_for_u64x4() {
   let a = u64x4::from([u64::MIN + 1, u64::MAX, 30, 70]);
   let b = u64x4::from([2, 2, 10, 20]);
-  let expected = u64x4::from([2, (Wrapping(u64::MAX) * Wrapping(2)).0, 300, 1400]);
+  let expected =
+    u64x4::from([2, (Wrapping(u64::MAX) * Wrapping(2)).0, 300, 1400]);
   let actual = a * b;
   assert_eq!(expected, actual);
 }


### PR DESCRIPTION
Here we are, I implemented
* Multiplication for ``i64x2``, ``i64x4``, ``u64x2``, ``u64x4`` ``u32x4`` ``u16x8``
* Splats for all of them so you can simply do ``i64x2 * i64``
* Tests for all the types
----------------------
i think we should implement multiplication in every type that can have it, better done now than later tbh

fixes #102 