### PR TITLE
For non-AVX2 targets delegate to 128bit subparts

### DIFF
--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -602,7 +602,8 @@ impl f32x8 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * m + a
+        // still want to use 256 bit ops
+        (self * m) + a
       } else {
         Self {
           a : self.a.mul_add(m.a, a.a),
@@ -619,7 +620,8 @@ impl f32x8 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * m - a
+        // still want to use 256 bit ops
+        (self * m) - a
       } else {
         Self {
           a : self.a.mul_sub(m.a, a.a),
@@ -636,7 +638,8 @@ impl f32x8 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * -m + a
+        // still want to use 256 bit ops
+        a - (self * m)
       } else {
         Self {
           a : self.a.mul_neg_add(m.a, a.a),
@@ -653,7 +656,8 @@ impl f32x8 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_sub_m256(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * -m - a
+        // still want to use 256 bit ops
+        -(self * m) - a
       } else {
         Self {
           a : self.a.mul_neg_sub(m.a, a.a),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -376,7 +376,17 @@ impl f32x8 {
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-    Self { a: self.a.abs(), b: self.b.abs() }
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        let non_sign_bits = f32x8::from(f32::from_bits(i32::MAX as u32));
+        self & non_sign_bits
+      } else {
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
+      }
+    }
   }
 
   /// Calculates the lanewise maximum of both vectors. This is a faster
@@ -591,6 +601,8 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * m + a
       } else {
         Self {
           a : self.a.mul_add(m.a, a.a),
@@ -606,6 +618,8 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * m - a
       } else {
         Self {
           a : self.a.mul_sub(m.a, a.a),
@@ -621,6 +635,8 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * -m + a
       } else {
         Self {
           a : self.a.mul_neg_add(m.a, a.a),
@@ -636,6 +652,8 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_sub_m256(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * -m - a
       } else {
         Self {
           a : self.a.mul_neg_sub(m.a, a.a),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -5,33 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
     pub struct f32x8 { avx: m256 }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq)]
-    #[repr(C, align(32))]
-    pub struct f32x8 { sse0: m128, sse1: m128 }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct f32x8 { simd0: v128, simd1: v128 }
-
-    impl Default for f32x8 {
-      fn default() -> Self {
-        Self::splat(0.0)
-      }
-    }
-
-    impl PartialEq for f32x8 {
-      fn eq(&self, other: &Self) -> bool {
-        u32x4_all_true(f32x4_eq(self.simd0, other.simd0)) &
-          u32x4_all_true(f32x4_eq(self.simd1, other.simd1))
-      }
-    }
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f32x8 { arr: [f32;8] }
+    pub struct f32x8 { a : f32x4, b : f32x4 }
   }
 }
 
@@ -78,21 +55,11 @@ impl Add for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: add_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_m128(self.sse0, rhs.sse0), sse1: add_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_add(self.simd0, rhs.simd0), simd1: f32x4_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] + rhs.arr[0],
-          self.arr[1] + rhs.arr[1],
-          self.arr[2] + rhs.arr[2],
-          self.arr[3] + rhs.arr[3],
-          self.arr[4] + rhs.arr[4],
-          self.arr[5] + rhs.arr[5],
-          self.arr[6] + rhs.arr[6],
-          self.arr[7] + rhs.arr[7],
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -106,21 +73,11 @@ impl Sub for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: sub_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_m128(self.sse0, rhs.sse0), sse1: sub_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_sub(self.simd0, rhs.simd0), simd1: f32x4_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] - rhs.arr[0],
-          self.arr[1] - rhs.arr[1],
-          self.arr[2] - rhs.arr[2],
-          self.arr[3] - rhs.arr[3],
-          self.arr[4] - rhs.arr[4],
-          self.arr[5] - rhs.arr[5],
-          self.arr[6] - rhs.arr[6],
-          self.arr[7] - rhs.arr[7],
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -134,21 +91,11 @@ impl Mul for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: mul_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: mul_m128(self.sse0, rhs.sse0), sse1: mul_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_mul(self.simd0, rhs.simd0), simd1: f32x4_mul(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] * rhs.arr[0],
-          self.arr[1] * rhs.arr[1],
-          self.arr[2] * rhs.arr[2],
-          self.arr[3] * rhs.arr[3],
-          self.arr[4] * rhs.arr[4],
-          self.arr[5] * rhs.arr[5],
-          self.arr[6] * rhs.arr[6],
-          self.arr[7] * rhs.arr[7],
-        ]}
+        Self {
+          a : self.a.mul(rhs.a),
+          b : self.b.mul(rhs.b),
+        }
       }
     }
   }
@@ -162,21 +109,11 @@ impl Div for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: div_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: div_m128(self.sse0, rhs.sse0), sse1: div_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_div(self.simd0, rhs.simd0), simd1: f32x4_div(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] / rhs.arr[0],
-          self.arr[1] / rhs.arr[1],
-          self.arr[2] / rhs.arr[2],
-          self.arr[3] / rhs.arr[3],
-          self.arr[4] / rhs.arr[4],
-          self.arr[5] / rhs.arr[5],
-          self.arr[6] / rhs.arr[6],
-          self.arr[7] / rhs.arr[7],
-        ]}
+        Self {
+          a : self.a.div(rhs.a),
+          b : self.b.div(rhs.b),
+        }
       }
     }
   }
@@ -262,21 +199,11 @@ impl BitAnd for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitand_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128(self.sse0, rhs.sse0), sse1: bitand_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f32::from_bits(self.arr[0].to_bits() & rhs.arr[0].to_bits()),
-          f32::from_bits(self.arr[1].to_bits() & rhs.arr[1].to_bits()),
-          f32::from_bits(self.arr[2].to_bits() & rhs.arr[2].to_bits()),
-          f32::from_bits(self.arr[3].to_bits() & rhs.arr[3].to_bits()),
-          f32::from_bits(self.arr[4].to_bits() & rhs.arr[4].to_bits()),
-          f32::from_bits(self.arr[5].to_bits() & rhs.arr[5].to_bits()),
-          f32::from_bits(self.arr[6].to_bits() & rhs.arr[6].to_bits()),
-          f32::from_bits(self.arr[7].to_bits() & rhs.arr[7].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -290,21 +217,11 @@ impl BitOr for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitor_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128(self.sse0, rhs.sse0), sse1: bitor_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f32::from_bits(self.arr[0].to_bits() | rhs.arr[0].to_bits()),
-          f32::from_bits(self.arr[1].to_bits() | rhs.arr[1].to_bits()),
-          f32::from_bits(self.arr[2].to_bits() | rhs.arr[2].to_bits()),
-          f32::from_bits(self.arr[3].to_bits() | rhs.arr[3].to_bits()),
-          f32::from_bits(self.arr[4].to_bits() | rhs.arr[4].to_bits()),
-          f32::from_bits(self.arr[5].to_bits() | rhs.arr[5].to_bits()),
-          f32::from_bits(self.arr[6].to_bits() | rhs.arr[6].to_bits()),
-          f32::from_bits(self.arr[7].to_bits() | rhs.arr[7].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -318,21 +235,11 @@ impl BitXor for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitxor_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128(self.sse0, rhs.sse0), sse1: bitxor_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f32::from_bits(self.arr[0].to_bits() ^ rhs.arr[0].to_bits()),
-          f32::from_bits(self.arr[1].to_bits() ^ rhs.arr[1].to_bits()),
-          f32::from_bits(self.arr[2].to_bits() ^ rhs.arr[2].to_bits()),
-          f32::from_bits(self.arr[3].to_bits() ^ rhs.arr[3].to_bits()),
-          f32::from_bits(self.arr[4].to_bits() ^ rhs.arr[4].to_bits()),
-          f32::from_bits(self.arr[5].to_bits() ^ rhs.arr[5].to_bits()),
-          f32::from_bits(self.arr[6].to_bits() ^ rhs.arr[6].to_bits()),
-          f32::from_bits(self.arr[7].to_bits() ^ rhs.arr[7].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -346,21 +253,11 @@ impl CmpEq for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(EqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_m128(self.sse0, rhs.sse0), sse1: cmp_eq_mask_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_eq(self.simd0, rhs.simd0), simd1: f32x4_eq(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1] == rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2] == rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3] == rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4] == rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5] == rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6] == rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7] == rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -374,21 +271,11 @@ impl CmpGe for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(GreaterEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_ge_mask_m128(self.sse0, rhs.sse0), sse1: cmp_ge_mask_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_ge(self.simd0, rhs.simd0), simd1: f32x4_ge(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] >= rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1] >= rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2] >= rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3] >= rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4] >= rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5] >= rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6] >= rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7] >= rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_ge(rhs.a),
+          b : self.b.cmp_ge(rhs.b),
+        }
       }
     }
   }
@@ -402,21 +289,11 @@ impl CmpGt for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(GreaterThanOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_m128(self.sse0, rhs.sse0), sse1: cmp_gt_mask_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_gt(self.simd0, rhs.simd0), simd1: f32x4_gt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1] > rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2] > rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3] > rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4] > rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5] > rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6] > rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7] > rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -430,21 +307,11 @@ impl CmpNe for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(NotEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_neq_mask_m128(self.sse0, rhs.sse0), sse1: cmp_neq_mask_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_ne(self.simd0, rhs.simd0), simd1: f32x4_ne(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] != rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1] != rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2] != rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3] != rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4] != rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5] != rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6] != rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7] != rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_ne(rhs.a),
+          b : self.b.cmp_ne(rhs.b),
+        }
       }
     }
   }
@@ -458,21 +325,11 @@ impl CmpLe for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(LessEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_le_mask_m128(self.sse0, rhs.sse0), sse1: cmp_le_mask_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_le(self.simd0, rhs.simd0), simd1: f32x4_le(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] <= rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1] <= rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2] <= rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3] <= rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4] <= rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5] <= rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6] <= rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7] <= rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_le(rhs.a),
+          b : self.b.cmp_le(rhs.b),
+        }
       }
     }
   }
@@ -484,24 +341,14 @@ impl CmpLt for f32x8 {
   #[must_use]
   fn cmp_lt(self, rhs: Self) -> Self::Output {
     pick! {
-        if #[cfg(target_feature="avx")] {
-          Self { avx: cmp_op_mask_m256::<{cmp_op!(LessThanOrdered)}>(self.avx, rhs.avx) }
-        } else if #[cfg(target_feature="sse2")] {
-          Self { sse0: cmp_lt_mask_m128(self.sse0, rhs.sse0), sse1: cmp_lt_mask_m128(self.sse1, rhs.sse1) }
-        } else if #[cfg(target_feature="simd128")] {
-          Self { simd0: f32x4_lt(self.simd0, rhs.simd0), simd1: f32x4_lt(self.simd1, rhs.simd1) }
-        } else {
-          Self { arr: [
-            if self.arr[0] < rhs.arr[0] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[1] < rhs.arr[1] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[2] < rhs.arr[2] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[3] < rhs.arr[3] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[4] < rhs.arr[4] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[5] < rhs.arr[5] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[6] < rhs.arr[6] { f32::from_bits(u32::MAX) } else { 0.0 },
-            if self.arr[7] < rhs.arr[7] { f32::from_bits(u32::MAX) } else { 0.0 },
-          ]}
+      if #[cfg(target_feature="avx")] {
+        Self { avx: cmp_op_mask_m256::<{cmp_op!(LessThanOrdered)}>(self.avx, rhs.avx) }
+      } else {
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
         }
+      }
     }
   }
 }
@@ -518,26 +365,18 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: blend_varying_m256(f.avx, t.avx, self.avx) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_m128(f.sse0, t.sse0, self.sse0), sse1: blend_varying_m128(f.sse1, t.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_abs(self.simd0), simd1: f32x4_abs(self.simd1) }
-      } else {
-        let non_sign_bits = f32x8::from(f32::from_bits(i32::MAX as u32));
-        self & non_sign_bits
-      }
-    }
+    Self { a: self.a.abs(), b: self.b.abs() }
   }
 
   /// Calculates the lanewise maximum of both vectors. This is a faster
@@ -549,21 +388,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: max_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: max_m128(self.sse0, rhs.sse0), sse1: max_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_pmax(self.simd0, rhs.simd0), simd1: f32x4_pmax(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { rhs.arr[0] } else { self.arr[0] },
-          if self.arr[1] < rhs.arr[1] { rhs.arr[1] } else { self.arr[1] },
-          if self.arr[2] < rhs.arr[2] { rhs.arr[2] } else { self.arr[2] },
-          if self.arr[3] < rhs.arr[3] { rhs.arr[3] } else { self.arr[3] },
-          if self.arr[4] < rhs.arr[4] { rhs.arr[4] } else { self.arr[4] },
-          if self.arr[5] < rhs.arr[5] { rhs.arr[5] } else { self.arr[5] },
-          if self.arr[6] < rhs.arr[6] { rhs.arr[6] } else { self.arr[6] },
-          if self.arr[7] < rhs.arr[7] { rhs.arr[7] } else { self.arr[7] },
-        ]}
+        Self {
+          a : self.a.fast_max(rhs.a),
+          b : self.b.fast_max(rhs.b),
+        }
       }
     }
   }
@@ -579,42 +408,13 @@ impl f32x8 {
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().blend(self, Self { avx: max_m256(self.avx, rhs.avx) })
-      } else if #[cfg(target_feature="sse2")] {
-        // max_m128 seems to do rhs < self ? self : rhs. So if there's any NaN
-        // involved, it chooses rhs, so we need to specifically check rhs for
-        // NaN.
-        rhs.is_nan().blend(self, Self { sse0: max_m128(self.sse0, rhs.sse0), sse1: max_m128(self.sse1, rhs.sse1) })
-      } else if #[cfg(target_feature="simd128")] {
-        // WASM has two max intrinsics:
-        // - max: This propagates NaN, that's the opposite of what we need.
-        // - pmax: This is defined as self < rhs ? rhs : self, which basically
-        //   chooses self if either is NaN.
-        //
-        // pmax is what we want, but we need to specifically check self for NaN.
-        Self {
-          simd0: v128_bitselect(
-            rhs.simd0,
-            f32x4_pmax(self.simd0, rhs.simd0),
-            f32x4_ne(self.simd0, self.simd0), // NaN check
-          ),
-          simd1: v128_bitselect(
-            rhs.simd1,
-            f32x4_pmax(self.simd1, rhs.simd1),
-            f32x4_ne(self.simd1, self.simd1), // NaN check
-          ),
-        }
       } else {
-        Self { arr: [
-          self.arr[0].max(rhs.arr[0]),
-          self.arr[1].max(rhs.arr[1]),
-          self.arr[2].max(rhs.arr[2]),
-          self.arr[3].max(rhs.arr[3]),
-          self.arr[4].max(rhs.arr[4]),
-          self.arr[5].max(rhs.arr[5]),
-          self.arr[6].max(rhs.arr[6]),
-          self.arr[7].max(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
+
     }
   }
 
@@ -627,21 +427,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: min_m256(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: min_m128(self.sse0, rhs.sse0), sse1: min_m128(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_pmin(self.simd0, rhs.simd0), simd1: f32x4_pmin(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { rhs.arr[0] } else { self.arr[0] },
-          if self.arr[1] > rhs.arr[1] { rhs.arr[1] } else { self.arr[1] },
-          if self.arr[2] > rhs.arr[2] { rhs.arr[2] } else { self.arr[2] },
-          if self.arr[3] > rhs.arr[3] { rhs.arr[3] } else { self.arr[3] },
-          if self.arr[4] > rhs.arr[4] { rhs.arr[4] } else { self.arr[4] },
-          if self.arr[5] > rhs.arr[5] { rhs.arr[5] } else { self.arr[5] },
-          if self.arr[6] > rhs.arr[6] { rhs.arr[6] } else { self.arr[6] },
-          if self.arr[7] > rhs.arr[7] { rhs.arr[7] } else { self.arr[7] },
-        ]}
+        Self {
+          a : self.a.fast_min(rhs.a),
+          b : self.b.fast_min(rhs.b),
+        }
       }
     }
   }
