### PR TITLE
Add inline attribute to array casts

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1470,10 +1470,12 @@ impl f32x4 {
     Self::pow_f32x4(self, f32x4::splat(y))
   }
 
+  #[inline]
   pub fn to_array(self) -> [f32; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[f32; 4] {
     cast_ref(self)
   }

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1686,10 +1686,12 @@ impl f32x8 {
     Self::pow_f32x8(self, f32x8::splat(y))
   }
 
+  #[inline]
   pub fn to_array(self) -> [f32; 8] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[f32; 8] {
     cast_ref(self)
   }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1506,10 +1506,12 @@ impl f64x2 {
     Self::pow_f64x2(self, f64x2::splat(y))
   }
 
+  #[inline]
   pub fn to_array(self) -> [f64; 2] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[f64; 2] {
     cast_ref(self)
   }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1641,10 +1641,12 @@ impl f64x4 {
     Self::pow_f64x4(self, f64x4::splat(y))
   }
 
+  #[inline]
   pub fn to_array(self) -> [f64; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[f64; 4] {
     cast_ref(self)
   }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -662,10 +662,12 @@ impl i16x16 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [i16; 16] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i16; 16] {
     cast_ref(self)
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -462,10 +462,12 @@ impl i16x8 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [i16; 8] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i16; 8] {
     cast_ref(self)
   }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -480,10 +480,12 @@ impl i32x4 {
     !self.any()
   }
 
+  #[inline]
   pub fn to_array(self) -> [i32; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i32; 4] {
     cast_ref(self)
   }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -577,10 +577,12 @@ impl i32x8 {
     !self.any()
   }
 
+  #[inline]
   pub fn to_array(self) -> [i32; 8] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i32; 8] {
     cast_ref(self)
   }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -360,10 +360,12 @@ impl i64x2 {
     cast([arr[0] as f64, arr[1] as f64])
   }
 
+  #[inline]
   pub fn to_array(self) -> [i64; 2] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i64; 2] {
     cast_ref(self)
   }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -409,10 +409,12 @@ impl i64x4 {
     cast([arr[0] as f64, arr[1] as f64, arr[2] as f64, arr[3] as f64])
   }
 
+  #[inline]
   pub fn to_array(self) -> [i64; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i64; 4] {
     cast_ref(self)
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -479,10 +479,12 @@ impl i8x16 {
     !self.any()
   }
 
+  #[inline]
   pub fn to_array(self) -> [i8; 16] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i8; 16] {
     cast_ref(self)
   }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -594,10 +594,12 @@ impl i8x32 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [i8; 32] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[i8; 32] {
     cast_ref(self)
   }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -405,10 +405,12 @@ impl u16x8 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u16; 8] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u16; 8] {
     cast_ref(self)
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -363,10 +363,12 @@ impl u32x4 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u32; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u32; 4] {
     cast_ref(self)
   }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -413,10 +413,12 @@ impl u32x8 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u32; 8] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u32; 8] {
     cast_ref(self)
   }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -324,10 +324,12 @@ impl u64x2 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u64; 2] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u64; 2] {
     cast_ref(self)
   }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -371,10 +371,12 @@ impl u64x4 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u64; 4] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u64; 4] {
     cast_ref(self)
   }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -353,10 +353,12 @@ impl u8x16 {
     }
   }
 
+  #[inline]
   pub fn to_array(self) -> [u8; 16] {
     cast(self)
   }
 
+  #[inline]
   pub fn as_array_ref(&self) -> &[u8; 16] {
     cast_ref(self)
   }


### PR DESCRIPTION
I found that the Rust compiler was not inlining the methods `to_array` and `as_array_ref`, which are extremely thin wrappers around cast functions and should in theory always be inlined. The lack of inlining was also preventing certain code optimizations that the compiler would normally perform.