### PR TITLE
add saturating add/sub i16 and multiply and scale

### DIFF
--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -438,7 +438,7 @@ impl f64x2 {
   #[must_use]
   pub fn fast_max(self, rhs: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse")] {
+      if #[cfg(target_feature="sse2")] {
         Self { sse: max_m128d(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self {
@@ -495,7 +495,7 @@ impl f64x2 {
   #[must_use]
   pub fn fast_min(self, rhs: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse")] {
+      if #[cfg(target_feature="sse2")] {
         Self { sse: min_m128d(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -533,14 +533,14 @@ impl i16x8 {
       } else {
         // compiler does a surprisingly good job of vectorizing this
         Self { arr: [
-          self.arr[0] = ((i32::from(self.arr[0]) * i32::from(hrs.arr[0]) + 0x4000) >> 15) as i16,
-          self.arr[1] = ((i32::from(self.arr[1]) * i32::from(hrs.arr[1]) + 0x4000) >> 15) as i16,
-          self.arr[2] = ((i32::from(self.arr[2]) * i32::from(hrs.arr[2]) + 0x4000) >> 15) as i16,
-          self.arr[3] = ((i32::from(self.arr[3]) * i32::from(hrs.arr[3]) + 0x4000) >> 15) as i16,
-          self.arr[4] = ((i32::from(self.arr[4]) * i32::from(hrs.arr[4]) + 0x4000) >> 15) as i16,
-          self.arr[5] = ((i32::from(self.arr[5]) * i32::from(hrs.arr[5]) + 0x4000) >> 15) as i16,
-          self.arr[6] = ((i32::from(self.arr[6]) * i32::from(hrs.arr[6]) + 0x4000) >> 15) as i16,
-          self.arr[7] = ((i32::from(self.arr[7]) * i32::from(hrs.arr[7]) + 0x4000) >> 15) as i16,          ]}
+          ((i32::from(self.arr[0]) * i32::from(rhs.arr[0]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[1]) * i32::from(rhs.arr[1]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[2]) * i32::from(rhs.arr[2]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[3]) * i32::from(rhs.arr[3]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[4]) * i32::from(rhs.arr[4]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[5]) * i32::from(rhs.arr[5]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[6]) * i32::from(rhs.arr[6]) + 0x4000) >> 15) as i16,
+          ((i32::from(self.arr[7]) * i32::from(rhs.arr[7]) + 0x4000) >> 15) as i16,          ]}
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -461,7 +461,89 @@ impl i16x8 {
       }
     }
   }
-
+  #[inline]
+  #[must_use]
+  pub fn saturating_add(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: add_saturating_i16_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i16x8_add_sat(self.simd, rhs.simd) }
+      } else {
+        Self { arr: [
+          self.arr[0].saturating_add(rhs.arr[0]),
+          self.arr[1].saturating_add(rhs.arr[1]),
+          self.arr[2].saturating_add(rhs.arr[2]),
+          self.arr[3].saturating_add(rhs.arr[3]),
+          self.arr[4].saturating_add(rhs.arr[4]),
+          self.arr[5].saturating_add(rhs.arr[5]),
+          self.arr[6].saturating_add(rhs.arr[6]),
+          self.arr[7].saturating_add(rhs.arr[7]),
+        ]}
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn saturating_sub(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: sub_saturating_i16_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i16x8_sub_sat(self.simd, rhs.simd) }
+      } else {
+        Self { arr: [
+          self.arr[0].saturating_sub(rhs.arr[0]),
+          self.arr[1].saturating_sub(rhs.arr[1]),
+          self.arr[2].saturating_sub(rhs.arr[2]),
+          self.arr[3].saturating_sub(rhs.arr[3]),
+          self.arr[4].saturating_sub(rhs.arr[4]),
+          self.arr[5].saturating_sub(rhs.arr[5]),
+          self.arr[6].saturating_sub(rhs.arr[6]),
+          self.arr[7].saturating_sub(rhs.arr[7]),
+        ]}
+      }
+    }
+  }
+  /// Multiply and scale equivilent to ((self * rhs) + 0x4000) >> 15 on each
+  /// lane, effectively multiplying by a 16 bit fixed point number between -1
+  /// and 1. This corresponds to the following instructions:
+  /// - vqrdmulhq_n_s16 instruction on simd128
+  /// - _mm256_mulhrs_epi16 on avx2
+  /// - emulated via mul_i16_* on sse2
+  #[inline]
+  #[must_use]
+  pub fn mul_scale_round(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse:  mul_i16_scale_round_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(target_feature="sse2")] {
+        // unfortunately mul_i16_scale_round_m128i only got added in sse3
+        let hi = mul_i16_keep_high_m128i(self.sse, rhs.sse);
+        let lo = mul_i16_keep_low_m128i(self.sse, rhs.sse);
+        let mut v1 = unpack_low_i16_m128i(lo, hi);
+        let mut v2 = unpack_high_i16_m128i(lo, hi);
+        let a = set_splat_i32_m128i(0x4000);
+        v1 = shr_imm_i32_m128i::<15>(add_i32_m128i(v1, a));
+        v2 = shr_imm_i32_m128i::<15>(add_i32_m128i(v2, a));
+        let s = pack_i32_to_i16_m128i(v1, v2);
+        Self { sse: s }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: vqrdmulhq_n_s16(self.simd, rhs.simd) }
+      } else {
+        // compiler does a surprisingly good job of vectorizing this
+        Self { arr: [
+          self.arr[0] = ((i32::from(self.arr[0]) * i32::from(hrs.arr[0]) + 0x4000) >> 15) as i16,
+          self.arr[1] = ((i32::from(self.arr[1]) * i32::from(hrs.arr[1]) + 0x4000) >> 15) as i16,
+          self.arr[2] = ((i32::from(self.arr[2]) * i32::from(hrs.arr[2]) + 0x4000) >> 15) as i16,
+          self.arr[3] = ((i32::from(self.arr[3]) * i32::from(hrs.arr[3]) + 0x4000) >> 15) as i16,
+          self.arr[4] = ((i32::from(self.arr[4]) * i32::from(hrs.arr[4]) + 0x4000) >> 15) as i16,
+          self.arr[5] = ((i32::from(self.arr[5]) * i32::from(hrs.arr[5]) + 0x4000) >> 15) as i16,
+          self.arr[6] = ((i32::from(self.arr[6]) * i32::from(hrs.arr[6]) + 0x4000) >> 15) as i16,
+          self.arr[7] = ((i32::from(self.arr[7]) * i32::from(hrs.arr[7]) + 0x4000) >> 15) as i16,          ]}
+      }
+    }
+  }
   #[inline]
   pub fn to_array(self) -> [i16; 8] {
     cast(self)

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -5,7 +5,7 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct u32x8 { avx2: m256i }
-  } else if #[cfg(target_feature="sse")] {
+  } else if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct u32x8 { sse0: m128i, sse1: m128i }

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -25,6 +25,34 @@ fn impl_sub_for_i16x8() {
 }
 
 #[test]