@@ -658,41 +448,11 @@ impl f32x8 {
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().blend(self, Self { avx: min_m256(self.avx, rhs.avx) })
-      } else if #[cfg(target_feature="sse2")] {
-        // min_m128 seems to do rhs > self ? self : rhs. So if there's any NaN
-        // involved, it chooses rhs, so we need to specifically check rhs for
-        // NaN.
-        rhs.is_nan().blend(self, Self { sse0: min_m128(self.sse0, rhs.sse0), sse1: min_m128(self.sse1, rhs.sse1) })
-      } else if #[cfg(target_feature="simd128")] {
-        // WASM has two min intrinsics:
-        // - min: This propagates NaN, that's the opposite of what we need.
-        // - pmin: This is defined as rhs < self ? rhs : self, which basically
-        //   chooses self if either is NaN.
-        //
-        // pmin is what we want, but we need to specifically check self for NaN.
-        Self {
-          simd0: v128_bitselect(
-            rhs.simd0,
-            f32x4_pmin(self.simd0, rhs.simd0),
-            f32x4_ne(self.simd0, self.simd0), // NaN check
-          ),
-          simd1: v128_bitselect(
-            rhs.simd1,
-            f32x4_pmin(self.simd1, rhs.simd1),
-            f32x4_ne(self.simd1, self.simd1), // NaN check
-          ),
-        }
       } else {
-        Self { arr: [
-          self.arr[0].min(rhs.arr[0]),
-          self.arr[1].min(rhs.arr[1]),
-          self.arr[2].min(rhs.arr[2]),
-          self.arr[3].min(rhs.arr[3]),
-          self.arr[4].min(rhs.arr[4]),
-          self.arr[5].min(rhs.arr[5]),
-          self.arr[6].min(rhs.arr[6]),
-          self.arr[7].min(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -702,21 +462,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(Unordered)}>(self.avx, self.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_unord_mask_m128(self.sse0, self.sse0) , sse1: cmp_unord_mask_m128(self.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_ne(self.simd0, self.simd0), simd1: f32x4_ne(self.simd1, self.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[1].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[2].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[3].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[4].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[5].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[6].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-          if self.arr[7].is_nan() { f32::from_bits(u32::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.is_nan(),
+          b : self.b.is_nan(),
+        }
       }
     }
   }
@@ -746,37 +496,11 @@ impl f32x8 {
       // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out
       if #[cfg(target_feature="avx")] {
         Self { avx: round_m256::<{round_op!(Nearest)}>(self.avx) }
-      }  else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: round_m128::<{round_op!(Nearest)}>(self.sse0), sse1: round_m128::<{round_op!(Nearest)}>(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_nearest(self.simd0), simd1: f32x4_nearest(self.simd1) }
       } else {
-        // Note(Lokathor): This software fallback is probably very slow compared
-        // to having a hardware option available, even just the sse2 version is
-        // better than this. Oh well.
-        let to_int = f32x8::from(1.0 / f32::EPSILON);
-        let u: u32x8 = cast(self);
-        let e: i32x8 = cast((u >> 23) & u32x8::from(0xff));
-        let mut y: f32x8;
-
-        let no_op_magic = i32x8::from(0x7f + 23);
-        let no_op_mask: f32x8 = cast(e.cmp_gt(no_op_magic) | e.cmp_eq(no_op_magic));
-        let no_op_val: f32x8 = self;
-
-        let zero_magic = i32x8::from(0x7f - 1);
-        let zero_mask: f32x8 = cast(e.cmp_lt(zero_magic));
-        let zero_val: f32x8 = self * f32x8::from(0.0);
-
-        let neg_bit: f32x8 = cast(cast::<u32x8, i32x8>(u).cmp_lt(i32x8::default()));
-        let x: f32x8 = neg_bit.blend(-self, self);
-        y = x + to_int - to_int - x;
-        y = y.cmp_gt(f32x8::from(0.5)).blend(
-          y + x - f32x8::from(-1.0),
-          y.cmp_lt(f32x8::from(-0.5)).blend(y + x + f32x8::from(1.0), y + x),
-        );
-        y = neg_bit.blend(-y, y);
-
-        no_op_mask.blend(no_op_val, zero_mask.blend(zero_val, y))
+        Self {
+          a : self.a.round(),
+          b : self.b.round(),
+        }
       }
     }
   }
@@ -790,10 +514,10 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         cast(convert_to_i32_m256i_from_m256(self.avx))
-      } else if #[cfg(target_feature="sse2")] {
-        i32x8 { sse0: convert_to_i32_m128i_from_m128(self.sse0), sse1: convert_to_i32_m128i_from_m128(self.sse1) }
       } else {
-        self.round_int()
+        cast([
+          self.a.fast_round_int(),
+          self.b.fast_round_int()])
       }
     }
   }
@@ -812,29 +536,10 @@ impl f32x8 {
         let flip_to_max: i32x8 = cast(self.cmp_ge(Self::splat(2147483648.0)));
         let cast: i32x8 = cast(convert_to_i32_m256i_from_m256(non_nan.avx));
         flip_to_max ^ cast
-      } else if #[cfg(target_feature="sse2")] {
-        // Based on: https://github.com/v8/v8/blob/210987a552a2bf2a854b0baa9588a5959ff3979d/src/codegen/shared-ia32-x64/macro-assembler-shared-ia32-x64.h#L489-L504
-        let non_nan_mask = self.cmp_eq(self);
-        let non_nan = self & non_nan_mask;
-        let flip_to_max: i32x8 = cast(self.cmp_ge(Self::splat(2147483648.0)));
-        let cast: i32x8 = i32x8 { sse0: convert_to_i32_m128i_from_m128(non_nan.sse0), sse1: convert_to_i32_m128i_from_m128(non_nan.sse1) };
-        flip_to_max ^ cast
-      } else if #[cfg(target_feature="simd128")] {
-        cast(Self {
-          simd0: i32x4_trunc_sat_f32x4(f32x4_nearest(self.simd0)),
-          simd1: i32x4_trunc_sat_f32x4(f32x4_nearest(self.simd1)),
-        })
       } else {
-        let rounded: [f32; 8] = cast(self.round());
         cast([
-          rounded[0] as i32,
-          rounded[1] as i32,
-          rounded[2] as i32,
-          rounded[3] as i32,
-          rounded[4] as i32,
-          rounded[5] as i32,
-          rounded[6] as i32,
-          rounded[7] as i32,
+          self.a.round_int(),
+          self.b.round_int(),
         ])
       }
     }
@@ -849,10 +554,11 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx"))] {
         cast(convert_truncate_to_i32_m256i_from_m256(self.avx))
-      } else if #[cfg(target_feature="sse2")] {
-        i32x8 { sse0: truncate_m128_to_m128i(self.sse0), sse1: truncate_m128_to_m128i(self.sse1) }
       } else {
-        self.trunc_int()
+        cast([
+          self.a.fast_trunc_int(),
+          self.b.fast_trunc_int(),
+        ])
       }
     }
   }
@@ -871,29 +577,10 @@ impl f32x8 {
         let flip_to_max: i32x8 = cast(self.cmp_ge(Self::splat(2147483648.0)));
         let cast: i32x8 = cast(convert_truncate_to_i32_m256i_from_m256(non_nan.avx));
         flip_to_max ^ cast
-      } else if #[cfg(target_feature="sse2")] {
-        // Based on: https://github.com/v8/v8/blob/210987a552a2bf2a854b0baa9588a5959ff3979d/src/codegen/shared-ia32-x64/macro-assembler-shared-ia32-x64.h#L489-L504
-        let non_nan_mask = self.cmp_eq(self);
-        let non_nan = self & non_nan_mask;
-        let flip_to_max: i32x8 = cast(self.cmp_ge(Self::splat(2147483648.0)));
-        let cast: i32x8 = i32x8 { sse0: truncate_m128_to_m128i(non_nan.sse0), sse1: truncate_m128_to_m128i(non_nan.sse1) };
-        flip_to_max ^ cast
-      } else if #[cfg(target_feature="simd128")] {
-        cast(Self {
-          simd0: i32x4_trunc_sat_f32x4(self.simd0),
-          simd1: i32x4_trunc_sat_f32x4(self.simd1),
-        })
       } else {
-        let n: [f32; 8] = cast(self);
         cast([
-          n[0] as i32,
-          n[1] as i32,
-          n[2] as i32,
-          n[3] as i32,
-          n[4] as i32,
-          n[5] as i32,
-          n[6] as i32,
-          n[7] as i32,
+          self.a.trunc_int(),
+          self.b.trunc_int(),
         ])
       }
     }
@@ -904,10 +591,11 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))] {
-        Self { sse0: fused_mul_add_m128(self.sse0, m.sse0, a.sse0), sse1: fused_mul_add_m128(self.sse1, m.sse1, a.sse1) }
       } else {
-        (self * m) + a
+        Self {
+          a : self.a.mul_add(m.a, a.a),
+          b : self.b.mul_add(m.b, a.b),
+        }
       }
     }
   }
@@ -918,10 +606,11 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))] {
-        Self { sse0: fused_mul_sub_m128(self.sse0, m.sse0, a.sse0), sse1: fused_mul_sub_m128(self.sse1, m.sse1, a.sse1) }
       } else {
-        (self * m) - a
+        Self {
+          a : self.a.mul_sub(m.a, a.a),
+          b : self.b.mul_sub(m.b, a.b),
+        }
       }
     }
   }
@@ -932,10 +621,11 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))] {
-        Self { sse0: fused_mul_neg_add_m128(self.sse0, m.sse0, a.sse0), sse1: fused_mul_neg_add_m128(self.sse1, m.sse1, a.sse1) }
       } else {
-        a - (self * m)
+        Self {
+          a : self.a.mul_neg_add(m.a, a.a),
+          b : self.b.mul_neg_add(m.b, a.b),
+        }
       }
     }
   }
@@ -946,10 +636,11 @@ impl f32x8 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_sub_m256(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))] {
-        Self { sse0: fused_mul_neg_sub_m128(self.sse0, m.sse0, a.sse0), sse1: fused_mul_neg_sub_m128(self.sse1, m.sse1, a.sse1) }
       } else {
-        -(self * m) - a
+        Self {
+          a : self.a.mul_neg_sub(m.a, a.a),
+          b : self.b.mul_neg_sub(m.b, a.b),
+        }
       }
     }
   }
@@ -1264,22 +955,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: reciprocal_m256(self.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: reciprocal_m128(self.sse0), sse1: reciprocal_m128(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        let one = f32x4_splat(1.0);
-        Self { simd0: f32x4_div(one, self.simd0), simd1: f32x4_div(one, self.simd1) }
       } else {
-        Self { arr: [
-          1.0 / self.arr[0],
-          1.0 / self.arr[1],
-          1.0 / self.arr[2],
-          1.0 / self.arr[3],
-          1.0 / self.arr[4],
-          1.0 / self.arr[5],
-          1.0 / self.arr[6],
-          1.0 / self.arr[7],
-        ]}
+        Self {
+          a : self.a.recip(),
+          b : self.b.recip(),
+        }
       }
     }
   }
@@ -1289,33 +969,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: reciprocal_sqrt_m256(self.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: reciprocal_sqrt_m128(self.sse0), sse1: reciprocal_sqrt_m128(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        let one = f32x4_splat(1.0);
-        Self { simd0: f32x4_div(one, f32x4_sqrt(self.simd0)), simd1: f32x4_div(one, f32x4_sqrt(self.simd1)) }
-      } else if #[cfg(feature="std")] {
-        Self { arr: [
-          1.0 / self.arr[0].sqrt(),
-          1.0 / self.arr[1].sqrt(),
-          1.0 / self.arr[2].sqrt(),
-          1.0 / self.arr[3].sqrt(),
-          1.0 / self.arr[4].sqrt(),
-          1.0 / self.arr[5].sqrt(),
-          1.0 / self.arr[6].sqrt(),
-          1.0 / self.arr[7].sqrt(),
-        ]}
       } else {
-        Self { arr: [
-          1.0 / software_sqrt(self.arr[0] as f64) as f32,
-          1.0 / software_sqrt(self.arr[1] as f64) as f32,
-          1.0 / software_sqrt(self.arr[2] as f64) as f32,
-          1.0 / software_sqrt(self.arr[3] as f64) as f32,
-          1.0 / software_sqrt(self.arr[4] as f64) as f32,
-          1.0 / software_sqrt(self.arr[5] as f64) as f32,
-          1.0 / software_sqrt(self.arr[6] as f64) as f32,
-          1.0 / software_sqrt(self.arr[7] as f64) as f32,
-        ]}
+        Self {
+          a : self.a.recip_sqrt(),
+          b : self.b.recip_sqrt(),
+        }
       }
     }
   }
@@ -1325,32 +983,11 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: sqrt_m256(self.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sqrt_m128(self.sse0), sse1: sqrt_m128(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f32x4_sqrt(self.simd0), simd1: f32x4_sqrt(self.simd1) }
-      } else if #[cfg(feature="std")] {
-        Self { arr: [
-          self.arr[0].sqrt(),
-          self.arr[1].sqrt(),
-          self.arr[2].sqrt(),
-          self.arr[3].sqrt(),
-          self.arr[4].sqrt(),
-          self.arr[5].sqrt(),
-          self.arr[6].sqrt(),
-          self.arr[7].sqrt(),
-        ]}
       } else {
-        Self { arr: [
-          software_sqrt(self.arr[0] as f64) as f32,
-          software_sqrt(self.arr[1] as f64) as f32,
-          software_sqrt(self.arr[2] as f64) as f32,
-          software_sqrt(self.arr[3] as f64) as f32,
-          software_sqrt(self.arr[4] as f64) as f32,
-          software_sqrt(self.arr[5] as f64) as f32,
-          software_sqrt(self.arr[6] as f64) as f32,
-          software_sqrt(self.arr[7] as f64) as f32,
-        ]}
+        Self {
+          a : self.a.sqrt(),
+          b : self.b.sqrt(),
+        }
       }
     }
   }
@@ -1360,19 +997,8 @@ impl f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         move_mask_m256(self.avx)
-      } else if #[cfg(target_feature="sse2")] {
-        (move_mask_m128(self.sse1) << 4) ^ move_mask_m128(self.sse0)
-      } else if #[cfg(target_feature="simd128")] {
-        ((u32x4_bitmask(self.simd1) as i32) << 4) ^ u32x4_bitmask(self.simd0) as i32
       } else {
-        (((self.arr[0].to_bits() as i32) < 0) as i32) << 0 |
-        (((self.arr[1].to_bits() as i32) < 0) as i32) << 1 |
-        (((self.arr[2].to_bits() as i32) < 0) as i32) << 2 |
-        (((self.arr[3].to_bits() as i32) < 0) as i32) << 3 |
-        (((self.arr[4].to_bits() as i32) < 0) as i32) << 4 |
-        (((self.arr[5].to_bits() as i32) < 0) as i32) << 5 |
-        (((self.arr[6].to_bits() as i32) < 0) as i32) << 6 |
-        (((self.arr[7].to_bits() as i32) < 0) as i32) << 7
+        (self.b.move_mask() << 4) | self.a.move_mask()
       }
     }
   }
@@ -1380,10 +1006,10 @@ impl f32x8 {
   #[must_use]
   pub fn any(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        v128_any_true(self.simd0) | v128_any_true(self.simd1)
+      if #[cfg(target_feature="avx")] {
+        move_mask_m256(self.avx) != 0
       } else {
-        self.move_mask() != 0
+        self.a.any() || self.b.any()
       }
     }
   }
@@ -1391,11 +1017,10 @@ impl f32x8 {
   #[must_use]
   pub fn all(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        u32x4_all_true(self.simd0) & u32x4_all_true(self.simd1)
+      if #[cfg(target_feature="avx")] {
+        move_mask_m256(self.avx) == 0b11111111
       } else {
-        // eight lanes
-        self.move_mask() == 0b11111111
+        self.a.all() && self.b.all()
       }
     }
   }
@@ -1504,17 +1129,8 @@ impl f32x8 {
         let hi = shuffle_abi_f32_all_m128::<0b_01>(sum_dual, sum_dual);
         let sum = add_m128_s(lo, hi);
         get_f32_from_m128_s(sum)
-      }
-      else if #[cfg(target_feature="sse3")] {
-        let a = add_horizontal_m128(self.sse0, self.sse0);
-        let b = add_horizontal_m128(a, a);
-        let c = add_horizontal_m128(self.sse1, self.sse1);
-        let d = add_horizontal_m128(c, c);
-        let sum = add_m128_s(b, d);
-        get_f32_from_m128_s(sum)
       } else {
-        let arr: [f32; 8] = cast(self);
-        arr.iter().sum()
+        self.a.reduce_add() + self.b.reduce_add()
       }
     }
   }
