### PR TITLE
Add as_array_ref to all types, similar to to_array

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1467,4 +1467,8 @@ impl f32x4 {
   pub fn to_array(self) -> [f32; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[f32; 4] {
+    cast_ref(self)
+  }
 }

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1684,6 +1684,10 @@ impl f32x8 {
   pub fn to_array(self) -> [f32; 8] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[f32; 8] {
+    cast_ref(self)
+  }
 }
 
 impl Not for f32x8 {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1504,6 +1504,10 @@ impl f64x2 {
   pub fn to_array(self) -> [f64; 2] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[f64; 2] {
+    cast_ref(self)
+  }
 }
 
 impl Not for f64x2 {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1639,6 +1639,10 @@ impl f64x4 {
   pub fn to_array(self) -> [f64; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[f64; 4] {
+    cast_ref(self)
+  }
 }
 
 impl Not for f64x4 {

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -660,4 +660,8 @@ impl i16x16 {
   pub fn to_array(self) -> [i16; 16] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i16; 16] {
+    cast_ref(self)
+  }
 }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -460,4 +460,8 @@ impl i16x8 {
   pub fn to_array(self) -> [i16; 8] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i16; 8] {
+    cast_ref(self)
+  }
 }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -478,4 +478,8 @@ impl i32x4 {
   pub fn to_array(self) -> [i32; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i32; 4] {
+    cast_ref(self)
+  }
 }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -575,6 +575,10 @@ impl i32x8 {
   pub fn to_array(self) -> [i32; 8] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i32; 8] {
+    cast_ref(self)
+  }
 }
 
 impl Not for i32x8 {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -358,4 +358,8 @@ impl i64x2 {
   pub fn to_array(self) -> [i64; 2] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i64; 2] {
+    cast_ref(self)
+  }
 }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -407,6 +407,10 @@ impl i64x4 {
   pub fn to_array(self) -> [i64; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i64; 4] {
+    cast_ref(self)
+  }
 }
 
 impl Not for i64x4 {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -477,4 +477,8 @@ impl i8x16 {
   pub fn to_array(self) -> [i8; 16] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i8; 16] {
+    cast_ref(self)
+  }
 }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -592,4 +592,8 @@ impl i8x32 {
   pub fn to_array(self) -> [i8; 32] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[i8; 32] {
+    cast_ref(self)
+  }
 }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -403,4 +403,8 @@ impl u16x8 {
   pub fn to_array(self) -> [u16; 8] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u16; 8] {
+    cast_ref(self)
+  }
 }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -361,4 +361,8 @@ impl u32x4 {
   pub fn to_array(self) -> [u32; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u32; 4] {
+    cast_ref(self)
+  }
 }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -411,6 +411,10 @@ impl u32x8 {
   pub fn to_array(self) -> [u32; 8] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u32; 8] {
+    cast_ref(self)
+  }
 }
 
 impl Not for u32x8 {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -322,4 +322,8 @@ impl u64x2 {
   pub fn to_array(self) -> [u64; 2] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u64; 2] {
+    cast_ref(self)
+  }
 }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -369,6 +369,10 @@ impl u64x4 {
   pub fn to_array(self) -> [u64; 4] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u64; 4] {
+    cast_ref(self)
+  }
 }
 
 impl Not for u64x4 {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -351,4 +351,8 @@ impl u8x16 {
   pub fn to_array(self) -> [u8; 16] {
     cast(self)
   }
+
+  pub fn as_array_ref(&self) -> &[u8; 16] {
+    cast_ref(self)
+  }
 }


### PR DESCRIPTION
As per: https://github.com/Lokathor/wide/issues/111#issuecomment-990446169

I didn't call them `as_slice` because the sizes of all return types are known.