### PR TITLE
Add from_slice_unaligned and move_mask to i16x8, i16x16, i32x8 and i32x16

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,22 +11,22 @@ jobs:
       matrix:
         rust:
         # x86 without sse/sse2 on by default
-        - { target: i586-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86
-        - { target: i686-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86_64
-        - { target: x86_64-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # wasm32
-        - { target: wasm32-wasi, toolchain: 1.54.0, os: ubuntu-latest, wasmtime: v5.0.0 }
+        - { target: wasm32-wasi, toolchain: 1.56.0, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: stable, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: beta, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: nightly, os: ubuntu-latest, wasmtime: v5.0.0 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,17 +11,17 @@ jobs:
       matrix:
         rust:
         # x86 without sse/sse2 on by default
-        - { target: i586-pc-windows-msvc, toolchain: 1.52.1, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86
-        - { target: i686-pc-windows-msvc, toolchain: 1.52.1, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86_64
-        - { target: x86_64-pc-windows-msvc, toolchain: 1.52.1, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: 1.54.0, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ default = ["std"]
 std = []
 
 [dependencies]
-safe_arch = { version = "0.6", features = ["bytemuck"] }
+safe_arch = { version = "0.7", features = ["bytemuck"] }
 bytemuck = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["data-structures", "hardware-support"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 
+# minimum version supported with WASM and all intrinsics for safe_arch (also first version to support this config option)
+rust-version = "1.56"
+
 [features]
 default = ["std"]
 

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -307,9 +307,9 @@ impl i16x16 {
   pub fn any(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i16_m256i(i16::MIN))) != 0
+        ((move_mask_i8_m256i(self.avx2) as u32) & 0b10101010101010101010101010101010) != 0
       } else {
-        self.a.any() || self.b.any()
+        (self.a | self.b).any()
       }
     }
   }
@@ -318,9 +318,9 @@ impl i16x16 {
   pub fn all(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i16_m256i(i16::MIN))) as u32 == 0b10101010101010101010101010101010
+        ((move_mask_i8_m256i(self.avx2) as u32) & 0b10101010101010101010101010101010) == 0b10101010101010101010101010101010
       } else {
-        self.a.all() || self.b.all()
+        (self.a & self.b).all()
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -476,7 +476,7 @@ impl i16x8 {
         ((self.arr[4] < 0) as i32) << 4 |
         ((self.arr[5] < 0) as i32) << 5 |
         ((self.arr[6] < 0) as i32) << 6 |
-        ((self.arr[7] < 0) as i32) << 7 |
+        ((self.arr[7] < 0) as i32) << 7
       }
     }
   }
@@ -608,8 +608,6 @@ impl i16x8 {
   #[inline]
   #[must_use]
   pub fn from_slice_unaligned(input: &[i16]) -> Self {
-    assert!(input.len() >= 8);
-
     pick! {
       if #[cfg(target_feature="sse2")] {
         unsafe { Self { sse: load_unaligned_m128i( &*(input.as_ptr() as * const [u8;16]) ) } }
@@ -618,7 +616,8 @@ impl i16x8 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vld1q_s16( input.as_ptr() as *const i16 ) } }
       } else {
-        Self::new( input[0..8].try_into().unwrap() )
+        // 2018 edition doesn't have try_into
+        Self::new( [input[0], input[1], input[2], input[3], input[4], input[5], input[6], input[7]])
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -608,6 +608,8 @@ impl i16x8 {
   #[inline]
   #[must_use]
   pub fn from_slice_unaligned(input: &[i16]) -> Self {
+    assert!(input.len() >= 8);
+
     pick! {
       if #[cfg(target_feature="sse2")] {
         unsafe { Self { sse: load_unaligned_m128i( &*(input.as_ptr() as * const [u8;16]) ) } }
@@ -617,7 +619,7 @@ impl i16x8 {
         unsafe { Self { neon: vld1q_s16( input.as_ptr() as *const i16 ) } }
       } else {
         // 2018 edition doesn't have try_into
-        Self::new( [input[0], input[1], input[2], input[3], input[4], input[5], input[6], input[7]])
+        unsafe { Self::new( *(input.as_ptr() as * const [i16;8]) ) }
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -445,6 +445,71 @@ impl i16x8 {
     Self::from(array)
   }
 
+  #[inline]
+  #[must_use]
+  pub fn move_mask(self) -> i32 {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        move_mask_i8_m128i( pack_i16_to_i8_m128i(self.sse,self.sse)) & 0xff
+      } else if #[cfg(target_feature="simd128")] {
+        i16x8_bitmask(self.simd) as i32
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe
+        {
+          let as_u16 = vreinterpretq_u16_s16(self.neon);
+
+          // mask the top bit
+          let masked = vandq_u16(as_u16, vdupq_n_u16(0x8000));
+
+          // shift by appropriate amount
+          let shiftby : [i16;8] = [-7,-6,-5,-4,-3,-2,-1,0];
+          let out = vshlq_u16(masked, vld1q_s16(shiftby.as_ptr()) );
+
+          // horizontal add everything and return it
+          vaddvq_u16(out) as i32
+         }
+       } else {
+        ((self.arr[0] < 0) as i32) << 0 |
+        ((self.arr[1] < 0) as i32) << 1 |
+        ((self.arr[2] < 0) as i32) << 2 |
+        ((self.arr[3] < 0) as i32) << 3 |
+        ((self.arr[4] < 0) as i32) << 4 |
+        ((self.arr[5] < 0) as i32) << 5 |
+        ((self.arr[6] < 0) as i32) << 6 |
+        ((self.arr[7] < 0) as i32) << 7 |
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn any(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        v128_any_true(self.simd)
+      } else {
+        self.move_mask() != 0
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn all(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        u8x16_all_true(self.simd)
+      } else {
+        // sixteen lanes
+        self.move_mask() == 0b1111_1111
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn none(self) -> bool {
+    !self.any()
+  }
+
   /// Unpack the lower half of the input and expand it to `i16` values.
   #[inline]
   pub fn from_u8x16_low(u: u8x16) -> Self {
@@ -520,6 +585,11 @@ impl i16x8 {
       if #[cfg(target_feature="avx2")] {
         let a = v.avx2.bitand(set_splat_i32_m256i(0xffff));
         i16x8 { sse: pack_i32_to_u16_m128i( extract_m128i_from_m256i::<0>(a), extract_m128i_from_m256i::<1>(a) ) }
+      } else if #[cfg(target_feature="sse2")] {
+        let a = shr_imm_i32_m128i::<16>(shl_imm_u32_m128i::<16>(v.a.sse));
+        let b = shr_imm_i32_m128i::<16>(shl_imm_u32_m128i::<16>(v.b.sse));
+
+        i16x8 { sse: pack_i32_to_i16_m128i( a, b)  }
       } else {
       i16x8::new([
         v.as_array_ref()[0] as i16,
@@ -531,6 +601,24 @@ impl i16x8 {
         v.as_array_ref()[6] as i16,
         v.as_array_ref()[7] as i16,
       ])
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn from_slice_unaligned(input: &[i16]) -> Self {
+    assert!(input.len() >= 8);
+
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        unsafe { Self { sse: load_unaligned_m128i( &*(input.as_ptr() as * const [u8;16]) ) } }
+      } else if #[cfg(target_feature="simd128")] {
+        unsafe { Self { simd: v128_load(input.as_ptr() as *const v128 ) } }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe { Self { neon: vld1q_s16( input.as_ptr() as *const i16 ) } }
+      } else {
+        Self::new( input[0..8].try_into().unwrap() )
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -456,17 +456,15 @@ impl i16x8 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe
         {
-          let as_u16 = vreinterpretq_u16_s16(self.neon);
+          // set all to 1 if top bit is set, else 0
+          let masked = vcltq_s16(self.neon, vdupq_n_s16(0));
 
-          // mask the top bit
-          let masked = vandq_u16(as_u16, vdupq_n_u16(0x8000));
+          // select the right bit out of each lane
+          let selectbit : uint16x8_t = core::intrinsics::transmute([1u16, 2, 4, 8, 16, 32, 64, 128]);
+          let r = vandq_u16(masked, selectbit);
 
-          // shift by appropriate amount
-          let shiftby : [i16;8] = [-15, -14, -13, -12, -11, -10, -9, -8];
-          let out = vshlq_u16(masked, vld1q_s16(shiftby.as_ptr()) );
-
-          // horizontal add everything and return it
-          vaddvq_u16(out) as i32
+          // horizontally add the 16-bit lanes
+          vaddvq_u16(r) as i32
          }
        } else {
         ((self.arr[0] < 0) as i32) << 0 |

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -462,7 +462,7 @@ impl i16x8 {
           let masked = vandq_u16(as_u16, vdupq_n_u16(0x8000));
 
           // shift by appropriate amount
-          let shiftby : [i16;8] = [-7,-6,-5,-4,-3,-2,-1,0];
+          let shiftby : [i16;8] = [-15, -14, -13, -12, -11, -10, -9, -8];
           let out = vshlq_u16(masked, vld1q_s16(shiftby.as_ptr()) );
 
           // horizontal add everything and return it

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -115,7 +115,7 @@ impl Mul for i32x4 {
   fn mul(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: mul_i32_keep_low_m128i(self.sse, rhs.sse) }
+        Self { sse: mul_32_m128i(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: i32x4_mul(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -523,25 +523,32 @@ impl i32x4 {
   #[must_use]
   pub fn any(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        v128_any_true(self.simd)
+      if #[cfg(target_feature="sse2")] {
+        (move_mask_i8_m128i(self.sse) & 0b1000100010001000) != 0
+      } else if #[cfg(target_feature="simd128")] {
+        u32x4_bitmask(self.simd) != 0
       } else {
-        self.move_mask() != 0
+        let v : [u64;2] = cast(self);
+        ((v[0] | v[1]) & 0x8000000080000000) != 0
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn all(self) -> bool {
     pick! {
-      if #[cfg(target_feature="simd128")] {
-        u32x4_all_true(self.simd)
+      if #[cfg(target_feature="sse2")] {
+        (move_mask_i8_m128i(self.sse) & 0b1000100010001000) == 0b1000100010001000
+      } else if #[cfg(target_feature="simd128")] {
+        u32x4_bitmask(self.simd) == 0b1111
       } else {
-        // four lanes
-        self.move_mask() == 0b1111
+        let v : [u64;2] = cast(self);
+        (v[0] & v[1] & 0x8000000080000000) == 0x8000000080000000
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn none(self) -> bool {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -438,6 +438,7 @@ impl i32x4 {
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
@@ -492,33 +493,32 @@ impl i32x4 {
   #[must_use]
   pub fn move_mask(self) -> i32 {
     pick! {
-      if #[cfg(target_feature="sse2")] {
-        move_mask_i8_m128i(self.sse)
+      if #[cfg(target_feature="sse")] {
+        move_mask_m128(cast(self.sse))
       } else if #[cfg(target_feature="simd128")] {
-        i32x4_bitmask(self.simd) as i32
+        u32x4_bitmask(self.simd) as i32
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe
         {
-          let as_u32 = vreinterpretq_u32_s32(self.neon);
+          // set all to 1 if top bit is set, else 0
+          let masked = vcltq_s32(self.neon, vdupq_n_s32(0));
 
-          // mask the top bit
-          let masked = vandq_u32(as_u32, vdupq_n_u32(0x80000000));
+          // select the right bit out of each lane
+          let selectbit : uint32x4_t = core::intrinsics::transmute([1u32, 2, 4, 8]);
+          let r = vandq_u32(masked, selectbit);
 
-          // shift by appropriate amount
-          let shiftby : [i32;4] = [-31,-30,-29,-28];
-          let out = vshlq_u32(masked, vld1q_s32(shiftby.as_ptr()) );
-
-          // horizontal add everything and return it
-          vaddvq_u32(out) as i32
-        }
+          // horizontally add the 16-bit lanes
+          vaddvq_u32(r) as i32
+         }
       } else {
-        ((self.arr[0] < 0) as i32) << 0 |
-        ((self.arr[1] < 0) as i32) << 1 |
-        ((self.arr[2] < 0) as i32) << 2 |
-        ((self.arr[3] < 0) as i32) << 3
+        (((self.arr[0] as i32) < 0) as i32) << 0 |
+        (((self.arr[1] as i32) < 0) as i32) << 1 |
+        (((self.arr[2] as i32) < 0) as i32) << 2 |
+        (((self.arr[3] as i32) < 0) as i32) << 3
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -404,9 +404,9 @@ impl i32x8 {
   pub fn any(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i32_m256i(i32::MIN))) != 0
+        ((move_mask_i8_m256i(self.avx2) as u32) & 0b10001000100010001000100010001000) != 0
       } else {
-        self.a.any() || self.b.any()
+        (self.a | self.b).any()
       }
     }
   }
@@ -415,9 +415,9 @@ impl i32x8 {
   pub fn all(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i32_m256i(i32::MIN))) as u32 == 0b10001000100010001000100010001000
+        ((move_mask_i8_m256i(self.avx2) as u32) & 0b10001000100010001000100010001000) == 0b10001000100010001000100010001000
       } else {
-        self.a.all() || self.b.all()
+        (self.a & self.b).all()
       }
     }
   }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -392,18 +392,19 @@ impl i32x8 {
   pub fn move_mask(self) -> i32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(self.avx2)
+        move_mask_m256(cast(self.avx2)) as i32
       } else {
         self.a.move_mask() | (self.b.move_mask() << 4)
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(self.avx2) != 0
+        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i32_m256i(i32::MIN))) != 0
       } else {
         self.a.any() || self.b.any()
       }
@@ -414,9 +415,9 @@ impl i32x8 {
   pub fn all(self) -> bool {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        move_mask_i8_m256i(self.avx2) == 0b11111111
+        move_mask_i8_m256i(bitand_m256i(self.avx2, set_splat_i32_m256i(i32::MIN))) as u32 == 0b10001000100010001000100010001000
       } else {
-        self.a.all() && self.b.all()
+        self.a.all() || self.b.all()
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -594,8 +594,8 @@ impl i8x16 {
           let masked = vandq_u8(as_u8, vdupq_n_u8(0x80));
 
           // shift by appropriate amount
-          let shiftby : int8x16_t = std::mem::transmute([-7i8, -6, -5, -4, -3, -2, -1, 0, -7, -6, -5, -4, -3, -2, -1, 0]);
-          let out = vshlq_u8(masked, shiftby);
+          let shiftby : i8x16 = cast([-7i8, -6, -5, -4, -3, -2, -1, 0, -7, -6, -5, -4, -3, -2, -1, 0]);
+          let out = vshlq_u8(masked, shiftby.neon);
 
           // interleave the lanes so that a 16-bit sum accumulates the bits in the right order
           // this gets translated into a single tbl call by the optimizer

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -577,8 +577,8 @@ impl i8x16 {
     }
   }
 
-  #[inline]
-  #[must_use]
+  //  #[inline]
+  //  #[must_use]
   pub fn move_mask(self) -> i32 {
     pick! {
       if #[cfg(target_feature="sse2")] {
@@ -597,9 +597,11 @@ impl i8x16 {
           let shiftby : [i8;16] = [-7,-6,-5,-4,-3,-2,-1,0,-7,-6,-5,-4,-3,-2,-1,0];
           let out = vshlq_u8(masked, vld1q_s8(shiftby.as_ptr()) );
 
-          // horizontal add everything and return it
-          i32::from(vaddv_u8(vget_low_u8(out))) + (i32::from(vaddv_u8(vget_high_u8(out))) << 8)
-         }
+          // this gets translated into a single tbl call by the optimizer
+          let c = vzip_u8(vget_low_u8(out), vget_high_u8(out));
+
+          vaddvq_u16(vreinterpretq_u16_u8(vcombine_u8(c.0, c.1))) as i32
+        }
        } else {
         ((self.arr[0] < 0) as i32) << 0 |
         ((self.arr[1] < 0) as i32) << 1 |

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -577,8 +577,8 @@ impl i8x16 {
     }
   }
 
-  //  #[inline]
-  //  #[must_use]
+  #[inline]
+  #[must_use]
   pub fn move_mask(self) -> i32 {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -571,7 +571,7 @@ impl i8x16 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vld1q_s8( input.as_ptr() as *const i8 ) } }
       } else {
-        Self::new( input[0..8].try_into().unwrap() )
+        Self::new( [input[0], input[1], input[2], input[3],input[4], input[5], input[6], input[7], input[8], input[9], input[10], input[11], input[12], input[13], input[14], input[15]])
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -561,7 +561,7 @@ impl i8x16 {
   #[inline]
   #[must_use]
   pub fn from_slice_unaligned(input: &[i8]) -> Self {
-    assert!(input.len() >= 8);
+    assert!(input.len() >= 16);
 
     pick! {
       if #[cfg(target_feature="sse2")] {
@@ -571,7 +571,8 @@ impl i8x16 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vld1q_s8( input.as_ptr() as *const i8 ) } }
       } else {
-        Self::new( [input[0], input[1], input[2], input[3],input[4], input[5], input[6], input[7], input[8], input[9], input[10], input[11], input[12], input[13], input[14], input[15]])
+        // 2018 edition doesn't have try_into
+        unsafe { Self::new( *(input.as_ptr() as * const [i8;16]) ) }
       }
     }
   }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -290,6 +290,48 @@ impl i8x32 {
   }
 
   #[inline]
+  #[must_use]
+  pub fn move_mask(self) -> i32 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        move_mask_i8_m256i(self.avx) as i32
+      } else {
+        self.a.move_mask() | (self.b.move_mask() << 16)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn any(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        move_mask_i8_m256i(self.avx) != 0
+      } else {
+        self.a.any() || self.b.any()
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn all(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        move_mask_i8_m256i(self.avx) == -1
+      } else {
+        self.a.all() || self.b.all()
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn none(self) -> bool {
+    !self.any()
+  }
+
+  #[inline]
   pub fn to_array(self) -> [i8; 32] {
     cast(self)
   }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -308,7 +308,7 @@ impl i8x32 {
       if #[cfg(target_feature="avx2")] {
         move_mask_i8_m256i(self.avx) != 0
       } else {
-        self.a.any() || self.b.any()
+        (self.a | self.b).any()
       }
     }
   }
@@ -320,7 +320,7 @@ impl i8x32 {
       if #[cfg(target_feature="avx2")] {
         move_mask_i8_m256i(self.avx) == -1
       } else {
-        self.a.all() || self.b.all()
+        (self.a & self.b).all()
       }
     }
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -115,7 +115,7 @@ impl Mul for u32x4 {
   fn mul(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: mul_i32_keep_low_m128i(self.sse, rhs.sse) }
+        Self { sse: mul_32_m128i(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u32x4_mul(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/tests/all_tests/t_i16x16.rs
+++ b/tests/all_tests/t_i16x16.rs
@@ -583,3 +583,47 @@ fn impl_from_i8x16() {
 
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn test_i16x16_move_mask() {
+  let a =
+    i16x16::from([-1, 0, -2, -3, -1, 0, -2, -3, -1, 0, -1, 0, -1, 0, -1, 0]);
+  let expected = 0b0101010111011101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i16x16_any() {
+  let a = i16x16::from([0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(a.any());
+
+  let a = i16x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(a.any());
+
+  //
+  let a = i16x16::from([0; 16]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i16x16_all() {
+  let a = i16x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(!a.all());
+  //
+  let a = i16x16::from([-1; 16]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i16x16_none() {
+  let a = i16x16::from([0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(!a.none());
+
+  let a = i16x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(!a.none());
+
+  //
+  let a = i16x16::from([0; 16]);
+  assert!(a.none());
+}

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -241,9 +241,9 @@ fn test_from_u8x16_low() {
 
 #[test]
 fn impl_from_i32x8_truncate() {
-  let src = i32x8::new([10000, 1001, 2, 3, 4, 5, 6, 65536]);
+  let src = i32x8::new([10000, 1001, 2, 3, 4, 5, -65536, 65536]);
 
-  let expected = i16x8::new([10000, 1001, 2, 3, 4, 5, 6, 0]);
+  let expected = i16x8::new([10000, 1001, 2, 3, 4, 5, 0, 0]);
 
   let result = i16x8::from_i32x8_truncate(src);
 
@@ -259,4 +259,54 @@ fn impl_from_i32x8_saturate() {
   let result = i16x8::from_i32x8_saturate(src);
 
   assert_eq!(result, expected);
+}
+
+#[test]
+fn impl_from_i16_slice() {
+  let src = [0, 1_i16, 2, 3, 4, 5, 6, 7, 8];
+
+  let result = i16x8::from_slice_unaligned(&src[1..9]);
+
+  let expected = i16x8::new([1_i16, 2, 3, 4, 5, 6, 7, 8]);
+  assert_eq!(result, expected);
+}
+
+#[test]
+fn test_i16x8_move_mask() {
+  let a = i16x8::from([-1, 0, -2, -3, -1, 0, -2, -3]);
+  let expected = 0b11011101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+  //
+  let a = i16x8::from([1, 0, 2, -3, 1, 0, 2, -3]);
+  let expected = 0b10001000;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i16x8_any() {
+  let a = i16x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(a.any());
+  //
+  let a = i16x8::from([0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i16x8_all() {
+  let a = i16x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(!a.all());
+  //
+  let a = i16x8::from([-1; 8]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i16x8_none() {
+  let a = i16x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(!a.none());
+  //
+  let a = i16x8::from([0; 8]);
+  assert!(a.none());
 }

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -155,3 +155,43 @@ fn impl_i32x4_round_float() {
   let actual = a.round_float();
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn test_i32x4_move_mask() {
+  let a = i32x4::from([-1, 0, -2, -3]);
+  let expected = 0b1101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+  //
+  let a = i32x4::from([i32::MAX, 0, 2, -3]);
+  let expected = 0b1000;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i32x4_any() {
+  let a = i32x4::from([0, 0, 0, -1]);
+  assert!(a.any());
+  //
+  let a = i32x4::from([0, 0, 0, 0]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i32x4_all() {
+  let a = i32x4::from([0, 0, 0, -1]);
+  assert!(!a.all());
+  //
+  let a = i32x4::from([-1; 4]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i32x4_none() {
+  let a = i32x4::from([0, 0, 0, -1]);
+  assert!(!a.none());
+  //
+  let a = i32x4::from([0; 4]);
+  assert!(a.none());
+}

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -222,3 +222,43 @@ fn impl_from_i16x8() {
 
   assert_eq!(actual, expected);
 }
+
+#[test]
+fn test_i16x8_move_mask() {
+  let a = i16x8::from([-1, 0, -2, -3, -1, 0, -2, -3]);
+  let expected = 0b11011101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+  //
+  let a = i16x8::from([1, 0, 2, -3, 1, 0, 2, -3]);
+  let expected = 0b10001000;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i32x8_any() {
+  let a = i32x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(a.any());
+  //
+  let a = i32x8::from([0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i32x8_all() {
+  let a = i32x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(!a.all());
+  //
+  let a = i32x8::from([-1; 8]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i32x8_none() {
+  let a = i32x8::from([0, 0, 0, -1, 0, 0, 0, 0]);
+  assert!(!a.none());
+  //
+  let a = i32x8::from([0; 8]);
+  assert!(a.none());
+}

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -327,3 +327,14 @@ fn impl_from_i16x16_saturate() {
 
   assert_eq!(result, expected);
 }
+
+#[test]
+fn impl_from_i8_slice() {
+  let src = [0, 1_i8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+  let result = i8x16::from_slice_unaligned(&src[1..17]);
+
+  let expected =
+    i8x16::new([1_i8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  assert_eq!(result, expected);
+}

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -329,6 +329,15 @@ fn impl_from_i16x16_saturate() {
 }
 
 #[test]
+fn test_i16x8_move_mask() {
+  let a =
+    i8x16::from([-1, 0, -2, -3, -1, 0, -2, -3, -1, 0, -1, 0, -1, 0, -1, 0]);
+  let expected = 0b0101010111011101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_from_i8_slice() {
   let src = [0, 1_i8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -329,12 +329,47 @@ fn impl_from_i16x16_saturate() {
 }
 
 #[test]
-fn test_i16x8_move_mask() {
+fn test_i8x16_move_mask() {
   let a =
     i8x16::from([-1, 0, -2, -3, -1, 0, -2, -3, -1, 0, -1, 0, -1, 0, -1, 0]);
   let expected = 0b0101010111011101;
   let actual = a.move_mask();
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i8x16_any() {
+  let a = i8x16::from([0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(a.any());
+
+  let a = i8x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(a.any());
+
+  //
+  let a = i8x16::from([0; 16]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i8x16_all() {
+  let a = i8x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(!a.all());
+  //
+  let a = i8x16::from([-1; 16]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i8x16_none() {
+  let a = i8x16::from([0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert!(!a.none());
+
+  let a = i8x16::from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0]);
+  assert!(!a.none());
+
+  //
+  let a = i8x16::from([0; 16]);
+  assert!(a.none());
 }
 
 #[test]

--- a/tests/all_tests/t_i8x32.rs
+++ b/tests/all_tests/t_i8x32.rs
@@ -527,3 +527,64 @@ fn impl_i8x32_min() {
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn test_i8x32_move_mask() {
+  let a = i8x32::from([
+    -1, 0, -2, -3, -1, 0, -2, -3, -1, 0, -1, 0, -1, 0, -1, 0, -1, -1, -1, -1,
+    -1, -1, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0,
+  ]);
+  let expected = 0b01010101011111110101010111011101;
+  let actual = a.move_mask();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_i8x32_any() {
+  let a = i8x32::from([
+    0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+  ]);
+  assert!(a.any());
+
+  let a = i8x32::from([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, -1, 0, 0, 0,
+  ]);
+  assert!(a.any());
+
+  //
+  let a = i8x32::from([0; 32]);
+  assert!(!a.any());
+}
+
+#[test]
+fn test_i8x32_all() {
+  let a = i8x32::from([
+    0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+  ]);
+  assert!(!a.all());
+  //
+  let a = i8x32::from([-1; 32]);
+  assert!(a.all());
+}
+
+#[test]
+fn test_i8x32_none() {
+  let a = i8x32::from([
+    0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+  ]);
+  assert!(!a.none());
+
+  let a = i8x32::from([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, -1, 0, 0, 0,
+  ]);
+  assert!(!a.none());
+
+  //
+  let a = i8x32::from([0; 32]);
+  assert!(a.none());
+}


### PR DESCRIPTION
Updated minimum rust version to 1.56, since this is the one that all the _MM_HINTS (otherwise safe_arch fails to compile)