@@ -1707,21 +1323,11 @@ impl Not for f32x8 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: self.avx.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not() , sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
-        Self { arr: [
-          f32::from_bits(!self.arr[0].to_bits()),
-          f32::from_bits(!self.arr[1].to_bits()),
-          f32::from_bits(!self.arr[2].to_bits()),
-          f32::from_bits(!self.arr[3].to_bits()),
-          f32::from_bits(!self.arr[4].to_bits()),
-          f32::from_bits(!self.arr[5].to_bits()),
-          f32::from_bits(!self.arr[6].to_bits()),
-          f32::from_bits(!self.arr[7].to_bits()),
-        ]}
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -538,7 +538,8 @@ impl f64x4 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256d(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * m + a
+        // still want to use 256 bit ops
+        (self * m) + a
       } else {
         Self {
           a : self.a.mul_add(m.a, a.a),
@@ -555,7 +556,8 @@ impl f64x4 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256d(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * m - a
+        // still want to use 256 bit ops
+        (self * m) - a
       } else {
         Self {
           a : self.a.mul_sub(m.a, a.a),
@@ -572,7 +574,8 @@ impl f64x4 {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256d(self.avx, m.avx, a.avx) }
       } else if #[cfg(target_feature="avx")] {
-        self * -m + a
+        // still want to use 256 bit ops
+        a - (self * m)
       } else {
         Self {
           a : self.a.mul_neg_add(m.a, a.a),
@@ -589,8 +592,9 @@ impl f64x4 {
        if #[cfg(all(target_feature="avx",target_feature="fma"))] {
          Self { avx: fused_mul_neg_sub_m256d(self.avx, m.avx, a.avx) }
         } else if #[cfg(target_feature="avx")] {
-          self * -m - a
-         } else {
+          // still want to use 256 bit ops
+          -(self * m) - a
+        } else {
          Self {
            a : self.a.mul_neg_sub(m.a, a.a),
            b : self.b.mul_neg_sub(m.b, a.b),

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -537,6 +537,8 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256d(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * m + a
       } else {
         Self {
           a : self.a.mul_add(m.a, a.a),
@@ -552,6 +554,8 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256d(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * m - a
       } else {
         Self {
           a : self.a.mul_sub(m.a, a.a),
@@ -567,6 +571,8 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256d(self.avx, m.avx, a.avx) }
+      } else if #[cfg(target_feature="avx")] {
+        self * -m + a
       } else {
         Self {
           a : self.a.mul_neg_add(m.a, a.a),
@@ -582,7 +588,9 @@ impl f64x4 {
     pick! {
        if #[cfg(all(target_feature="avx",target_feature="fma"))] {
          Self { avx: fused_mul_neg_sub_m256d(self.avx, m.avx, a.avx) }
-       } else {
+        } else if #[cfg(target_feature="avx")] {
+          self * -m - a
+         } else {
          Self {
            a : self.a.mul_neg_sub(m.a, a.a),
            b : self.b.mul_neg_sub(m.b, a.b),

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -5,33 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
     pub struct f64x4 { avx: m256d }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq)]
-    #[repr(C, align(32))]
-    pub struct f64x4 { sse0: m128d, sse1: m128d }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct f64x4 { simd0: v128, simd1: v128 }
-
-    impl Default for f64x4 {
-      fn default() -> Self {
-        Self::splat(0.0)
-      }
-    }
-
-    impl PartialEq for f64x4 {
-      fn eq(&self, other: &Self) -> bool {
-        u64x2_all_true(f64x2_eq(self.simd0, other.simd0)) &
-          u64x2_all_true(f64x2_eq(self.simd1, other.simd1))
-      }
-    }
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f64x4 { arr: [f64;4] }
+    pub struct f64x4 { a : f64x2, b : f64x2 }
   }
 }
 
@@ -76,21 +53,15 @@ impl Add for f64x4 {
   #[must_use]
   fn add(self, rhs: Self) -> Self::Output {
     pick! {
-    if #[cfg(target_feature="avx")] {
-      Self { avx: add_m256d(self.avx, rhs.avx) }
-    } else if #[cfg(target_feature="sse2")] {
-      Self { sse0: add_m128d(self.sse0, rhs.sse0), sse1: add_m128d(self.sse1, rhs.sse1) }
-    } else if #[cfg(target_feature="simd128")] {
-      Self { simd0: f64x2_add(self.simd0, rhs.simd0), simd1: f64x2_add(self.simd1, rhs.simd1) }
-    } else {
-          Self { arr: [
-            self.arr[0] + rhs.arr[0],
-            self.arr[1] + rhs.arr[1],
-            self.arr[2] + rhs.arr[2],
-            self.arr[3] + rhs.arr[3],
-          ]}
+      if #[cfg(target_feature="avx")] {
+        Self { avx: add_m256d(self.avx, rhs.avx) }
+      } else {
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
         }
       }
+    }
   }
 }
 
@@ -102,17 +73,11 @@ impl Sub for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: sub_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_m128d(self.sse0, rhs.sse0), sse1: sub_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_sub(self.simd0, rhs.simd0), simd1: f64x2_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] - rhs.arr[0],
-          self.arr[1] - rhs.arr[1],
-          self.arr[2] - rhs.arr[2],
-          self.arr[3] - rhs.arr[3],
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -126,17 +91,11 @@ impl Mul for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: mul_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: mul_m128d(self.sse0, rhs.sse0), sse1: mul_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_mul(self.simd0, rhs.simd0), simd1: f64x2_mul(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] * rhs.arr[0],
-          self.arr[1] * rhs.arr[1],
-          self.arr[2] * rhs.arr[2],
-          self.arr[3] * rhs.arr[3],
-        ]}
+        Self {
+          a : self.a.mul(rhs.a),
+          b : self.b.mul(rhs.b),
+        }
       }
     }
   }
@@ -150,17 +109,11 @@ impl Div for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: div_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: div_m128d(self.sse0, rhs.sse0), sse1: div_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_div(self.simd0, rhs.simd0), simd1: f64x2_div(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0] / rhs.arr[0],
-          self.arr[1] / rhs.arr[1],
-          self.arr[2] / rhs.arr[2],
-          self.arr[3] / rhs.arr[3],
-        ]}
+        Self {
+          a : self.a.div(rhs.a),
+          b : self.b.div(rhs.b),
+        }
       }
     }
   }
@@ -246,17 +199,11 @@ impl BitAnd for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitand_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128d(self.sse0, rhs.sse0), sse1: bitand_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f64::from_bits(self.arr[0].to_bits() & rhs.arr[0].to_bits()),
-          f64::from_bits(self.arr[1].to_bits() & rhs.arr[1].to_bits()),
-          f64::from_bits(self.arr[2].to_bits() & rhs.arr[2].to_bits()),
-          f64::from_bits(self.arr[3].to_bits() & rhs.arr[3].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -270,17 +217,11 @@ impl BitOr for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitor_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128d(self.sse0, rhs.sse0), sse1: bitor_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f64::from_bits(self.arr[0].to_bits() | rhs.arr[0].to_bits()),
-          f64::from_bits(self.arr[1].to_bits() | rhs.arr[1].to_bits()),
-          f64::from_bits(self.arr[2].to_bits() | rhs.arr[2].to_bits()),
-          f64::from_bits(self.arr[3].to_bits() | rhs.arr[3].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -294,17 +235,11 @@ impl BitXor for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: bitxor_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128d(self.sse0, rhs.sse0), sse1: bitxor_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          f64::from_bits(self.arr[0].to_bits() ^ rhs.arr[0].to_bits()),
-          f64::from_bits(self.arr[1].to_bits() ^ rhs.arr[1].to_bits()),
-          f64::from_bits(self.arr[2].to_bits() ^ rhs.arr[2].to_bits()),
-          f64::from_bits(self.arr[3].to_bits() ^ rhs.arr[3].to_bits()),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -318,17 +253,11 @@ impl CmpEq for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(EqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_eq_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_eq(self.simd0, rhs.simd0), simd1: f64x2_eq(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] == rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] == rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] == rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -342,17 +271,11 @@ impl CmpGe for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(GreaterEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_ge_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_ge_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_ge(self.simd0, rhs.simd0), simd1: f64x2_ge(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] >= rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] >= rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] >= rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] >= rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_ge(rhs.a),
+          b : self.b.cmp_ge(rhs.b),
+        }
       }
     }
   }
@@ -366,17 +289,11 @@ impl CmpGt for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!( GreaterThanOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_gt_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_gt(self.simd0, rhs.simd0), simd1: f64x2_gt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] > rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] > rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] > rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -390,17 +307,11 @@ impl CmpNe for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(NotEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_neq_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_neq_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_ne(self.simd0, rhs.simd0), simd1: f64x2_ne(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] != rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] != rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] != rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] != rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_ne(rhs.a),
+          b : self.b.cmp_ne(rhs.b),
+        }
       }
     }
   }
@@ -414,17 +325,11 @@ impl CmpLe for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(LessEqualOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_le_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_le_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_le(self.simd0, rhs.simd0), simd1: f64x2_le(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] <= rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] <= rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] <= rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] <= rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_le(rhs.a),
+          b : self.b.cmp_le(rhs.b),
+        }
       }
     }
   }
@@ -438,17 +343,11 @@ impl CmpLt for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")]{
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(LessThanOrdered)}>(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_lt_mask_m128d(self.sse0, rhs.sse0), sse1: cmp_lt_mask_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_lt(self.simd0, rhs.simd0), simd1: f64x2_lt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1] < rhs.arr[1] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2] < rhs.arr[2] { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3] < rhs.arr[3] { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -466,12 +365,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: blend_varying_m256d(f.avx, t.avx, self.avx) }
-      } else if  #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_m128d(f.sse0, t.sse0, self.sse0), sse1: blend_varying_m128d(f.sse1, t.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -480,11 +378,14 @@ impl f64x4 {
   #[must_use]
   pub fn abs(self) -> Self {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_abs(self.simd0), simd1: f64x2_abs(self.simd1) }
-      } else {
+      if #[cfg(target_feature="avx")] {
         let non_sign_bits = f64x4::from(f64::from_bits(i64::MAX as u64));
         self & non_sign_bits
+      } else {
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
       }
     }
   }
@@ -498,17 +399,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: max_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: max_m128d(self.sse0, rhs.sse0), sse1: max_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_pmax(self.simd0, rhs.simd0), simd1: f64x2_pmax(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { rhs.arr[0] } else { self.arr[0] },
-          if self.arr[1] < rhs.arr[1] { rhs.arr[1] } else { self.arr[1] },
-          if self.arr[2] < rhs.arr[2] { rhs.arr[2] } else { self.arr[2] },
-          if self.arr[3] < rhs.arr[3] { rhs.arr[3] } else { self.arr[3] },
-        ]}
+        Self {
+          a : self.a.fast_max(rhs.a),
+          b : self.b.fast_max(rhs.b),
+        }
       }
     }
   }
@@ -525,37 +420,11 @@ impl f64x4 {
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().blend(self, Self { avx: max_m256d(self.avx, rhs.avx) })
-      } else if #[cfg(target_feature="sse2")] {
-        // max_m128d seems to do rhs < self ? self : rhs. So if there's any NaN
-        // involved, it chooses rhs, so we need to specifically check rhs for
-        // NaN.
-        rhs.is_nan().blend(self, Self { sse0: max_m128d(self.sse0, rhs.sse0), sse1: max_m128d(self.sse1, rhs.sse1) })
-      } else if #[cfg(target_feature="simd128")] {
-        // WASM has two max intrinsics:
-        // - max: This propagates NaN, that's the opposite of what we need.
-        // - pmax: This is defined as self < rhs ? rhs : self, which basically
-        //   chooses self if either is NaN.
-        //
-        // pmax is what we want, but we need to specifically check self for NaN.
-        Self {
-          simd0: v128_bitselect(
-            rhs.simd0,
-            f64x2_pmax(self.simd0, rhs.simd0),
-            f64x2_ne(self.simd0, self.simd0), // NaN check
-          ),
-          simd1: v128_bitselect(
-            rhs.simd1,
-            f64x2_pmax(self.simd1, rhs.simd1),
-            f64x2_ne(self.simd1, self.simd1), // NaN check
-          ),
-        }
       } else {
-        Self { arr: [
-          self.arr[0].max(rhs.arr[0]),
-          self.arr[1].max(rhs.arr[1]),
-          self.arr[2].max(rhs.arr[2]),
-          self.arr[3].max(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
     }
   }
@@ -569,17 +438,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: min_m256d(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: min_m128d(self.sse0, rhs.sse0), sse1: min_m128d(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_pmin(self.simd0, rhs.simd0), simd1: f64x2_pmin(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { self.arr[0] } else { rhs.arr[0] },
-          if self.arr[1] < rhs.arr[1] { self.arr[1] } else { rhs.arr[1] },
-          if self.arr[2] < rhs.arr[2] { self.arr[2] } else { rhs.arr[2] },
-          if self.arr[3] < rhs.arr[3] { self.arr[3] } else { rhs.arr[3] },
-        ]}
+        Self {
+          a : self.a.fast_min(rhs.a),
+          b : self.b.fast_min(rhs.b),
+        }
       }
     }
   }
@@ -596,37 +459,11 @@ impl f64x4 {
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().blend(self, Self { avx: min_m256d(self.avx, rhs.avx) })
-      } else if #[cfg(target_feature="sse2")] {
-        // min_m128d seems to do rhs < self ? self : rhs. So if there's any NaN
-        // involved, it chooses rhs, so we need to specifically check rhs for
-        // NaN.
-        rhs.is_nan().blend(self, Self { sse0: min_m128d(self.sse0, rhs.sse0), sse1: min_m128d(self.sse1, rhs.sse1) })
-      } else if #[cfg(target_feature="simd128")] {
-        // WASM has two min intrinsics:
-        // - min: This propagates NaN, that's the opposite of what we need.
-        // - pmin: This is defined as rhs < self ? rhs : self, which basically
-        //   chooses self if either is NaN.
-        //
-        // pmin is what we want, but we need to specifically check self for NaN.
-        Self {
-          simd0: v128_bitselect(
-            rhs.simd0,
-            f64x2_pmin(self.simd0, rhs.simd0),
-            f64x2_ne(self.simd0, self.simd0), // NaN check
-          ),
-          simd1: v128_bitselect(
-            rhs.simd1,
-            f64x2_pmin(self.simd1, rhs.simd1),
-            f64x2_ne(self.simd1, self.simd1), // NaN check
-          ),
-        }
       } else {
-        Self { arr: [
-          self.arr[0].min(rhs.arr[0]),
-          self.arr[1].min(rhs.arr[1]),
-          self.arr[2].min(rhs.arr[2]),
-          self.arr[3].min(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -637,17 +474,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(Unordered)}>(self.avx, self.avx ) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_unord_mask_m128d(self.sse0, self.sse0) , sse1: cmp_unord_mask_m128d(self.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_ne(self.simd0, self.simd0) , simd1: f64x2_ne(self.simd1, self.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0].is_nan() { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[1].is_nan() { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[2].is_nan() { f64::from_bits(u64::MAX) } else { 0.0 },
-          if self.arr[3].is_nan() { f64::from_bits(u64::MAX) } else { 0.0 },
-        ]}
+        Self {
+          a : self.a.is_nan(),
+          b : self.b.is_nan(),
+        }
       }
     }
   }
@@ -678,16 +509,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: round_m256d::<{round_op!(Nearest)}>(self.avx) }
-      }  else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: round_m128d::<{round_op!(Nearest)}>(self.sse0), sse1: round_m128d::<{round_op!(Nearest)}>(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_nearest(self.simd0), simd1: f64x2_nearest(self.simd1) }
       } else {
-          let sign_mask = f64x4::from(-0.0);
-          let magic = f64x4::from(f64::from_bits(0x43300000_00000000));
-          let sign = self & sign_mask;
-          let signed_magic = magic | sign;
-          self + signed_magic - signed_magic
+        Self {
+          a : self.a.round(),
+          b : self.b.round(),
+        }
       }
     }
   }
@@ -711,11 +537,11 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_add_m256d(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))]
-      {
-        Self { sse0: fused_mul_add_m128d(self.sse0, m.sse0, a.sse0), sse1: fused_mul_add_m128d(self.sse1, m.sse1, a.sse1) }
       } else {
-        (self * m) + a
+        Self {
+          a : self.a.mul_add(m.a, a.a),
+          b : self.b.mul_add(m.b, a.b),
+        }
       }
     }
   }
@@ -726,11 +552,11 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_sub_m256d(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))]
-      {
-        Self { sse0: fused_mul_sub_m128d(self.sse0, m.sse0, a.sse0), sse1: fused_mul_sub_m128d(self.sse1, m.sse1, a.sse1) }
       } else {
-        (self * m) - a
+        Self {
+          a : self.a.mul_sub(m.a, a.a),
+          b : self.b.mul_sub(m.b, a.b),
+        }
       }
     }
   }
@@ -741,11 +567,11 @@ impl f64x4 {
     pick! {
       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
         Self { avx: fused_mul_neg_add_m256d(self.avx, m.avx, a.avx) }
-      } else if #[cfg(all(target_feature="avx",target_feature="fma"))]
-      {
-        Self { sse0: fused_mul_neg_add_m128d(self.sse0, m.sse0, a.sse0), sse1: fused_mul_neg_add_m128d(self.sse1, m.sse1, a.sse1) }
-      }  else {
-        a - (self * m)
+      } else {
+        Self {
+          a : self.a.mul_neg_add(m.a, a.a),
+          b : self.b.mul_neg_add(m.b, a.b),
+        }
       }
     }
   }
