### PR TITLE
Fix `i16x16::blend` when `avx2` is not available

### DIFF
--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -513,7 +513,10 @@ impl i16x16 {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self {
+          sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0),
+          sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1)
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self {
           simd0: v128_bitselect(t.simd0, f.simd0, self.simd0),


### PR DESCRIPTION
There's two SSE vectors when AVX2 is not available, so both need to be blended.