### PR TITLE
add reduce min/max along with tests. Also optimize i16x8 abs for sse2

### DIFF
--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -390,8 +390,27 @@ impl i16x16 {
   #[inline]
   #[must_use]
   pub fn reduce_add(self) -> i16 {
-    let arr: [i16; 16] = cast(self);
-    arr.iter().sum()
+    let arr: [i16x8; 2] = cast(self);
+
+    (arr[0] + arr[1]).reduce_add()
+  }
+
+  /// horizontal min of all the elements of the vector
+  #[inline]
+  #[must_use]
+  pub fn reduce_min(self) -> i16 {
+    let arr: [i16x8; 2] = cast(self);
+
+    arr[0].min(arr[1]).reduce_min()
+  }
+
+  /// horizontal max of all the elements of the vector
+  #[inline]
+  #[must_use]
+  pub fn reduce_max(self) -> i16 {
+    let arr: [i16x8; 2] = cast(self);
+
+    arr[0].max(arr[1]).reduce_max()
   }
 
   #[inline]

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -335,8 +335,24 @@ impl i32x8 {
   #[inline]
   #[must_use]
   pub fn reduce_add(self) -> i32 {
-    let arr: [i32; 8] = cast(self);
-    arr.iter().sum()
+    let arr: [i32x4; 2] = cast(self);
+    (arr[0] + arr[1]).reduce_add()
+  }
+
+  /// horizontal max of all the elements of the vector
+  #[inline]
+  #[must_use]
+  pub fn reduce_max(self) -> i32 {
+    let arr: [i32x4; 2] = cast(self);
+    arr[0].max(arr[1]).reduce_max()
+  }
+
+  /// horizontal min of all the elements of the vector
+  #[inline]
+  #[must_use]
+  pub fn reduce_min(self) -> i32 {
+    let arr: [i32x4; 2] = cast(self);
+    arr[0].min(arr[1]).reduce_min()
   }
 
   #[inline]

--- a/tests/all_tests/t_i16x16.rs
+++ b/tests/all_tests/t_i16x16.rs
@@ -634,3 +634,23 @@ fn impl_i16x16_reduce_add() {
     i16x16::from([1, 2, 3, 4, 5, 6, 7, 9, 10, 20, 30, 40, 50, 60, 70, 90]);
   assert_eq!(p.reduce_add(), 407);
 }
+
+#[test]
+fn impl_i16x16_reduce_min() {
+  for i in 0..8 {
+    let mut v = [i16::MAX; 16];
+    v[i] = i16::MIN;
+    let p = i16x16::from(v);
+    assert_eq!(p.reduce_min(), i16::MIN);
+  }
+}
+
+#[test]
+fn impl_i16x16_reduce_max() {
+  for i in 0..8 {
+    let mut v = [i16::MIN; 16];
+    v[i] = i16::MAX;
+    let p = i16x16::from(v);
+    assert_eq!(p.reduce_min(), i16::MIN);
+  }
+}

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -316,3 +316,23 @@ fn impl_i16x8_reduce_add() {
   let p = i16x8::from([1, 2, 3, 4, 5, 6, 7, 9]);
   assert_eq!(p.reduce_add(), 37);
 }
+
+#[test]
+fn impl_i16x8_reduce_min() {
+  for i in 0..8 {
+    let mut v = [i16::MAX; 8];
+    v[i] = i16::MIN;
+    let p = i16x8::from(v);
+    assert_eq!(p.reduce_min(), i16::MIN);
+  }
+}
+
+#[test]
+fn impl_i16x8_reduce_max() {
+  for i in 0..8 {
+    let mut v = [i16::MIN; 8];
+    v[i] = i16::MAX;
+    let p = i16x8::from(v);
+    assert_eq!(p.reduce_min(), i16::MIN);
+  }
+}

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -201,3 +201,23 @@ fn impl_i32x4_reduce_add() {
   let p = i32x4::from([10000000, 20000000, 30000000, -40000000]);
   assert_eq!(p.reduce_add(), 20000000);
 }
+
+#[test]
+fn impl_i32x4_reduce_min() {
+  for i in 0..4 {
+    let mut v = [i32::MAX; 4];
+    v[i] = i32::MIN;
+    let p = i32x4::from(v);
+    assert_eq!(p.reduce_min(), i32::MIN);
+  }
+}
+
+#[test]
+fn impl_i32x4_reduce_max() {
+  for i in 0..4 {
+    let mut v = [i32::MIN; 4];
+    v[i] = i32::MAX;
+    let p = i32x4::from(v);
+    assert_eq!(p.reduce_max(), i32::MAX);
+  }
+}

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -271,3 +271,23 @@ fn impl_i32x8_reduce_add() {
   ]);
   assert_eq!(p.reduce_add(), 370000000);
 }
+
+#[test]
+fn impl_i32x8_reduce_min() {
+  for i in 0..8 {
+    let mut v = [i32::MAX; 8];
+    v[i] = i32::MIN;
+    let p = i32x8::from(v);
+    assert_eq!(p.reduce_min(), i32::MIN);
+  }
+}
+
+#[test]
+fn impl_i32x8_reduce_max() {
+  for i in 0..8 {
+    let mut v = [i32::MIN; 8];
+    v[i] = i32::MAX;
+    let p = i32x8::from(v);
+    assert_eq!(p.reduce_max(), i32::MAX);
+  }
+}


### PR DESCRIPTION
Also for 256 bit reductions, first reduce the top and bottom halves in parallel for generating better code. Use wrapping_add instead of sum to avoid blowups in debug builds since wrapping operations are assumed everywhere in this library.