@@ -754,14 +580,14 @@ impl f64x4 {
   #[must_use]
   pub fn mul_neg_sub(self, m: Self, a: Self) -> Self {
     pick! {
-        if #[cfg(all(target_feature="avx",target_feature="fma"))] {
-          Self { avx: fused_mul_neg_sub_m256d(self.avx, m.avx, a.avx) }
-        } else if #[cfg(all(target_feature="avx",target_feature="fma"))]
-        {
-          Self { sse0: fused_mul_neg_sub_m128d(self.sse0, m.sse0, a.sse0), sse1: fused_mul_neg_sub_m128d(self.sse1, m.sse1, a.sse1) }
-        }  else {
-           -(self * m) - a
-        }
+       if #[cfg(all(target_feature="avx",target_feature="fma"))] {
+         Self { avx: fused_mul_neg_sub_m256d(self.avx, m.avx, a.avx) }
+       } else {
+         Self {
+           a : self.a.mul_neg_sub(m.a, a.a),
+           b : self.b.mul_neg_sub(m.b, a.b),
+         }
+       }
     }
   }
 
@@ -1279,24 +1105,11 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: sqrt_m256d(self.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sqrt_m128d(self.sse0), sse1: sqrt_m128d(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: f64x2_sqrt(self.simd0), simd1: f64x2_sqrt(self.simd1) }
-      } else if #[cfg(feature="std")] {
-        Self { arr: [
-          self.arr[0].sqrt(),
-          self.arr[1].sqrt(),
-          self.arr[2].sqrt(),
-          self.arr[3].sqrt(),
-        ]}
       } else {
-        Self { arr: [
-          software_sqrt(self.arr[0] as f64) as f64,
-          software_sqrt(self.arr[1] as f64) as f64,
-          software_sqrt(self.arr[2] as f64) as f64,
-          software_sqrt(self.arr[3] as f64) as f64,
-        ]}
+        Self {
+          a : self.a.sqrt(),
+          b : self.b.sqrt(),
+        }
       }
     }
   }
@@ -1306,15 +1119,8 @@ impl f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         move_mask_m256d(self.avx)
-      } else if #[cfg(target_feature="sse2")] {
-        (move_mask_m128d(self.sse1) << 2) ^ move_mask_m128d(self.sse0)
-      } else if #[cfg(target_feature="simd128")] {
-        ((u64x2_bitmask(self.simd1) as i32) << 2) ^ u64x2_bitmask(self.simd0) as i32
       } else {
-        (((self.arr[0].to_bits() as i64) < 0) as i32) << 0 |
-        (((self.arr[1].to_bits() as i64) < 0) as i32) << 1 |
-        (((self.arr[2].to_bits() as i64) < 0) as i32) << 2 |
-        (((self.arr[3].to_bits() as i64) < 0) as i32) << 3
+        (self.b.move_mask() << 2) | self.a.move_mask()
       }
     }
   }
@@ -1322,10 +1128,10 @@ impl f64x4 {
   #[must_use]
   pub fn any(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        v128_any_true(self.simd0) | v128_any_true(self.simd1)
+      if #[cfg(target_feature="avx")] {
+        move_mask_m256d(self.avx) != 0
       } else {
-        self.move_mask() != 0
+        self.a.any() || self.b.any()
       }
     }
   }
@@ -1333,11 +1139,10 @@ impl f64x4 {
   #[must_use]
   pub fn all(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        u64x2_all_true(self.simd0) & u64x2_all_true(self.simd1)
+      if #[cfg(target_feature="avx")] {
+        move_mask_m256d(self.avx) == 0b1111
       } else {
-        // four lanes
-        self.move_mask() == 0b1111
+        self.a.all() && self.b.all()
       }
     }
   }
@@ -1447,13 +1252,8 @@ impl f64x4 {
         let hi64 = unpack_high_m128d(lo,lo);
         let sum = add_m128d_s(lo,hi64);
         get_f64_from_m128d_s(sum)
-      } else if #[cfg(target_feature="ssse3")] {
-        let a = add_horizontal_m128d(self.sse0, self.sse0);
-        let b = add_horizontal_m128d(self.sse1, self.sse1);
-        get_f64_from_m128d_s(a) + get_f64_from_m128d_s(b)
       } else {
-        let arr: [f64; 4] = cast(self);
-        arr.iter().sum()
+        self.a.reduce_add() + self.b.reduce_add()
       }
     }
   }
@@ -1663,17 +1463,11 @@ impl Not for f64x4 {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: self.avx.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not() , sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
-        Self { arr: [
-          f64::from_bits(!self.arr[0].to_bits()),
-          f64::from_bits(!self.arr[1].to_bits()),
-          f64::from_bits(!self.arr[2].to_bits()),
-          f64::from_bits(!self.arr[3].to_bits()),
-        ]}
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct i16x16 { avx2: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct i16x16 { pub(crate) sse0: m128i, pub(crate) sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct i16x16 { simd0: v128, simd1: v128 }
-
-    impl Default for i16x16 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for i16x16 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for i16x16 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i16x16 { arr: [i16;16] }
+    pub struct i16x16 { a : i16x8, b : i16x8 }
   }
 }
 
@@ -49,35 +25,11 @@ impl Add for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self {
-          sse0: add_i16_m128i(self.sse0, rhs.sse0),
-          sse1: add_i16_m128i(self.sse1, rhs.sse1)
-        }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_add(self.simd0, rhs.simd0),
-          simd1: i16x8_add(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-          self.arr[4].wrapping_add(rhs.arr[4]),
-          self.arr[5].wrapping_add(rhs.arr[5]),
-          self.arr[6].wrapping_add(rhs.arr[6]),
-          self.arr[7].wrapping_add(rhs.arr[7]),
-          self.arr[8].wrapping_add(rhs.arr[8]),
-          self.arr[9].wrapping_add(rhs.arr[9]),
-          self.arr[10].wrapping_add(rhs.arr[10]),
-          self.arr[11].wrapping_add(rhs.arr[11]),
-          self.arr[12].wrapping_add(rhs.arr[12]),
-          self.arr[13].wrapping_add(rhs.arr[13]),
-          self.arr[14].wrapping_add(rhs.arr[14]),
-          self.arr[15].wrapping_add(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -91,33 +43,11 @@ impl Sub for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i16_m128i(self.sse0, rhs.sse0),
-          sse1: sub_i16_m128i(self.sse1, rhs.sse1)  }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_sub(self.simd0, rhs.simd0),
-          simd1: i16x8_sub(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-          self.arr[4].wrapping_sub(rhs.arr[4]),
-          self.arr[5].wrapping_sub(rhs.arr[5]),
-          self.arr[6].wrapping_sub(rhs.arr[6]),
-          self.arr[7].wrapping_sub(rhs.arr[7]),
-          self.arr[8].wrapping_sub(rhs.arr[8]),
-          self.arr[9].wrapping_sub(rhs.arr[9]),
-          self.arr[10].wrapping_sub(rhs.arr[10]),
-          self.arr[11].wrapping_sub(rhs.arr[11]),
-          self.arr[12].wrapping_sub(rhs.arr[12]),
-          self.arr[13].wrapping_sub(rhs.arr[13]),
-          self.arr[14].wrapping_sub(rhs.arr[14]),
-          self.arr[15].wrapping_sub(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -131,33 +61,11 @@ impl Mul for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: mul_i16_keep_low_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: mul_i16_keep_low_m128i(self.sse0, rhs.sse0),
-          sse1: mul_i16_keep_low_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_mul(self.simd0, rhs.simd0),
-          simd1: i16x8_mul(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_mul(rhs.arr[0]),
-          self.arr[1].wrapping_mul(rhs.arr[1]),
-          self.arr[2].wrapping_mul(rhs.arr[2]),
-          self.arr[3].wrapping_mul(rhs.arr[3]),
-          self.arr[4].wrapping_mul(rhs.arr[4]),
-          self.arr[5].wrapping_mul(rhs.arr[5]),
-          self.arr[6].wrapping_mul(rhs.arr[6]),
-          self.arr[7].wrapping_mul(rhs.arr[7]),
-          self.arr[8].wrapping_mul(rhs.arr[8]),
-          self.arr[9].wrapping_mul(rhs.arr[9]),
-          self.arr[10].wrapping_mul(rhs.arr[10]),
-          self.arr[11].wrapping_mul(rhs.arr[11]),
-          self.arr[12].wrapping_mul(rhs.arr[12]),
-          self.arr[13].wrapping_mul(rhs.arr[13]),
-          self.arr[14].wrapping_mul(rhs.arr[14]),
-          self.arr[15].wrapping_mul(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.mul(rhs.a),
+          b : self.b.mul(rhs.b),
+        }
       }
     }
   }
@@ -225,33 +133,11 @@ impl BitAnd for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0),
-          sse1: bitand_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: v128_and(self.simd0, rhs.simd0),
-          simd1: v128_and(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-          self.arr[4].bitand(rhs.arr[4]),
-          self.arr[5].bitand(rhs.arr[5]),
-          self.arr[6].bitand(rhs.arr[6]),
-          self.arr[7].bitand(rhs.arr[7]),
-          self.arr[8].bitand(rhs.arr[8]),
-          self.arr[9].bitand(rhs.arr[9]),
-          self.arr[10].bitand(rhs.arr[10]),
-          self.arr[11].bitand(rhs.arr[11]),
-          self.arr[12].bitand(rhs.arr[12]),
-          self.arr[13].bitand(rhs.arr[13]),
-          self.arr[14].bitand(rhs.arr[14]),
-          self.arr[15].bitand(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -265,33 +151,11 @@ impl BitOr for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128i(self.sse0, rhs.sse0),
-          sse1: bitor_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: v128_or(self.simd0, rhs.simd0),
-          simd1: v128_or(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].bitor(rhs.arr[0]),
-          self.arr[1].bitor(rhs.arr[1]),
-          self.arr[2].bitor(rhs.arr[2]),
-          self.arr[3].bitor(rhs.arr[3]),
-          self.arr[4].bitor(rhs.arr[4]),
-          self.arr[5].bitor(rhs.arr[5]),
-          self.arr[6].bitor(rhs.arr[6]),
-          self.arr[7].bitor(rhs.arr[7]),
-          self.arr[8].bitor(rhs.arr[8]),
-          self.arr[9].bitor(rhs.arr[9]),
-          self.arr[10].bitor(rhs.arr[10]),
-          self.arr[11].bitor(rhs.arr[11]),
-          self.arr[12].bitor(rhs.arr[12]),
-          self.arr[13].bitor(rhs.arr[13]),
-          self.arr[14].bitor(rhs.arr[14]),
-          self.arr[15].bitor(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -305,33 +169,11 @@ impl BitXor for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0),
-          sse1: bitxor_m128i(self.sse1, rhs.sse1)  }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: v128_xor(self.simd0, rhs.simd0),
-          simd1: v128_xor(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-          self.arr[4].bitxor(rhs.arr[4]),
-          self.arr[5].bitxor(rhs.arr[5]),
-          self.arr[6].bitxor(rhs.arr[6]),
-          self.arr[7].bitxor(rhs.arr[7]),
-          self.arr[8].bitxor(rhs.arr[8]),
-          self.arr[9].bitxor(rhs.arr[9]),
-          self.arr[10].bitxor(rhs.arr[10]),
-          self.arr[11].bitxor(rhs.arr[11]),
-          self.arr[12].bitxor(rhs.arr[12]),
-          self.arr[13].bitxor(rhs.arr[13]),
-          self.arr[14].bitxor(rhs.arr[14]),
-          self.arr[15].bitxor(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -349,41 +191,14 @@ macro_rules! impl_shl_t_for_i16x16 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u16_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self {
-              sse0: shl_all_u16_m128i(self.sse0, shift),
-              sse1: shl_all_u16_m128i(self.sse1, shift)
-            }
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self {
-              simd0: i16x8_shl(self.simd0, u),
-              simd1: i16x8_shl(self.simd1, u)
-            }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-              self.arr[4] << u,
-              self.arr[5] << u,
-              self.arr[6] << u,
-              self.arr[7] << u,
-              self.arr[8] << u,
-              self.arr[9] << u,
-              self.arr[10] << u,
-              self.arr[11] << u,
-              self.arr[12] << u,
-              self.arr[13] << u,
-              self.arr[14] << u,
-              self.arr[15] << u,
-            ]}
+            Self {
+              a : self.a.shl(rhs),
+              b : self.b.shl(rhs),
+            }
           }
-        }
-      }
+       }
+     }
     })+
   };
 }
@@ -401,36 +216,11 @@ macro_rules! impl_shr_t_for_i16x16 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shr_all_i16_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shr_all_i16_m128i(self.sse0, shift),
-              sse1: shr_all_i16_m128i(self.sse1, shift) }
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self {
-              simd0: i16x8_shr(self.simd0, u),
-              simd1: i16x8_shr(self.simd1, u)
-            }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-              self.arr[4] >> u,
-              self.arr[5] >> u,
-              self.arr[6] >> u,
-              self.arr[7] >> u,
-              self.arr[8] >> u,
-              self.arr[9] >> u,
-              self.arr[10] >> u,
-              self.arr[11] >> u,
-              self.arr[12] >> u,
-              self.arr[13] >> u,
-              self.arr[14] >> u,
-              self.arr[15] >> u,
-            ]}
+            Self {
+              a : self.a.shr(rhs),
+              b : self.b.shr(rhs),
+            }
           }
         }
       }
@@ -447,33 +237,11 @@ impl CmpEq for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_eq_mask_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_i16_m128i(self.sse0, rhs.sse0),
-          sse1: cmp_eq_mask_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_eq(self.simd0, rhs.simd0),
-          simd1: i16x8_eq(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] == rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] == rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] == rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] == rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] == rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] == rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] == rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] == rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] == rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] == rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] == rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] == rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] == rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] == rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] == rhs.arr[15] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -487,33 +255,11 @@ impl CmpGt for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_gt_mask_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_i16_m128i(self.sse0, rhs.sse0),
-          sse1: cmp_gt_mask_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_gt(self.simd0, rhs.simd0),
-          simd1: i16x8_gt(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] > rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] > rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] > rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] > rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] > rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] > rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] > rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] > rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] > rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] > rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] > rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] > rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] > rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] > rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] > rhs.arr[15] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -527,33 +273,11 @@ impl CmpLt for i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: !cmp_gt_mask_i16_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i16_m256i(self.avx2,rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_lt_mask_i16_m128i(self.sse0, rhs.sse0),
-          sse1: cmp_lt_mask_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_lt(self.simd0, rhs.simd0),
-          simd1: i16x8_lt(self.simd1, rhs.simd1)
-        }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] < rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] < rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] < rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] < rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] < rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] < rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] < rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] < rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] < rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] < rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] < rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] < rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] < rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] < rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] < rhs.arr[15] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -571,18 +295,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self {
-          sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0),
-          sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1)
-        }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: v128_bitselect(t.simd0, f.simd0, self.simd0),
-          simd1: v128_bitselect(t.simd1, f.simd1, self.simd1)
-        }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -592,34 +309,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: abs_i16_m256i(self.avx2) }
-      } else if #[cfg(target_feature="ssse3")] {
-        Self { sse0: abs_i16_m128i(self.sse0),
-          sse1: abs_i16_m128i(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_abs(self.simd0),
-          simd1: i16x8_abs(self.simd1)
-        }
       } else {
-        let arr: [i16; 16] = cast(self);
-        cast([
-          arr[0].wrapping_abs(),
-          arr[1].wrapping_abs(),
-          arr[2].wrapping_abs(),
-          arr[3].wrapping_abs(),
-          arr[4].wrapping_abs(),
-          arr[5].wrapping_abs(),
-          arr[6].wrapping_abs(),
-          arr[7].wrapping_abs(),
-          arr[8].wrapping_abs(),
-          arr[9].wrapping_abs(),
-          arr[10].wrapping_abs(),
-          arr[11].wrapping_abs(),
-          arr[12].wrapping_abs(),
-          arr[13].wrapping_abs(),
-          arr[14].wrapping_abs(),
-          arr[15].wrapping_abs(),
-        ])
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
       }
     }
   }
@@ -629,16 +323,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: max_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: max_i16_m128i(self.sse0, rhs.sse0),
-          sse1: max_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_max(self.simd0, rhs.simd0),
-          simd1: i16x8_max(self.simd1, rhs.simd1)
-        }
       } else {
-        self.cmp_lt(rhs).blend(rhs, self)
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
     }
   }