+fn impl_add_saturating_for_i16x8() {
+  let a = i16x8::from([i16::MAX, i16::MIN, 3, 4, -1, -2, -3, -4]);
+  let b = i16x8::from([i16::MAX, i16::MIN, 7, 8, -15, -26, -37, 48]);
+  let expected = i16x8::from([i16::MAX, i16::MIN, 10, 12, -16, -28, -40, 44]);
+  let actual = a.saturating_add(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_mul_scale_i16x8() {
+  let a = i16x8::from([100, 200, 300, 400, 500, -600, 700, -800]);
+  let b = i16x8::from([900, 1000, 1100, 1200, 1300, -1400, -1500, 1600]);
+  let actual = a.mul_scale_round(b);
+  let expected = i16x8::from([3, 6, 10, 15, 20, 26, -32, -39]);
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_sub_saturating_for_i16x8() {
+  let a = i16x8::from([1, 2, 3, 4, 5, i16::MIN, i16::MIN + 1, i16::MAX]);
+  let b = i16x8::from([17, -18, 190, -20, 21, -1, 1, -1]);
+  let expected =
+    i16x8::from([-16, 20, -187, 24, -16, i16::MIN + 1, i16::MIN, i16::MAX]);
+  let actual = a.saturating_sub(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_mul_for_i16x8() {
   let a = i16x8::from([1, 2, 3, 4, 5, 6, i16::MIN + 1, i16::MIN]);
   let b = i16x8::from([17, -18, 190, -20, 21, -22, 1, 1]);


### PR DESCRIPTION
- Added saturating add and subtract for i16x8
- Added multiply and scale for i16x8 (equivalent of multiplying by a 16 bit fixed point between -1 and 1)
- Fixed two instances that mixed up sse and sse2 targets that caused syntax errors with target_features=-sse2