@@ -648,16 +337,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: min_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: min_i16_m128i(self.sse0, rhs.sse0),
-          sse1: min_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self {
-          simd0: i16x8_min(self.simd0, rhs.simd0),
-          simd1: i16x8_min(self.simd1, rhs.simd1)
-        }
       } else {
-        self.cmp_lt(rhs).blend(self, rhs)
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -668,29 +352,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_saturating_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_saturating_i16_m128i(self.sse0, rhs.sse0), sse1: add_saturating_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i16x8_add_sat(self.simd0, rhs.simd0), simd1: i16x8_add_sat(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].saturating_add(rhs.arr[0]),
-          self.arr[1].saturating_add(rhs.arr[1]),
-          self.arr[2].saturating_add(rhs.arr[2]),
-          self.arr[3].saturating_add(rhs.arr[3]),
-          self.arr[4].saturating_add(rhs.arr[4]),
-          self.arr[5].saturating_add(rhs.arr[5]),
-          self.arr[6].saturating_add(rhs.arr[6]),
-          self.arr[7].saturating_add(rhs.arr[7]),
-          self.arr[8].saturating_add(rhs.arr[8]),
-          self.arr[9].saturating_add(rhs.arr[9]),
-          self.arr[10].saturating_add(rhs.arr[10]),
-          self.arr[11].saturating_add(rhs.arr[11]),
-          self.arr[12].saturating_add(rhs.arr[12]),
-          self.arr[13].saturating_add(rhs.arr[13]),
-          self.arr[14].saturating_add(rhs.arr[14]),
-          self.arr[15].saturating_add(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.saturating_add(rhs.a),
+          b : self.b.saturating_add(rhs.b),
+        }
       }
     }
   }
@@ -700,29 +366,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_saturating_i16_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_saturating_i16_m128i(self.sse0, rhs.sse0), sse1: sub_saturating_i16_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i16x8_sub_sat(self.simd0, rhs.simd0), simd1: i16x8_sub_sat(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].saturating_sub(rhs.arr[0]),
-          self.arr[1].saturating_sub(rhs.arr[1]),
-          self.arr[2].saturating_sub(rhs.arr[2]),
-          self.arr[3].saturating_sub(rhs.arr[3]),
-          self.arr[4].saturating_sub(rhs.arr[4]),
-          self.arr[5].saturating_sub(rhs.arr[5]),
-          self.arr[6].saturating_sub(rhs.arr[6]),
-          self.arr[7].saturating_sub(rhs.arr[7]),
-          self.arr[8].saturating_sub(rhs.arr[8]),
-          self.arr[9].saturating_sub(rhs.arr[9]),
-          self.arr[10].saturating_sub(rhs.arr[10]),
-          self.arr[11].saturating_sub(rhs.arr[11]),
-          self.arr[12].saturating_sub(rhs.arr[12]),
-          self.arr[13].saturating_sub(rhs.arr[13]),
-          self.arr[14].saturating_sub(rhs.arr[14]),
-          self.arr[15].saturating_sub(rhs.arr[15]),
-        ]}
+        Self {
+          a : self.a.saturating_sub(rhs.a),
+          b : self.b.saturating_sub(rhs.b),
+        }
       }
     }
   }
@@ -740,50 +388,11 @@ impl i16x16 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: mul_i16_scale_round_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="ssse3")] {
-        Self { sse0:  mul_i16_scale_round_m128i(self.sse0, rhs.sse0), sse1:  mul_i16_scale_round_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="sse2")] {
-        // unfortunately mul_i16_scale_round_m128i only got added in sse3
-        let hi0 = mul_i16_keep_high_m128i(self.sse0, rhs.sse0);
-        let lo0 = mul_i16_keep_low_m128i(self.sse0, rhs.sse0);
-        let mut v10 = unpack_low_i16_m128i(lo0, hi0);
-        let mut v20 = unpack_high_i16_m128i(lo0, hi0);
-        let a = set_splat_i32_m128i(0x4000);
-        v10 = shr_imm_i32_m128i::<15>(add_i32_m128i(v10, a));
-        v20 = shr_imm_i32_m128i::<15>(add_i32_m128i(v20, a));
-        let s0 = pack_i32_to_i16_m128i(v10, v20);
-
-        let hi1 = mul_i16_keep_high_m128i(self.sse1, rhs.sse1);
-        let lo1 = mul_i16_keep_low_m128i(self.sse1, rhs.sse1);
-        let mut v11 = unpack_low_i16_m128i(lo1, hi1);
-        let mut v21 = unpack_high_i16_m128i(lo1, hi1);
-        v11 = shr_imm_i32_m128i::<15>(add_i32_m128i(v11, a));
-        v21 = shr_imm_i32_m128i::<15>(add_i32_m128i(v21, a));
-        let s1 = pack_i32_to_i16_m128i(v11, v21);
-
-        Self { sse0: s0, sse1: s1 }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i16x8_q15mulr_sat(self.simd0, rhs.simd0), simd1: i16x8_q15mulr_sat(self.simd1, rhs.simd1) }
       } else {
-        // compiler does a surprisingly good job of vectorizing this
-        Self { arr: [
-          ((i32::from(self.arr[0]) * i32::from(rhs.arr[0]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[1]) * i32::from(rhs.arr[1]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[2]) * i32::from(rhs.arr[2]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[3]) * i32::from(rhs.arr[3]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[4]) * i32::from(rhs.arr[4]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[5]) * i32::from(rhs.arr[5]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[6]) * i32::from(rhs.arr[6]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[7]) * i32::from(rhs.arr[7]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[8]) * i32::from(rhs.arr[8]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[9]) * i32::from(rhs.arr[9]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[10]) * i32::from(rhs.arr[10]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[11]) * i32::from(rhs.arr[11]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[12]) * i32::from(rhs.arr[12]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[13]) * i32::from(rhs.arr[13]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[14]) * i32::from(rhs.arr[14]) + 0x4000) >> 15) as i16,
-          ((i32::from(self.arr[15]) * i32::from(rhs.arr[15]) + 0x4000) >> 15) as i16,
-        ]}
+        Self {
+          a : self.a.mul_scale_round(rhs.a),
+          b : self.b.mul_scale_round(rhs.b),
+        }
       }
     }
   }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct i32x8 { avx2: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct i32x8 { pub(crate) sse0: m128i, pub(crate) sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct i32x8 { simd0: v128, simd1: v128 }
-
-    impl Default for i32x8 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for i32x8 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for i32x8 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i32x8 { arr: [i32;8] }
+    pub struct i32x8 { a : i32x4, b : i32x4}
   }
 }
 
@@ -49,21 +25,11 @@ impl Add for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_i32_m128i(self.sse0, rhs.sse0), sse1: add_i32_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_add(self.simd0, rhs.simd0), simd1: i32x4_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-          self.arr[4].wrapping_add(rhs.arr[4]),
-          self.arr[5].wrapping_add(rhs.arr[5]),
-          self.arr[6].wrapping_add(rhs.arr[6]),
-          self.arr[7].wrapping_add(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -77,21 +43,11 @@ impl Sub for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i32_m128i(self.sse0, rhs.sse0), sse1: sub_i32_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_sub(self.simd0, rhs.simd0), simd1: i32x4_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-          self.arr[4].wrapping_sub(rhs.arr[4]),
-          self.arr[5].wrapping_sub(rhs.arr[5]),
-          self.arr[6].wrapping_sub(rhs.arr[6]),
-          self.arr[7].wrapping_sub(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -105,23 +61,11 @@ impl Mul for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: mul_i32_keep_low_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: mul_i32_keep_low_m128i(self.sse0, rhs.sse0), sse1: mul_i32_keep_low_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_mul(self.simd0, rhs.simd0), simd1: i32x4_mul(self.simd1, rhs.simd1) }
       } else {
-        let arr1: [i32; 8] = cast(self);
-        let arr2: [i32; 8] = cast(rhs);
-        cast([
-          arr1[0].wrapping_mul(arr2[0]),
-          arr1[1].wrapping_mul(arr2[1]),
-          arr1[2].wrapping_mul(arr2[2]),
-          arr1[3].wrapping_mul(arr2[3]),
-          arr1[4].wrapping_mul(arr2[4]),
-          arr1[5].wrapping_mul(arr2[5]),
-          arr1[6].wrapping_mul(arr2[6]),
-          arr1[7].wrapping_mul(arr2[7]),
-        ])
+        Self {
+          a : self.a.mul(rhs.a),
+          b : self.b.mul(rhs.b),
+        }
       }
     }
   }
@@ -189,21 +133,11 @@ impl BitAnd for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-          self.arr[4].bitand(rhs.arr[4]),
-          self.arr[5].bitand(rhs.arr[5]),
-          self.arr[6].bitand(rhs.arr[6]),
-          self.arr[7].bitand(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -215,25 +149,14 @@ impl BitOr for i32x8 {
   #[must_use]
   fn bitor(self, rhs: Self) -> Self::Output {
     pick! {
-      if #[cfg(target_feature="avx2")] {
-        Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128i(self.sse0, rhs.sse0), sse1: bitor_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
-      } else {
-        Self { arr: [
-          self.arr[0].bitor(rhs.arr[0]),
-          self.arr[1].bitor(rhs.arr[1]),
-          self.arr[2].bitor(rhs.arr[2]),
-          self.arr[3].bitor(rhs.arr[3]),
-          self.arr[4].bitor(rhs.arr[4]),
-          self.arr[5].bitor(rhs.arr[5]),
-          self.arr[6].bitor(rhs.arr[6]),
-          self.arr[7].bitor(rhs.arr[7]),
-        ]}
+    if #[cfg(target_feature="avx2")] {
+      Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
+    } else {
+      Self {
+        a : self.a.bitor(rhs.a),
+        b : self.b.bitor(rhs.b),
       }
-    }
+    }    }
   }
 }
 
@@ -245,21 +168,11 @@ impl BitXor for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-          self.arr[4].bitxor(rhs.arr[4]),
-          self.arr[5].bitxor(rhs.arr[5]),
-          self.arr[6].bitxor(rhs.arr[6]),
-          self.arr[7].bitxor(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -277,24 +190,11 @@ macro_rules! impl_shl_t_for_i32x8 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shl_all_u32_m128i(self.sse0, shift), sse1: shl_all_u32_m128i(self.sse1, shift)}
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: i32x4_shl(self.simd0, u), simd1: i32x4_shl(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-              self.arr[4] << u,
-              self.arr[5] << u,
-              self.arr[6] << u,
-              self.arr[7] << u,
-            ]}
+            Self {
+              a : self.a.shl(rhs),
+              b : self.b.shl(rhs),
+            }
           }
         }
       }
@@ -315,24 +215,11 @@ macro_rules! impl_shr_t_for_i32x8 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shr_all_i32_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shr_all_i32_m128i(self.sse0, shift), sse1: shr_all_i32_m128i(self.sse1, shift)}
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: i32x4_shr(self.simd0, u), simd1: i32x4_shr(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-              self.arr[4] >> u,
-              self.arr[5] >> u,
-              self.arr[6] >> u,
-              self.arr[7] >> u,
-            ]}
+            Self {
+              a : self.a.shr(rhs),
+              b : self.b.shr(rhs),
+            }
           }
         }
       }
@@ -350,21 +237,11 @@ impl CmpEq for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_eq_mask_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_eq_mask_i32_m128i(self.sse1,rhs.sse1), }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_eq(self.simd0, rhs.simd0), simd1: i32x4_eq(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] == rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] == rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] == rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] == rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] == rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] == rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] == rhs.arr[7] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -378,21 +255,11 @@ impl CmpGt for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_gt_mask_i32_m128i(self.sse1,rhs.sse1), }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_gt(self.simd0, rhs.simd0), simd1: i32x4_gt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] > rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] > rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] > rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] > rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] > rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] > rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] > rhs.arr[7] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -406,21 +273,11 @@ impl CmpLt for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: !cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2)  ^ cmp_eq_mask_i32_m256i(self.avx2,rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_lt_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_lt_mask_i32_m128i(self.sse1,rhs.sse1), }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_lt(self.simd0, rhs.simd0), simd1: i32x4_lt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] < rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] < rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] < rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] < rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] < rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] < rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] < rhs.arr[7] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -437,12 +294,11 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b)
+        }
       }
     }
   }
@@ -452,22 +308,11 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: abs_i32_m256i(self.avx2) }
-      } else if #[cfg(target_feature="ssse3")] {
-        Self { sse0: abs_i32_m128i(self.sse0), sse1: abs_i32_m128i(self.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_abs(self.simd0), simd1: i32x4_abs(self.simd1) }
       } else {
-        let arr: [i32; 8] = cast(self);
-        cast([
-          arr[0].wrapping_abs(),
-          arr[1].wrapping_abs(),
-          arr[2].wrapping_abs(),
-          arr[3].wrapping_abs(),
-          arr[4].wrapping_abs(),
-          arr[5].wrapping_abs(),
-          arr[6].wrapping_abs(),
-          arr[7].wrapping_abs(),
-        ])
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
       }
     }
   }
@@ -477,12 +322,11 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: max_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: max_i32_m128i(self.sse0, rhs.sse0), sse1: max_i32_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_max(self.simd0, rhs.simd0), simd1: i32x4_max(self.simd1, rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(rhs, self)
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
     }
   }
@@ -492,12 +336,11 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: min_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: min_i32_m128i(self.sse0, rhs.sse0), sse1: min_i32_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i32x4_min(self.simd0, rhs.simd0), simd1: i32x4_min(self.simd1, rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(self, rhs)
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -507,21 +350,10 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         cast(convert_to_m256_from_i32_m256i(self.avx2))
-      } else if #[cfg(target_feature="sse2")] {
-        cast(Self { sse0 : cast(convert_to_m128_from_i32_m128i(self.sse0)), sse1 : cast(convert_to_m128_from_i32_m128i(self.sse1)) })
-      } else if #[cfg(target_feature="simd128")] {
-        cast(Self { simd0: f32x4_convert_i32x4(self.simd0), simd1: f32x4_convert_i32x4(self.simd1) })
       } else {
-        let arr: [i32; 8] = cast(self);
         cast([
-          arr[0] as f32,
-          arr[1] as f32,
-          arr[2] as f32,
-          arr[3] as f32,
-          arr[4] as f32,
-          arr[5] as f32,
-          arr[6] as f32,
-          arr[7] as f32,
+          self.a.round_float(),
+          self.b.round_float(),
         ])
       }
     }
@@ -533,18 +365,8 @@ impl i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         move_mask_i8_m256i(self.avx2)
-      } else if #[cfg(target_feature="sse2")] {
-        move_mask_i8_m128i(self.sse1) << 4 | move_mask_i8_m128i(self.sse0)
-      } else if #[cfg(target_feature="simd128")] {
-        (i32x4_bitmask(self.simd1) as i32) << 4 | i32x4_bitmask(self.simd0) as i32
       } else {
-        let mut out = 0;
-        for (index, i_eight) in self.arr.iter().copied().enumerate() {
-          if i_eight < 0 {
-            out |= 1 << index;
-          }
-        }
-        out
+        self.a.move_mask() + self.b.move_mask() << 4
       }
     }
   }
@@ -552,29 +374,22 @@ impl i32x8 {
   #[must_use]
   pub fn any(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        v128_any_true(self.simd0) | v128_any_true(self.simd1)
+      if #[cfg(target_feature="avx2")] {
+        move_mask_i8_m256i(self.avx2) != 0
       } else {
-        self.move_mask() != 0
+        self.a.any() || self.b.any()
       }
     }
   }
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        u32x4_all_true(self.simd0) & u32x4_all_true(self.simd1)
-      } else {
-        // eight lanes
-        self.move_mask() == 0b1111_1111
-      }
-    }
+    self.a.all() && self.b.all()
   }
   #[inline]
   #[must_use]
   pub fn none(self) -> bool {
-    !self.any()
+    self.a.none() && self.b.none()
   }
 
   #[inline]
@@ -595,21 +410,11 @@ impl Not for i32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: self.avx2.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not(), sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
-        Self { arr: [
-          !self.arr[0],
-          !self.arr[1],
-          !self.arr[2],
-          !self.arr[3],
-          !self.arr[4],
-          !self.arr[5],
-          !self.arr[6],
-          !self.arr[7],
-        ]}
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -366,7 +366,7 @@ impl i32x8 {
       if #[cfg(target_feature="avx2")] {
         move_mask_i8_m256i(self.avx2)
       } else {
-        self.a.move_mask() + self.b.move_mask() << 4
+        self.a.move_mask() | (self.b.move_mask() << 4)
       }
     }
   }
@@ -384,12 +384,18 @@ impl i32x8 {
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
-    self.a.all() && self.b.all()
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        move_mask_i8_m256i(self.avx2) == 0b11111111
+      } else {
+        self.a.all() && self.b.all()
+      }
+    }
   }
   #[inline]
   #[must_use]
   pub fn none(self) -> bool {
-    self.a.none() && self.b.none()
+    !self.any()
   }
 
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -58,7 +58,20 @@ impl Mul for i64x4 {
   #[inline]
   #[must_use]
   fn mul(self, rhs: Self) -> Self::Output {
-    Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let arr1: [i64; 4] = cast(self);
+        let arr2: [i64; 4] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+          arr1[2].wrapping_mul(arr2[2]),
+          arr1[3].wrapping_mul(arr2[3]),
+        ])
+      } else {
+        Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
+      }
+    }
   }
 }
 

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct i64x4 { avx2: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct i64x4 { sse0: m128i, sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct i64x4 { simd0: v128, simd1: v128 }
-
-    impl Default for i64x4 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for i64x4 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for i64x4 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i64x4 { arr: [i64;4] }
+    pub struct i64x4 { a : i64x2, b : i64x2 }
   }
 }
 
@@ -49,17 +25,11 @@ impl Add for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_i64_m128i(self.sse0, rhs.sse0), sse1: add_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_add(self.simd0, rhs.simd0), simd1: i64x2_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -73,17 +43,11 @@ impl Sub for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i64_m128i(self.sse0, rhs.sse0), sse1: sub_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_sub(self.simd0, rhs.simd0), simd1: i64x2_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -94,20 +58,7 @@ impl Mul for i64x4 {
   #[inline]
   #[must_use]
   fn mul(self, rhs: Self) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_mul(self.simd0, rhs.simd0), simd1: i64x2_mul(self.simd1, rhs.simd1) }
-      } else {
-        let arr1: [i64; 4] = cast(self);
-        let arr2: [i64; 4] = cast(rhs);
-        cast([
-          arr1[0].wrapping_mul(arr2[0]),
-          arr1[1].wrapping_mul(arr2[1]),
-          arr1[2].wrapping_mul(arr2[2]),
-          arr1[3].wrapping_mul(arr2[3]),
-        ])
-      }
-    }
+    Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
   }
 }
 
@@ -173,17 +124,11 @@ impl BitAnd for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -197,19 +142,13 @@ impl BitOr for i64x4 {
     pick! {
     if #[cfg(target_feature="avx2")] {
             Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-          } else  if #[cfg(target_feature="sse2")] {
-            Self { sse0: bitor_m128i(self.sse0, rhs.sse0) , sse1: bitor_m128i(self.sse1, rhs.sse1)}
-          } else if #[cfg(target_feature="simd128")] {
-            Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
-          } else {
-            Self { arr: [
-              self.arr[0].bitor(rhs.arr[0]),
-              self.arr[1].bitor(rhs.arr[1]),
-              self.arr[2].bitor(rhs.arr[2]),
-              self.arr[3].bitor(rhs.arr[3]),
-            ]}
-          }
+      } else {
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
         }
+      }
+    }
   }
 }
 
@@ -221,17 +160,11 @@ impl BitXor for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -249,21 +182,11 @@ macro_rules! impl_shl_t_for_i64x4 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shl_all_u64_m128i(self.sse0, shift), sse1: shl_all_u64_m128i(self.sse1, shift) }
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: i64x2_shl(self.simd0, u), simd1: i64x2_shl(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-
-            ]}
+            Self {
+              a : self.a.shl(rhs),
+              b : self.b.shl(rhs),
+            }
           }
         }
       }
@@ -281,18 +204,14 @@ macro_rules! impl_shr_t_for_i64x4 {
       #[must_use]
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
-          if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: i64x2_shr(self.simd0, u), simd1: i64x2_shr(self.simd1, u) }
+          if #[cfg(target_feature="avx2")] {
+            let shift = cast([rhs as u64, 0]);
+            Self { avx2: shr_all_u64_m256i(self.avx2, shift) }
           } else {
-            let u = rhs as u64;
-            let arr: [i64; 4] = cast(self);
-            cast([
-              arr[0] >> u,
-              arr[1] >> u,
-              arr[2] >> u,
-              arr[3] >> u,
-            ])
+            Self {
+              a : self.a.shr(rhs),
+              b : self.b.shr(rhs),
+            }
           }
         }
       }
@@ -309,19 +228,11 @@ impl CmpEq for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: cmp_eq_mask_i64_m128i(self.sse0, rhs.sse0),sse1: cmp_eq_mask_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_eq(self.simd0, rhs.simd0), simd1: i64x2_eq(self.simd1, rhs.simd1) }
       } else {
-        let s: [i64;4] = cast(self);
-        let r: [i64;4] = cast(rhs);
-        cast([
-          if s[0] == r[0] { -1_i64 } else { 0 },
-          if s[1] == r[1] { -1_i64 } else { 0 },
-          if s[2] == r[2] { -1_i64 } else { 0 },
-          if s[3] == r[3] { -1_i64 } else { 0 },
-        ])
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -335,19 +246,11 @@ impl CmpGt for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.2")] {
-        Self { sse0: cmp_gt_mask_i64_m128i(self.sse0, rhs.sse0), sse1: cmp_gt_mask_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_gt(self.simd0, rhs.simd0), simd1: i64x2_gt(self.simd1, rhs.simd1) }
       } else {
-        let s: [i64;4] = cast(self);
-        let r: [i64;4] = cast(rhs);
-        cast([
-          if s[0] > r[0] { -1_i64 } else { 0 },
-          if s[1] > r[1] { -1_i64 } else { 0 },
-          if s[2] > r[2] { -1_i64 } else { 0 },
-          if s[3] > r[3] { -1_i64 } else { 0 },
-        ])
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -361,20 +264,11 @@ impl CmpLt for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: !(cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2)) }
-      } else if #[cfg(target_feature="sse4.2")] {
-        Self { sse0: !cmp_gt_mask_i64_m128i(self.sse0, rhs.sse0) ^ cmp_eq_mask_i64_m128i(self.sse0, rhs.sse0),
-               sse1: !cmp_gt_mask_i64_m128i(self.sse1, rhs.sse1) ^ cmp_eq_mask_i64_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i64x2_lt(self.simd0, rhs.simd0), simd1: i64x2_lt(self.simd1, rhs.simd1) }
       } else {
-        let s: [i64;4] = cast(self);
-        let r: [i64;4] = cast(rhs);
-        cast([
-          if s[0] < r[0] { -1_i64 } else { 0 },
-          if s[1] < r[1] { -1_i64 } else { 0 },
-          if s[2] < r[2] { -1_i64 } else { 0 },
-          if s[3] < r[3] { -1_i64 } else { 0 },
-        ])
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -392,12 +286,11 @@ impl i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -427,18 +320,11 @@ impl Not for i64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: self.avx2.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not() , sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
         Self {
-          arr: [
-          !self.arr[0],
-          !self.arr[1],
-          !self.arr[2],
-          !self.arr[3],
-        ]}
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct i8x32 { avx: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct i8x32 { sse0: m128i, sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct i8x32 { simd0: v128, simd1: v128 }
-
-    impl Default for i8x32 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for i8x32 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for i8x32 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i8x32 { arr: [i8;32] }
+    pub struct i8x32 { a : i8x16, b : i8x16 }
   }
 }
 
@@ -49,45 +25,11 @@ impl Add for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: add_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_i8_m128i(self.sse0, rhs.sse0), sse1: add_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_add(self.simd0, rhs.simd0), simd1: i8x16_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-          self.arr[4].wrapping_add(rhs.arr[4]),
-          self.arr[5].wrapping_add(rhs.arr[5]),
-          self.arr[6].wrapping_add(rhs.arr[6]),
-          self.arr[7].wrapping_add(rhs.arr[7]),
-          self.arr[8].wrapping_add(rhs.arr[8]),
-          self.arr[9].wrapping_add(rhs.arr[9]),
-          self.arr[10].wrapping_add(rhs.arr[10]),
-          self.arr[11].wrapping_add(rhs.arr[11]),
-          self.arr[12].wrapping_add(rhs.arr[12]),
-          self.arr[13].wrapping_add(rhs.arr[13]),
-          self.arr[14].wrapping_add(rhs.arr[14]),
-          self.arr[15].wrapping_add(rhs.arr[15]),
-          self.arr[16].wrapping_add(rhs.arr[16]),
-          self.arr[17].wrapping_add(rhs.arr[17]),
-          self.arr[18].wrapping_add(rhs.arr[18]),
-          self.arr[19].wrapping_add(rhs.arr[19]),
-          self.arr[20].wrapping_add(rhs.arr[20]),
-          self.arr[21].wrapping_add(rhs.arr[21]),
-          self.arr[22].wrapping_add(rhs.arr[22]),
-          self.arr[23].wrapping_add(rhs.arr[23]),
-          self.arr[24].wrapping_add(rhs.arr[24]),
-          self.arr[25].wrapping_add(rhs.arr[25]),
-          self.arr[26].wrapping_add(rhs.arr[26]),
-          self.arr[27].wrapping_add(rhs.arr[27]),
-          self.arr[28].wrapping_add(rhs.arr[28]),
-          self.arr[29].wrapping_add(rhs.arr[29]),
-          self.arr[30].wrapping_add(rhs.arr[30]),
-          self.arr[31].wrapping_add(rhs.arr[31]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -101,45 +43,11 @@ impl Sub for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: sub_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i8_m128i(self.sse0, rhs.sse0), sse1: sub_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_sub(self.simd0, rhs.simd0), simd1: i8x16_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-          self.arr[4].wrapping_sub(rhs.arr[4]),
-          self.arr[5].wrapping_sub(rhs.arr[5]),
-          self.arr[6].wrapping_sub(rhs.arr[6]),
-          self.arr[7].wrapping_sub(rhs.arr[7]),
-          self.arr[8].wrapping_sub(rhs.arr[8]),
-          self.arr[9].wrapping_sub(rhs.arr[9]),
-          self.arr[10].wrapping_sub(rhs.arr[10]),
-          self.arr[11].wrapping_sub(rhs.arr[11]),
-          self.arr[12].wrapping_sub(rhs.arr[12]),
-          self.arr[13].wrapping_sub(rhs.arr[13]),
-          self.arr[14].wrapping_sub(rhs.arr[14]),
-          self.arr[15].wrapping_sub(rhs.arr[15]),
-          self.arr[16].wrapping_sub(rhs.arr[16]),
-          self.arr[17].wrapping_sub(rhs.arr[17]),
-          self.arr[18].wrapping_sub(rhs.arr[18]),
-          self.arr[19].wrapping_sub(rhs.arr[19]),
-          self.arr[20].wrapping_sub(rhs.arr[20]),
-          self.arr[21].wrapping_sub(rhs.arr[21]),
-          self.arr[22].wrapping_sub(rhs.arr[22]),
-          self.arr[23].wrapping_sub(rhs.arr[23]),
-          self.arr[24].wrapping_sub(rhs.arr[24]),
-          self.arr[25].wrapping_sub(rhs.arr[25]),
-          self.arr[26].wrapping_sub(rhs.arr[26]),
-          self.arr[27].wrapping_sub(rhs.arr[27]),
-          self.arr[28].wrapping_sub(rhs.arr[28]),
-          self.arr[29].wrapping_sub(rhs.arr[29]),
-          self.arr[30].wrapping_sub(rhs.arr[30]),
-          self.arr[31].wrapping_sub(rhs.arr[31]),
-          ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -189,45 +97,11 @@ impl BitAnd for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
           Self { avx : bitand_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0),  sse1: bitand_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-          self.arr[4].bitand(rhs.arr[4]),
-          self.arr[5].bitand(rhs.arr[5]),
-          self.arr[6].bitand(rhs.arr[6]),
-          self.arr[7].bitand(rhs.arr[7]),
-          self.arr[8].bitand(rhs.arr[8]),
-          self.arr[9].bitand(rhs.arr[9]),
-          self.arr[10].bitand(rhs.arr[10]),
-          self.arr[11].bitand(rhs.arr[11]),
-          self.arr[12].bitand(rhs.arr[12]),
-          self.arr[13].bitand(rhs.arr[13]),
-          self.arr[14].bitand(rhs.arr[14]),
-          self.arr[15].bitand(rhs.arr[15]),
-          self.arr[16].bitand(rhs.arr[16]),
-          self.arr[17].bitand(rhs.arr[17]),
-          self.arr[18].bitand(rhs.arr[18]),
-          self.arr[19].bitand(rhs.arr[19]),
-          self.arr[20].bitand(rhs.arr[20]),
-          self.arr[21].bitand(rhs.arr[21]),
-          self.arr[22].bitand(rhs.arr[22]),
-          self.arr[23].bitand(rhs.arr[23]),
-          self.arr[24].bitand(rhs.arr[24]),
-          self.arr[25].bitand(rhs.arr[25]),
-          self.arr[26].bitand(rhs.arr[26]),
-          self.arr[27].bitand(rhs.arr[27]),
-          self.arr[28].bitand(rhs.arr[28]),
-          self.arr[29].bitand(rhs.arr[29]),
-          self.arr[30].bitand(rhs.arr[30]),
-          self.arr[31].bitand(rhs.arr[31]),
-          ]}
+          Self {
+            a : self.a.bitand(rhs.a),
+            b : self.b.bitand(rhs.b),
+          }
       }
     }
   }
@@ -241,45 +115,11 @@ impl BitOr for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx : bitor_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128i(self.sse0, rhs.sse0),  sse1: bitor_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitor(rhs.arr[0]),
-          self.arr[1].bitor(rhs.arr[1]),
-          self.arr[2].bitor(rhs.arr[2]),
-          self.arr[3].bitor(rhs.arr[3]),
-          self.arr[4].bitor(rhs.arr[4]),
-          self.arr[5].bitor(rhs.arr[5]),
-          self.arr[6].bitor(rhs.arr[6]),
-          self.arr[7].bitor(rhs.arr[7]),
-          self.arr[8].bitor(rhs.arr[8]),
-          self.arr[9].bitor(rhs.arr[9]),
-          self.arr[10].bitor(rhs.arr[10]),
-          self.arr[11].bitor(rhs.arr[11]),
-          self.arr[12].bitor(rhs.arr[12]),
-          self.arr[13].bitor(rhs.arr[13]),
-          self.arr[14].bitor(rhs.arr[14]),
-          self.arr[15].bitor(rhs.arr[15]),
-          self.arr[16].bitor(rhs.arr[16]),
-          self.arr[17].bitor(rhs.arr[17]),
-          self.arr[18].bitor(rhs.arr[18]),
-          self.arr[19].bitor(rhs.arr[19]),
-          self.arr[20].bitor(rhs.arr[20]),
-          self.arr[21].bitor(rhs.arr[21]),
-          self.arr[22].bitor(rhs.arr[22]),
-          self.arr[23].bitor(rhs.arr[23]),
-          self.arr[24].bitor(rhs.arr[24]),
-          self.arr[25].bitor(rhs.arr[25]),
-          self.arr[26].bitor(rhs.arr[26]),
-          self.arr[27].bitor(rhs.arr[27]),
-          self.arr[28].bitor(rhs.arr[28]),
-          self.arr[29].bitor(rhs.arr[29]),
-          self.arr[30].bitor(rhs.arr[30]),
-          self.arr[31].bitor(rhs.arr[31]),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -293,45 +133,11 @@ impl BitXor for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx : bitxor_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0),  sse1: bitxor_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-          self.arr[4].bitxor(rhs.arr[4]),
-          self.arr[5].bitxor(rhs.arr[5]),
-          self.arr[6].bitxor(rhs.arr[6]),
-          self.arr[7].bitxor(rhs.arr[7]),
-          self.arr[8].bitxor(rhs.arr[8]),
-          self.arr[9].bitxor(rhs.arr[9]),
-          self.arr[10].bitxor(rhs.arr[10]),
-          self.arr[11].bitxor(rhs.arr[11]),
-          self.arr[12].bitxor(rhs.arr[12]),
-          self.arr[13].bitxor(rhs.arr[13]),
-          self.arr[14].bitxor(rhs.arr[14]),
-          self.arr[15].bitxor(rhs.arr[15]),
-          self.arr[16].bitxor(rhs.arr[16]),
-          self.arr[17].bitxor(rhs.arr[17]),
-          self.arr[18].bitxor(rhs.arr[18]),
-          self.arr[19].bitxor(rhs.arr[19]),
-          self.arr[20].bitxor(rhs.arr[20]),
-          self.arr[21].bitxor(rhs.arr[21]),
-          self.arr[22].bitxor(rhs.arr[22]),
-          self.arr[23].bitxor(rhs.arr[23]),
-          self.arr[24].bitxor(rhs.arr[24]),
-          self.arr[25].bitxor(rhs.arr[25]),
-          self.arr[26].bitxor(rhs.arr[26]),
-          self.arr[27].bitxor(rhs.arr[27]),
-          self.arr[28].bitxor(rhs.arr[28]),
-          self.arr[29].bitxor(rhs.arr[29]),
-          self.arr[30].bitxor(rhs.arr[30]),
-          self.arr[31].bitxor(rhs.arr[31]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -345,45 +151,11 @@ impl CmpEq for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx : cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_i8_m128i(self.sse0, rhs.sse0),  sse1: cmp_eq_mask_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_eq(self.simd0, rhs.simd0), simd1: i8x16_eq(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] == rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] == rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] == rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] == rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] == rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] == rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] == rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] == rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] == rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] == rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] == rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] == rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] == rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] == rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] == rhs.arr[15] { -1 } else { 0 },
-          if self.arr[16] == rhs.arr[16] { -1 } else { 0 },
-          if self.arr[17] == rhs.arr[17] { -1 } else { 0 },
-          if self.arr[18] == rhs.arr[18] { -1 } else { 0 },
-          if self.arr[19] == rhs.arr[19] { -1 } else { 0 },
-          if self.arr[20] == rhs.arr[20] { -1 } else { 0 },
-          if self.arr[21] == rhs.arr[21] { -1 } else { 0 },
-          if self.arr[22] == rhs.arr[22] { -1 } else { 0 },
-          if self.arr[23] == rhs.arr[23] { -1 } else { 0 },
-          if self.arr[24] == rhs.arr[24] { -1 } else { 0 },
-          if self.arr[25] == rhs.arr[25] { -1 } else { 0 },
-          if self.arr[26] == rhs.arr[26] { -1 } else { 0 },
-          if self.arr[27] == rhs.arr[27] { -1 } else { 0 },
-          if self.arr[28] == rhs.arr[28] { -1 } else { 0 },
-          if self.arr[29] == rhs.arr[29] { -1 } else { 0 },
-          if self.arr[30] == rhs.arr[30] { -1 } else { 0 },
-          if self.arr[31] == rhs.arr[31] { -1 } else { 0 },
-          ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -397,45 +169,11 @@ impl CmpGt for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx : cmp_gt_mask_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_i8_m128i(self.sse0, rhs.sse0),  sse1: cmp_gt_mask_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_gt(self.simd0, rhs.simd0), simd1: i8x16_gt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] > rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] > rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] > rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] > rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] > rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] > rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] > rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] > rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] > rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] > rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] > rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] > rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] > rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] > rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] > rhs.arr[15] { -1 } else { 0 },
-          if self.arr[16] > rhs.arr[16] { -1 } else { 0 },
-          if self.arr[17] > rhs.arr[17] { -1 } else { 0 },
-          if self.arr[18] > rhs.arr[18] { -1 } else { 0 },
-          if self.arr[19] > rhs.arr[19] { -1 } else { 0 },
-          if self.arr[20] > rhs.arr[20] { -1 } else { 0 },
-          if self.arr[21] > rhs.arr[21] { -1 } else { 0 },
-          if self.arr[22] > rhs.arr[22] { -1 } else { 0 },
-          if self.arr[23] > rhs.arr[23] { -1 } else { 0 },
-          if self.arr[24] > rhs.arr[24] { -1 } else { 0 },
-          if self.arr[25] > rhs.arr[25] { -1 } else { 0 },
-          if self.arr[26] > rhs.arr[26] { -1 } else { 0 },
-          if self.arr[27] > rhs.arr[27] { -1 } else { 0 },
-          if self.arr[28] > rhs.arr[28] { -1 } else { 0 },
-          if self.arr[29] > rhs.arr[29] { -1 } else { 0 },
-          if self.arr[30] > rhs.arr[30] { -1 } else { 0 },
-          if self.arr[31] > rhs.arr[31] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -449,45 +187,11 @@ impl CmpLt for i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx : !(cmp_gt_mask_i8_m256i(self.avx,rhs.avx) ^ cmp_eq_mask_i8_m256i(self.avx,rhs.avx)) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_lt_mask_i8_m128i(self.sse0, rhs.sse0),  sse1: cmp_lt_mask_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_lt(self.simd0, rhs.simd0), simd1: i8x16_lt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { -1 } else { 0 },
-          if self.arr[1] < rhs.arr[1] { -1 } else { 0 },
-          if self.arr[2] < rhs.arr[2] { -1 } else { 0 },
-          if self.arr[3] < rhs.arr[3] { -1 } else { 0 },
-          if self.arr[4] < rhs.arr[4] { -1 } else { 0 },
-          if self.arr[5] < rhs.arr[5] { -1 } else { 0 },
-          if self.arr[6] < rhs.arr[6] { -1 } else { 0 },
-          if self.arr[7] < rhs.arr[7] { -1 } else { 0 },
-          if self.arr[8] < rhs.arr[8] { -1 } else { 0 },
-          if self.arr[9] < rhs.arr[9] { -1 } else { 0 },
-          if self.arr[10] < rhs.arr[10] { -1 } else { 0 },
-          if self.arr[11] < rhs.arr[11] { -1 } else { 0 },
-          if self.arr[12] < rhs.arr[12] { -1 } else { 0 },
-          if self.arr[13] < rhs.arr[13] { -1 } else { 0 },
-          if self.arr[14] < rhs.arr[14] { -1 } else { 0 },
-          if self.arr[15] < rhs.arr[15] { -1 } else { 0 },
-          if self.arr[16] < rhs.arr[16] { -1 } else { 0 },
-          if self.arr[17] < rhs.arr[17] { -1 } else { 0 },
-          if self.arr[18] < rhs.arr[18] { -1 } else { 0 },
-          if self.arr[19] < rhs.arr[19] { -1 } else { 0 },
-          if self.arr[20] < rhs.arr[20] { -1 } else { 0 },
-          if self.arr[21] < rhs.arr[21] { -1 } else { 0 },
-          if self.arr[22] < rhs.arr[22] { -1 } else { 0 },
-          if self.arr[23] < rhs.arr[23] { -1 } else { 0 },
-          if self.arr[24] < rhs.arr[24] { -1 } else { 0 },
-          if self.arr[25] < rhs.arr[25] { -1 } else { 0 },
-          if self.arr[26] < rhs.arr[26] { -1 } else { 0 },
-          if self.arr[27] < rhs.arr[27] { -1 } else { 0 },
-          if self.arr[28] < rhs.arr[28] { -1 } else { 0 },
-          if self.arr[29] < rhs.arr[29] { -1 } else { 0 },
-          if self.arr[30] < rhs.arr[30] { -1 } else { 0 },
-          if self.arr[31] < rhs.arr[31] { -1 } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -505,12 +209,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0),  sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -520,46 +223,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: abs_i8_m256i(self.avx) }
-      } else if #[cfg(target_feature="ssse3")] {
-        Self { sse0: abs_i8_m128i(self.sse0), sse1: abs_i8_m128i(self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_abs(self.simd0), simd1: i8x16_abs(self.simd1) }
       } else {
-        let arr: [i8; 32] = cast(self);
-        cast([
-          arr[0].wrapping_abs(),
-          arr[1].wrapping_abs(),
-          arr[2].wrapping_abs(),
-          arr[3].wrapping_abs(),
-          arr[4].wrapping_abs(),
-          arr[5].wrapping_abs(),
-          arr[6].wrapping_abs(),
-          arr[7].wrapping_abs(),
-          arr[8].wrapping_abs(),
-          arr[9].wrapping_abs(),
-          arr[10].wrapping_abs(),
-          arr[11].wrapping_abs(),
-          arr[12].wrapping_abs(),
-          arr[13].wrapping_abs(),
-          arr[14].wrapping_abs(),
-          arr[15].wrapping_abs(),
-          arr[16].wrapping_abs(),
-          arr[17].wrapping_abs(),
-          arr[18].wrapping_abs(),
-          arr[19].wrapping_abs(),
-          arr[20].wrapping_abs(),
-          arr[21].wrapping_abs(),
-          arr[22].wrapping_abs(),
-          arr[23].wrapping_abs(),
-          arr[24].wrapping_abs(),
-          arr[25].wrapping_abs(),
-          arr[26].wrapping_abs(),
-          arr[27].wrapping_abs(),
-          arr[28].wrapping_abs(),
-          arr[29].wrapping_abs(),
-          arr[30].wrapping_abs(),
-          arr[31].wrapping_abs(),
-        ])
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
       }
     }
   }
@@ -569,12 +237,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: max_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: max_i8_m128i(self.sse0,rhs.sse0), sse1: max_i8_m128i(self.sse1,rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_max(self.simd0,rhs.simd0), simd1: i8x16_max(self.simd1,rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(rhs, self)
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
     }
   }
@@ -584,12 +251,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: min_i8_m256i(self.avx,rhs.avx) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: min_i8_m128i(self.sse0,rhs.sse0), sse1: min_i8_m128i(self.sse1,rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_min(self.simd0,rhs.simd0), simd1: i8x16_min(self.simd1,rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(self, rhs)
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -600,45 +266,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: add_saturating_i8_m256i(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_saturating_i8_m128i(self.sse0, rhs.sse0), sse1: add_saturating_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_add_sat(self.simd0, rhs.simd0), simd1: i8x16_add_sat(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].saturating_add(rhs.arr[0]),
-          self.arr[1].saturating_add(rhs.arr[1]),
-          self.arr[2].saturating_add(rhs.arr[2]),
-          self.arr[3].saturating_add(rhs.arr[3]),
-          self.arr[4].saturating_add(rhs.arr[4]),
-          self.arr[5].saturating_add(rhs.arr[5]),
-          self.arr[6].saturating_add(rhs.arr[6]),
-          self.arr[7].saturating_add(rhs.arr[7]),
-          self.arr[8].saturating_add(rhs.arr[8]),
-          self.arr[9].saturating_add(rhs.arr[9]),
-          self.arr[10].saturating_add(rhs.arr[10]),
-          self.arr[11].saturating_add(rhs.arr[11]),
-          self.arr[12].saturating_add(rhs.arr[12]),
-          self.arr[13].saturating_add(rhs.arr[13]),
-          self.arr[14].saturating_add(rhs.arr[14]),
-          self.arr[15].saturating_add(rhs.arr[15]),
-          self.arr[16].saturating_add(rhs.arr[16]),
-          self.arr[17].saturating_add(rhs.arr[17]),
-          self.arr[18].saturating_add(rhs.arr[18]),
-          self.arr[19].saturating_add(rhs.arr[19]),
-          self.arr[20].saturating_add(rhs.arr[20]),
-          self.arr[21].saturating_add(rhs.arr[21]),
-          self.arr[22].saturating_add(rhs.arr[22]),
-          self.arr[23].saturating_add(rhs.arr[23]),
-          self.arr[24].saturating_add(rhs.arr[24]),
-          self.arr[25].saturating_add(rhs.arr[25]),
-          self.arr[26].saturating_add(rhs.arr[26]),
-          self.arr[27].saturating_add(rhs.arr[27]),
-          self.arr[28].saturating_add(rhs.arr[28]),
-          self.arr[29].saturating_add(rhs.arr[29]),
-          self.arr[30].saturating_add(rhs.arr[30]),
-          self.arr[31].saturating_add(rhs.arr[31]),
-        ]}
+        Self {
+          a : self.a.saturating_add(rhs.a),
+          b : self.b.saturating_add(rhs.b),
+        }
       }
     }
   }
@@ -648,45 +280,11 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: sub_saturating_i8_m256i(self.avx, rhs.avx) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_saturating_i8_m128i(self.sse0, rhs.sse0), sse1: sub_saturating_i8_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: i8x16_sub_sat(self.simd0, rhs.simd0), simd1: i8x16_sub_sat(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].saturating_sub(rhs.arr[0]),
-          self.arr[1].saturating_sub(rhs.arr[1]),
-          self.arr[2].saturating_sub(rhs.arr[2]),
-          self.arr[3].saturating_sub(rhs.arr[3]),
-          self.arr[4].saturating_sub(rhs.arr[4]),
-          self.arr[5].saturating_sub(rhs.arr[5]),
-          self.arr[6].saturating_sub(rhs.arr[6]),
-          self.arr[7].saturating_sub(rhs.arr[7]),
-          self.arr[8].saturating_sub(rhs.arr[8]),
-          self.arr[9].saturating_sub(rhs.arr[9]),
-          self.arr[10].saturating_sub(rhs.arr[10]),
-          self.arr[11].saturating_sub(rhs.arr[11]),
-          self.arr[12].saturating_sub(rhs.arr[12]),
-          self.arr[13].saturating_sub(rhs.arr[13]),
-          self.arr[14].saturating_sub(rhs.arr[14]),
-          self.arr[15].saturating_sub(rhs.arr[15]),
-          self.arr[16].saturating_sub(rhs.arr[16]),
-          self.arr[17].saturating_sub(rhs.arr[17]),
-          self.arr[18].saturating_sub(rhs.arr[18]),
-          self.arr[19].saturating_sub(rhs.arr[19]),
-          self.arr[20].saturating_sub(rhs.arr[20]),
-          self.arr[21].saturating_sub(rhs.arr[21]),
-          self.arr[22].saturating_sub(rhs.arr[22]),
-          self.arr[23].saturating_sub(rhs.arr[23]),
-          self.arr[24].saturating_sub(rhs.arr[24]),
-          self.arr[25].saturating_sub(rhs.arr[25]),
-          self.arr[26].saturating_sub(rhs.arr[26]),
-          self.arr[27].saturating_sub(rhs.arr[27]),
-          self.arr[28].saturating_sub(rhs.arr[28]),
-          self.arr[29].saturating_sub(rhs.arr[29]),
-          self.arr[30].saturating_sub(rhs.arr[30]),
-          self.arr[31].saturating_sub(rhs.arr[31]),
-        ]}
+        Self {
+          a : self.a.saturating_sub(rhs.a),
+          b : self.b.saturating_sub(rhs.b),
+        }
       }
     }
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -311,6 +311,42 @@ impl u32x4 {
   }
   #[inline]
   #[must_use]
+  pub fn cmp_gt(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: cmp_gt_mask_i32_m128i(self.sse,rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u32x4_gt(self.simd, rhs.simd) }
+      } else {
+        Self { arr: [
+          if self.arr[0] > rhs.arr[0] { u32::MAX } else { 0 },
+          if self.arr[1] > rhs.arr[1] { u32::MAX } else { 0 },
+          if self.arr[2] > rhs.arr[2] { u32::MAX } else { 0 },
+          if self.arr[3] > rhs.arr[3] { u32::MAX } else { 0 },
+        ]}
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn cmp_lt(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: cmp_lt_mask_i32_m128i(self.sse,rhs.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u32x4_lt(self.simd, rhs.simd) }
+      } else {
+        Self { arr: [
+          if self.arr[0] < rhs.arr[0] { u32::MAX } else { 0 },
+          if self.arr[1] < rhs.arr[1] { u32::MAX } else { 0 },
+          if self.arr[2] < rhs.arr[2] { u32::MAX } else { 0 },
+          if self.arr[3] < rhs.arr[3] { u32::MAX } else { 0 },
+        ]}
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
   pub fn blend(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -215,7 +215,7 @@ impl u32x8 {
   pub fn cmp_lt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: cmp_lt_mask_i32_m256i(self.avx2, rhs.avx2 ) }
+        Self { avx2: !cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i32_m256i(self.avx2,rhs.avx2) }
       } else {
         Self {
           a : self.a.cmp_lt(rhs.a),

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct u32x8 { avx2: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct u32x8 { sse0: m128i, sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct u32x8 { simd0: v128, simd1: v128 }
-
-    impl Default for u32x8 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for u32x8 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for u32x8 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u32x8 { arr: [u32;8] }
+    pub struct u32x8 { a : u32x4, b : u32x4 }
   }
 }
 
@@ -49,21 +25,11 @@ impl Add for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_i32_m128i(self.sse0, rhs.sse0), sse1: add_i32_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_add(self.simd0, rhs.simd0), simd1: u32x4_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-          self.arr[4].wrapping_add(rhs.arr[4]),
-          self.arr[5].wrapping_add(rhs.arr[5]),
-          self.arr[6].wrapping_add(rhs.arr[6]),
-          self.arr[7].wrapping_add(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -77,21 +43,11 @@ impl Sub for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_i32_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i32_m128i(self.sse0, rhs.sse0), sse1: sub_i32_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_sub(self.simd0, rhs.simd0), simd1: u32x4_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-          self.arr[4].wrapping_sub(rhs.arr[4]),
-          self.arr[5].wrapping_sub(rhs.arr[5]),
-          self.arr[6].wrapping_sub(rhs.arr[6]),
-          self.arr[7].wrapping_sub(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -105,23 +61,11 @@ impl Mul for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: mul_i32_keep_low_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: mul_i32_keep_low_m128i(self.sse0, rhs.sse0), sse1: mul_i32_keep_low_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_mul(self.simd0, rhs.simd0), simd1: u32x4_mul(self.simd1, rhs.simd1) }
       } else {
-        let arr1: [u32; 8] = cast(self);
-        let arr2: [u32; 8] = cast(rhs);
-        cast([
-          arr1[0].wrapping_mul(arr2[0]),
-          arr1[1].wrapping_mul(arr2[1]),
-          arr1[2].wrapping_mul(arr2[2]),
-          arr1[3].wrapping_mul(arr2[3]),
-          arr1[4].wrapping_mul(arr2[4]),
-          arr1[5].wrapping_mul(arr2[5]),
-          arr1[6].wrapping_mul(arr2[6]),
-          arr1[7].wrapping_mul(arr2[7]),
-        ])
+        Self {
+          a : self.a.mul(rhs.a),
+          b : self.b.mul(rhs.b),
+        }
       }
     }
   }
@@ -135,21 +79,11 @@ impl BitAnd for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-          self.arr[4].bitand(rhs.arr[4]),
-          self.arr[5].bitand(rhs.arr[5]),
-          self.arr[6].bitand(rhs.arr[6]),
-          self.arr[7].bitand(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -163,21 +97,11 @@ impl BitOr for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128i(self.sse0, rhs.sse0), sse1: bitor_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitor(rhs.arr[0]),
-          self.arr[1].bitor(rhs.arr[1]),
-          self.arr[2].bitor(rhs.arr[2]),
-          self.arr[3].bitor(rhs.arr[3]),
-          self.arr[4].bitor(rhs.arr[4]),
-          self.arr[5].bitor(rhs.arr[5]),
-          self.arr[6].bitor(rhs.arr[6]),
-          self.arr[7].bitor(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -191,21 +115,11 @@ impl BitXor for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-          self.arr[4].bitxor(rhs.arr[4]),
-          self.arr[5].bitxor(rhs.arr[5]),
-          self.arr[6].bitxor(rhs.arr[6]),
-          self.arr[7].bitxor(rhs.arr[7]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -223,24 +137,11 @@ macro_rules! impl_shl_t_for_u32x8 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shl_all_u32_m128i(self.sse0, shift), sse1: shl_all_u32_m128i(self.sse1, shift)}
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: u32x4_shl(self.simd0, u), simd1: u32x4_shl(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-              self.arr[4] << u,
-              self.arr[5] << u,
-              self.arr[6] << u,
-              self.arr[7] << u,
-            ]}
+            Self {
+              a : self.a.shl(rhs),
+              b : self.b.shl(rhs),
+            }
           }
         }
       }
@@ -261,24 +162,11 @@ macro_rules! impl_shr_t_for_u32x8 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shr_all_u32_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shr_all_u32_m128i(self.sse0, shift), sse1: shr_all_u32_m128i(self.sse1, shift)}
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: u32x4_shr(self.simd0, u), simd1: u32x4_shr(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-              self.arr[4] >> u,
-              self.arr[5] >> u,
-              self.arr[6] >> u,
-              self.arr[7] >> u,
-            ]}
+            Self {
+              a : self.a.shr(rhs),
+              b : self.b.shr(rhs),
+            }
           }
         }
       }
@@ -300,21 +188,11 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_eq_mask_i32_m256i(self.avx2, rhs.avx2 ) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_eq_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_eq_mask_i32_m128i(self.sse1,rhs.sse1), }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_eq(self.simd0, rhs.simd0), simd1: u32x4_eq(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] == rhs.arr[0] { u32::MAX } else { 0 },
-          if self.arr[1] == rhs.arr[1] { u32::MAX } else { 0 },
-          if self.arr[2] == rhs.arr[2] { u32::MAX } else { 0 },
-          if self.arr[3] == rhs.arr[3] { u32::MAX } else { 0 },
-          if self.arr[4] == rhs.arr[4] { u32::MAX } else { 0 },
-          if self.arr[5] == rhs.arr[5] { u32::MAX } else { 0 },
-          if self.arr[6] == rhs.arr[6] { u32::MAX } else { 0 },
-          if self.arr[7] == rhs.arr[7] { u32::MAX } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -324,21 +202,11 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2 ) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: cmp_gt_mask_i32_m128i(self.sse0,rhs.sse0), sse1: cmp_gt_mask_i32_m128i(self.sse1,rhs.sse1), }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_gt(self.simd0, rhs.simd0), simd1: u32x4_gt(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          if self.arr[0] > rhs.arr[0] { u32::MAX } else { 0 },
-          if self.arr[1] > rhs.arr[1] { u32::MAX } else { 0 },
-          if self.arr[2] > rhs.arr[2] { u32::MAX } else { 0 },
-          if self.arr[3] > rhs.arr[3] { u32::MAX } else { 0 },
-          if self.arr[4] > rhs.arr[4] { u32::MAX } else { 0 },
-          if self.arr[5] > rhs.arr[5] { u32::MAX } else { 0 },
-          if self.arr[6] > rhs.arr[6] { u32::MAX } else { 0 },
-          if self.arr[7] > rhs.arr[7] { u32::MAX } else { 0 },
-        ]}
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -346,22 +214,13 @@ impl u32x8 {
   #[must_use]
   pub fn cmp_lt(self, rhs: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_lt(self.simd0, rhs.simd0), simd1: u32x4_lt(self.simd1, rhs.simd1) }
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: cmp_lt_mask_i32_m256i(self.avx2, rhs.avx2 ) }
       } else {
-        let s_arr: [u32; 8] = cast(self);
-        let r_arr: [u32; 8] = cast(rhs);
-        let out_arr: [u32; 8] = [
-          if s_arr[0] < r_arr[0] { u32::MAX } else { 0 },
-          if s_arr[1] < r_arr[1] { u32::MAX } else { 0 },
-          if s_arr[2] < r_arr[2] { u32::MAX } else { 0 },
-          if s_arr[3] < r_arr[3] { u32::MAX } else { 0 },
-          if s_arr[4] < r_arr[4] { u32::MAX } else { 0 },
-          if s_arr[5] < r_arr[5] { u32::MAX } else { 0 },
-          if s_arr[6] < r_arr[6] { u32::MAX } else { 0 },
-          if s_arr[7] < r_arr[7] { u32::MAX } else { 0 },
-        ];
-        cast(out_arr)
+        Self {
+          a : self.a.cmp_lt(rhs.a),
+          b : self.b.cmp_lt(rhs.b),
+        }
       }
     }
   }
@@ -371,12 +230,11 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -387,12 +245,11 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: max_i32_m128i(self.sse0, rhs.sse0), sse1: max_i32_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_max(self.simd0, rhs.simd0), simd1: u32x4_max(self.simd1, rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(rhs, self)
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
       }
     }
   }
@@ -402,12 +259,11 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: max_i32_m128i(self.sse0, rhs.sse0), sse1: max_i32_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u32x4_min(self.simd0, rhs.simd0), simd1: u32x4_min(self.simd1, rhs.simd1) }
       } else {
-        self.cmp_lt(rhs).blend(self, rhs)
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
       }
     }
   }
@@ -430,21 +286,11 @@ impl Not for u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: self.avx2.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not(), sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0), simd1: v128_not(self.simd1) }
       } else {
-        Self { arr: [
-          !self.arr[0],
-          !self.arr[1],
-          !self.arr[2],
-          !self.arr[3],
-          !self.arr[4],
-          !self.arr[5],
-          !self.arr[6],
-          !self.arr[7],
-        ]}
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -58,7 +58,20 @@ impl Mul for u64x4 {
   #[inline]
   #[must_use]
   fn mul(self, rhs: Self) -> Self::Output {
-    Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let arr1: [i64; 4] = cast(self);
+        let arr2: [i64; 4] = cast(rhs);
+        cast([
+          arr1[0].wrapping_mul(arr2[0]),
+          arr1[1].wrapping_mul(arr2[1]),
+          arr1[2].wrapping_mul(arr2[2]),
+          arr1[3].wrapping_mul(arr2[3]),
+        ])
+      } else {
+        Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
+      }
+    }
   }
 }
 

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -5,34 +5,10 @@ pick! {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
     pub struct u64x4 { avx2: m256i }
-  } else if #[cfg(target_feature="sse2")] {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    #[repr(C, align(32))]
-    pub struct u64x4 { sse0: m128i, sse1: m128i }
-  } else if #[cfg(target_feature="simd128")] {
-    use core::arch::wasm32::*;
-
-    #[derive(Clone, Copy)]
-    #[repr(C, align(32))]
-    pub struct u64x4 { simd0: v128, simd1: v128 }
-
-    impl Default for u64x4 {
-      fn default() -> Self {
-        Self::splat(0)
-      }
-    }
-
-    impl PartialEq for u64x4 {
-      fn eq(&self, other: &Self) -> bool {
-        !v128_any_true(v128_or(v128_xor(self.simd0, other.simd0), v128_xor(self.simd1, other.simd1)))
-      }
-    }
-
-    impl Eq for u64x4 { }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u64x4 { arr: [u64;4] }
+    pub struct u64x4 { a : u64x2, b : u64x2 }
   }
 }
 
@@ -49,17 +25,11 @@ impl Add for u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: add_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: add_i64_m128i(self.sse0, rhs.sse0), sse1: add_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u64x2_add(self.simd0, rhs.simd0), simd1: u64x2_add(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_add(rhs.arr[0]),
-          self.arr[1].wrapping_add(rhs.arr[1]),
-          self.arr[2].wrapping_add(rhs.arr[2]),
-          self.arr[3].wrapping_add(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
       }
     }
   }
@@ -73,17 +43,11 @@ impl Sub for u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: sub_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: sub_i64_m128i(self.sse0, rhs.sse0), sse1: sub_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u64x2_sub(self.simd0, rhs.simd0), simd1: u64x2_sub(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].wrapping_sub(rhs.arr[0]),
-          self.arr[1].wrapping_sub(rhs.arr[1]),
-          self.arr[2].wrapping_sub(rhs.arr[2]),
-          self.arr[3].wrapping_sub(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
       }
     }
   }
@@ -94,20 +58,7 @@ impl Mul for u64x4 {
   #[inline]
   #[must_use]
   fn mul(self, rhs: Self) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        Self { simd0: u64x2_mul(self.simd0, rhs.simd0), simd1: u64x2_mul(self.simd1, rhs.simd1) }
-      } else {
-        let arr1: [u64; 4] = cast(self);
-        let arr2: [u64; 4] = cast(rhs);
-        cast([
-          arr1[0].wrapping_mul(arr2[0]),
-          arr1[1].wrapping_mul(arr2[1]),
-          arr1[2].wrapping_mul(arr2[2]),
-          arr1[3].wrapping_mul(arr2[3]),
-        ])
-      }
-    }
+    Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
   }
 }
 
@@ -173,17 +124,11 @@ impl BitAnd for u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitand_m128i(self.sse0, rhs.sse0), sse1: bitand_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_and(self.simd0, rhs.simd0), simd1: v128_and(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitand(rhs.arr[0]),
-          self.arr[1].bitand(rhs.arr[1]),
-          self.arr[2].bitand(rhs.arr[2]),
-          self.arr[3].bitand(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.bitand(rhs.a),
+          b : self.b.bitand(rhs.b),
+        }
       }
     }
   }
@@ -197,17 +142,11 @@ impl BitOr for u64x4 {
     pick! {
     if #[cfg(target_feature="avx2")] {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
-      } else  if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitor_m128i(self.sse0, rhs.sse0) , sse1: bitor_m128i(self.sse1, rhs.sse1)}
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_or(self.simd0, rhs.simd0), simd1: v128_or(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitor(rhs.arr[0]),
-          self.arr[1].bitor(rhs.arr[1]),
-          self.arr[2].bitor(rhs.arr[2]),
-          self.arr[3].bitor(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
       }
     }
   }
@@ -221,17 +160,11 @@ impl BitXor for u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: bitxor_m128i(self.sse0, rhs.sse0), sse1: bitxor_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_xor(self.simd0, rhs.simd0), simd1: v128_xor(self.simd1, rhs.simd1) }
       } else {
-        Self { arr: [
-          self.arr[0].bitxor(rhs.arr[0]),
-          self.arr[1].bitxor(rhs.arr[1]),
-          self.arr[2].bitxor(rhs.arr[2]),
-          self.arr[3].bitxor(rhs.arr[3]),
-        ]}
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
       }
     }
   }
@@ -249,20 +182,11 @@ macro_rules! impl_shl_t_for_u64x4 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shl_all_u64_m128i(self.sse0, shift), sse1: shl_all_u64_m128i(self.sse1, shift) }
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: u64x2_shl(self.simd0, u), simd1: u64x2_shl(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-            ]}
+            Self {
+              a : self.a.shl(rhs),
+              b : self.b.shl(rhs),
+            }
           }
         }
       }
@@ -283,20 +207,11 @@ macro_rules! impl_shr_t_for_u64x4 {
           if #[cfg(target_feature="avx2")] {
             let shift = cast([rhs as u64, 0]);
             Self { avx2: shr_all_u64_m256i(self.avx2, shift) }
-          } else if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
-            Self { sse0: shr_all_u64_m128i(self.sse0, shift), sse1: shr_all_u64_m128i(self.sse1, shift) }
-          } else if #[cfg(target_feature="simd128")] {
-            let u = rhs as u32;
-            Self { simd0: u64x2_shr(self.simd0, u), simd1: u64x2_shr(self.simd1, u) }
           } else {
-            let u = rhs as u64;
-            Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-            ]}
+            Self {
+              a : self.a.shr(rhs),
+              b : self.b.shr(rhs),
+            }
           }
         }
       }
@@ -317,19 +232,11 @@ impl u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: cmp_eq_mask_i64_m128i(self.sse0, rhs.sse0),sse1: cmp_eq_mask_i64_m128i(self.sse1, rhs.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: u64x2_eq(self.simd0, rhs.simd0), simd1: u64x2_eq(self.simd1, rhs.simd1) }
       } else {
-        let s: [i64;4] = cast(self);
-        let r: [i64;4] = cast(rhs);
-        cast([
-          if s[0] == r[0] { -1_i64 } else { 0 },
-          if s[1] == r[1] { -1_i64 } else { 0 },
-          if s[2] == r[2] { -1_i64 } else { 0 },
-          if s[3] == r[3] { -1_i64 } else { 0 },
-        ])
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
       }
     }
   }
@@ -339,18 +246,11 @@ impl u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) }
-      } else if #[cfg(target_feature="sse4.2")] {
-        Self { sse0: cmp_gt_mask_i64_m128i(self.sse0, rhs.sse0), sse1: cmp_gt_mask_i64_m128i(self.sse1, rhs.sse1) }
       } else {
-        // u64x2_gt on WASM is not a thing. https://github.com/WebAssembly/simd/pull/414
-        let s: [u64;4] = cast(self);
-        let r: [u64;4] = cast(rhs);
-        cast([
-          if s[0] > r[0] { -1_i64 } else { 0 },
-          if s[1] > r[1] { -1_i64 } else { 0 },
-          if s[2] > r[2] { -1_i64 } else { 0 },
-          if s[3] > r[3] { -1_i64 } else { 0 },
-        ])
+        Self {
+          a : self.a.cmp_gt(rhs.a),
+          b : self.b.cmp_gt(rhs.b),
+        }
       }
     }
   }
@@ -361,12 +261,11 @@ impl u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
-      } else if #[cfg(target_feature="sse4.1")] {
-        Self { sse0: blend_varying_i8_m128i(f.sse0, t.sse0, self.sse0), sse1: blend_varying_i8_m128i(f.sse1, t.sse1, self.sse1) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_bitselect(t.simd0, f.simd0, self.simd0), simd1: v128_bitselect(t.simd1, f.simd1, self.simd1) }
       } else {
-        generic_bit_blend(self, t, f)
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
       }
     }
   }
@@ -389,17 +288,11 @@ impl Not for u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: self.avx2.not()  }
-      } else if #[cfg(target_feature="sse2")] {
-        Self { sse0: self.sse0.not() , sse1: self.sse1.not() }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd0: v128_not(self.simd0) , simd1: v128_not(self.simd1) }
       } else {
-        Self { arr: [
-          !self.arr[0],
-          !self.arr[1],
-          !self.arr[2],
-          !self.arr[3],
-        ]}
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
       }
     }
   }

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -92,6 +92,28 @@ fn impl_u32x4_cmp_eq() {
 }
 
 #[test]
+fn impl_u32x4_cmp_gt() {
+  let a = u32x4::from([1, 2, 3, 4]);
+  let b = u32x4::from([2_u32; 4]);
+  let expected = u32x4::from([0, 0, u32::MAX, u32::MAX]);
+  let actual = a.cmp_gt(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_u32x4_cmp_lt() {
+  let a = u32x4::from([1, 2, 3, 4]);
+  let b = u32x4::from([2_u32; 4]);
+  let expected = u32x4::from([u32::MAX, 0, 0, 0]);
+  let actual = a.cmp_lt(b);
+  assert_eq!(expected, actual);
+
+  let expected = u32x4::from([0, 0, 0, 0]);
+  let actual = a.cmp_lt(a);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_u32x4_blend() {
   let use_t: u32 = u32::MAX;
   let t = u32x4::from([1, 2, 3, 4]);


### PR DESCRIPTION
Simplify the implementation of the 256bit wide types by just composing them of two 128bit parts (a,b) when not compiling for AVX2. This results in exactly the same code after inlining and significantly reducing the complexity.

This will make it easier to add more target support, since it doesn't require copy/pasting for the 256bit implementations. It's also a pattern that might be useful for doing 512bit implementations for AVX-512

Separated this from the neon support PR since it's better to separate feature neutral refactoring from feature additions to catch regressions more easily.