### PR TITLE
Add unsigned_abs to i8,i16,i32,i64 to provide well defined behavior for abs

### DIFF
--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -700,6 +700,23 @@ impl i16x8 {
       }
     }
   }
+
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> u16x8 {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        u16x8 { sse: abs_i16_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        u16x8 { simd: i16x8_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {u16x8 { neon: vabsq_s16(self.neon) }}
+      } else {
+        let arr: [i16; 8] = cast(self);
+        cast(arr.map(|x| x.unsigned_abs()))
+      }
+    }
+  }
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -710,7 +710,7 @@ impl i16x8 {
       } else if #[cfg(target_feature="simd128")] {
         u16x8 { simd: i16x8_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {u16x8 { neon: vabsq_s16(self.neon) }}
+        unsafe {u16x8 { neon: vreinterpretq_u16_s16(vabsq_s16(self.neon)) }}
       } else {
         let arr: [i16; 8] = cast(self);
         cast(arr.map(|x| x.unsigned_abs()))

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -451,7 +451,12 @@ impl i32x4 {
         unsafe {u32x4 { neon: vreinterpretq_u32_s32(vabsq_s32(self.neon)) }}
       } else {
         let arr: [i32; 4] = cast(self);
-        cast(arr.map(|x| x.unsigned_abs()))
+        cast([
+          arr[0].unsigned_abs(),
+          arr[1].unsigned_abs(),
+          arr[2].unsigned_abs(),
+          arr[3].unsigned_abs(),
+        ])
       }
     }
   }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -439,6 +439,23 @@ impl i32x4 {
     }
   }
 
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> u32x4 {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        u32x4 { sse: abs_i32_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        u32x4 { simd: i32x4_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {u32x4 { neon: vreinterpretq_u32_s32(vabsq_s32(self.neon)) }}
+      } else {
+        let arr: [i32; 4] = cast(self);
+        cast(arr.map(|x| x.unsigned_abs()))
+      }
+    }
+  }
+
   /// horizontal add of all the elements of the vector
   #[inline]
   #[must_use]
@@ -472,23 +489,6 @@ impl i32x4 {
   pub fn reduce_min(self) -> i32 {
     let arr: [i32; 4] = cast(self);
     arr[0].min(arr[1]).min(arr[2].min(arr[3]))
-  }
-
-  #[inline]
-  #[must_use]
-  pub fn unsigned_abs(self) -> u32x4 {
-    pick! {
-      if #[cfg(target_feature="ssse3")] {
-        u32x4 { sse: abs_i32_m128i(self.sse) }
-      } else if #[cfg(target_feature="simd128")] {
-        u32x4 { simd: i32x4_abs(self.simd) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {u32x4 { neon: vabsq_s32(self.neon) }}
-      } else {
-        let arr: [i32; 4] = cast(self);
-        cast(arr.map(|x| x.unsigned_abs()))
-      }
-    }
   }
 
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -476,6 +476,23 @@ impl i32x4 {
 
   #[inline]
   #[must_use]
+  pub fn unsigned_abs(self) -> u32x4 {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        u32x4 { sse: abs_i32_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        u32x4 { simd: i32x4_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {u32x4 { neon: vabsq_s32(self.neon) }}
+      } else {
+        let arr: [i32; 4] = cast(self);
+        cast(arr.map(|x| x.unsigned_abs()))
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -369,6 +369,22 @@ impl i32x8 {
       }
     }
   }
+
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> u32x8 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        u32x8 { avx2: abs_i32_m256i(self.avx2) }
+      } else {
+        u32x8 {
+          a : self.a.unsigned_abs(),
+          b : self.b.unsigned_abs(),
+        }
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -422,7 +422,7 @@ impl i64x2 {
       if #[cfg(target_feature="ssse3")] {
         u64x2 { sse: abs_i64_m128i(self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        u64x2 { simd: i64x4_abs(self.simd) }
+        u64x2 { simd: i64x2_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {u64x2 { neon: vabsq_s64(self.neon) }}
       } else {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -424,7 +424,7 @@ impl i64x2 {
       } else if #[cfg(target_feature="simd128")] {
         u64x2 { simd: i64x2_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {u64x2 { neon: vabsq_s64(self.neon) }}
+        unsafe {u64x2 { neon: vreinterpretq_u64_s64(vabsq_s64(self.neon)) }}
       } else {
         let arr: [i64; 2] = cast(self);
         cast(arr.map(|x| x.unsigned_abs()))

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -409,7 +409,11 @@ impl i64x2 {
         unsafe {Self { neon: vabsq_s64(self.neon) }}
       } else {
         let arr: [i64; 2] = cast(self);
-        cast(arr.map(|x| x.wrapping_abs()))
+        cast(
+          [
+            arr[0].wrapping_abs(),
+            arr[1].wrapping_abs(),
+          ])
       }
     }
   }
@@ -425,7 +429,11 @@ impl i64x2 {
         unsafe {u64x2 { neon: vreinterpretq_u64_s64(vabsq_s64(self.neon)) }}
       } else {
         let arr: [i64; 2] = cast(self);
-        cast(arr.map(|x| x.unsigned_abs()))
+        cast(
+          [
+            arr[0].unsigned_abs(),
+            arr[1].unsigned_abs(),
+          ])
       }
     }
   }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -400,6 +400,40 @@ impl i64x2 {
 
   #[inline]
   #[must_use]
+  pub fn abs(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        Self { sse: abs_i64_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i64x2_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vabsq_s64(self.neon) }}
+      } else {
+        let arr: [i64; 2] = cast(self);
+        cast(arr.map(|x| x.wrapping_abs()))
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> u64x2 {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        u64x2 { sse: abs_i64_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        u64x2 { simd: i64x4_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {u64x2 { neon: vabsq_s64(self.neon) }}
+      } else {
+        let arr: [i64; 2] = cast(self);
+        cast(arr.map(|x| x.unsigned_abs()))
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_float(self) -> f64x2 {
     let arr: [i64; 2] = cast(self);
     cast([arr[0] as f64, arr[1] as f64])

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -402,9 +402,8 @@ impl i64x2 {
   #[must_use]
   pub fn abs(self) -> Self {
     pick! {
-      if #[cfg(target_feature="ssse3")] {
-        Self { sse: abs_i64_m128i(self.sse) }
-      } else if #[cfg(target_feature="simd128")] {
+      // x86 doesn't have this builtin
+      if #[cfg(target_feature="simd128")] {
         Self { simd: i64x2_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vabsq_s64(self.neon) }}
@@ -419,9 +418,8 @@ impl i64x2 {
   #[must_use]
   pub fn unsigned_abs(self) -> u64x2 {
     pick! {
-      if #[cfg(target_feature="ssse3")] {
-        u64x2 { sse: abs_i64_m128i(self.sse) }
-      } else if #[cfg(target_feature="simd128")] {
+      // x86 doesn't have this builtin
+      if #[cfg(target_feature="simd128")] {
         u64x2 { simd: i64x2_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {u64x2 { neon: vreinterpretq_u64_s64(vabsq_s64(self.neon)) }}

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -310,6 +310,36 @@ impl i64x4 {
 
   #[inline]
   #[must_use]
+  pub fn abs(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: abs_i64_m256i(self.avx2) }
+      } else {
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> u64x4 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        u64x4 { avx2: abs_i32_m256i(self.avx2) }
+      } else {
+        u64x4 {
+          a : self.a.unsigned_abs(),
+          b : self.b.unsigned_abs(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_float(self) -> f64x4 {
     let arr: [i64; 4] = cast(self);
     cast([arr[0] as f64, arr[1] as f64, arr[2] as f64, arr[3] as f64])

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -318,8 +318,8 @@ impl i64x4 {
         Self { avx2: cast(arr.map( |x| x.wrapping_abs())) }
       } else {
         Self {
-          a : self.a.wrapping_abs(),
-          b : self.b.wrapping_abs(),
+          a : self.a.abs(),
+          b : self.b.abs(),
         }
       }
     }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -315,7 +315,13 @@ impl i64x4 {
       if #[cfg(target_feature="avx2")] {
         // avx x86 doesn't have this builtin
         let arr: [i64; 4] = cast(self);
-        Self { avx2: cast(arr.map( |x| x.wrapping_abs())) }
+        cast(
+          [
+            arr[0].wrapping_abs(),
+            arr[1].wrapping_abs(),
+            arr[2].wrapping_abs(),
+            arr[3].wrapping_abs(),
+          ])
       } else {
         Self {
           a : self.a.abs(),
@@ -332,7 +338,13 @@ impl i64x4 {
       if #[cfg(target_feature="avx2")] {
         // avx x86 doesn't have this builtin
         let arr: [i64; 4] = cast(self);
-        u64x4 { avx2: cast(arr.map( |x| x.unsigned_abs())) }
+        cast(
+          [
+            arr[0].unsigned_abs(),
+            arr[1].unsigned_abs(),
+            arr[2].unsigned_abs(),
+            arr[3].unsigned_abs(),
+          ])
       } else {
         u64x4 {
           a : self.a.unsigned_abs(),

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -311,15 +311,35 @@ impl i64x4 {
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-    // avx x86 doesn't have this builtin
-    Self { a: self.a.abs(), b: self.b.abs() }
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // avx x86 doesn't have this builtin
+        let arr: [i64; 4] = cast(self);
+        Self { avx2: cast(arr.map( |x| x.wrapping_abs())) }
+      } else {
+        Self {
+          a : self.a.wrapping_abs(),
+          b : self.b.wrapping_abs(),
+        }
+      }
+    }
   }
 
   #[inline]
   #[must_use]
   pub fn unsigned_abs(self) -> u64x4 {
-    // avx x86 doesn't have this builtin
-    u64x4 { a: self.a.unsigned_abs(), b: self.b.unsigned_abs() }
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // avx x86 doesn't have this builtin
+        let arr: [i64; 4] = cast(self);
+        u64x4 { avx2: cast(arr.map( |x| x.unsigned_abs())) }
+      } else {
+        u64x4 {
+          a : self.a.unsigned_abs(),
+          b : self.b.unsigned_abs(),
+        }
+      }
+    }
   }
 
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -328,7 +328,7 @@ impl i64x4 {
   pub fn unsigned_abs(self) -> u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        u64x4 { avx2: abs_i32_m256i(self.avx2) }
+        u64x4 { avx2: abs_i64_m256i(self.avx2) }
       } else {
         u64x4 {
           a : self.a.unsigned_abs(),

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -311,29 +311,20 @@ impl i64x4 {
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        Self { avx2: abs_i64_m256i(self.avx2) }
-      } else {
-        Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
-        }
+      // avx x86 doesn't have this builtin
+      Self {
+        a : self.a.abs(),
+        b : self.b.abs(),
       }
-    }
   }
 
   #[inline]
   #[must_use]
   pub fn unsigned_abs(self) -> u64x4 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        u64x4 { avx2: abs_i64_m256i(self.avx2) }
-      } else {
-        u64x4 {
-          a : self.a.unsigned_abs(),
-          b : self.b.unsigned_abs(),
-        }
+      // avx x86 doesn't have this builtin
+      u64x4 {
+        a : self.a.unsigned_abs(),
+        b : self.b.unsigned_abs(),
       }
     }
   }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -311,22 +311,15 @@ impl i64x4 {
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {
-      // avx x86 doesn't have this builtin
-      Self {
-        a : self.a.abs(),
-        b : self.b.abs(),
-      }
+    // avx x86 doesn't have this builtin
+    Self { a: self.a.abs(), b: self.b.abs() }
   }
 
   #[inline]
   #[must_use]
   pub fn unsigned_abs(self) -> u64x4 {
-      // avx x86 doesn't have this builtin
-      u64x4 {
-        a : self.a.unsigned_abs(),
-        b : self.b.unsigned_abs(),
-      }
-    }
+    // avx x86 doesn't have this builtin
+    u64x4 { a: self.a.unsigned_abs(), b: self.b.unsigned_abs() }
   }
 
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -537,7 +537,7 @@ impl i8x16 {
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: i8x16_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vabsq_s8(self.neon) }}
+        unsafe {Self { neon: vreinterpretq_u8_s8(vabsq_s8(self.neon)) }}
       } else {
         let arr: [i8; 16] = cast(self);
         cast(

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -541,7 +541,24 @@ impl i8x16 {
       } else {
         let arr: [i8; 16] = cast(self);
         cast(
-          arr.map(|x| x.unsigned_abs()))
+          [
+            arr[0].unsigned_abs(),
+            arr[1].unsigned_abs(),
+            arr[2].unsigned_abs(),
+            arr[3].unsigned_abs(),
+            arr[4].unsigned_abs(),
+            arr[5].unsigned_abs(),
+            arr[6].unsigned_abs(),
+            arr[7].unsigned_abs(),
+            arr[8].unsigned_abs(),
+            arr[9].unsigned_abs(),
+            arr[10].unsigned_abs(),
+            arr[11].unsigned_abs(),
+            arr[12].unsigned_abs(),
+            arr[13].unsigned_abs(),
+            arr[14].unsigned_abs(),
+            arr[15].unsigned_abs(),
+            ])
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -530,14 +530,14 @@ impl i8x16 {
 
   #[inline]
   #[must_use]
-  pub fn unsigned_abs(self) -> Self {
+  pub fn unsigned_abs(self) -> u8x16 {
     pick! {
       if #[cfg(target_feature="ssse3")] {
-        Self { sse: abs_i8_m128i(self.sse) }
+        u8x16 { sse: abs_i8_m128i(self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: i8x16_abs(self.simd) }
+        u8x16 { simd: i8x16_abs(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vreinterpretq_u8_s8(vabsq_s8(self.neon)) }}
+        unsafe { u8x16 { neon: vreinterpretq_u8_s8(vabsq_s8(self.neon)) }}
       } else {
         let arr: [i8; 16] = cast(self);
         cast(

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -527,6 +527,25 @@ impl i8x16 {
       }
     }
   }
+
+  #[inline]
+  #[must_use]
+  pub fn unsigned_abs(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        Self { sse: abs_i8_m128i(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i8x16_abs(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vabsq_s8(self.neon) }}
+      } else {
+        let arr: [i8; 16] = cast(self);
+        cast(
+          arr.map(|x| x.unsigned_abs()))
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -949,6 +949,17 @@ pub trait CmpLe<Rhs = Self> {
   fn cmp_le(self, rhs: Rhs) -> Self::Output;
 }
 
+pub trait MulScaleRound<Rhs = Self> {
+  /// Multiply and scale equivilent to ((self * rhs) + 0x4000) >> 15 on each
+  /// lane, effectively multiplying by a 16 bit fixed point number between -1
+  /// and 1. This corresponds to the following instructions:
+  /// - vqrdmulhq_n_s16 instruction on neon
+  /// - i16x8_q15mulr_sat on simd128
+  /// - _mm_mulhrs_epi16 on ssse3
+  /// - emulated via mul_i16_* on sse2
+  fn mul_scale_round(self, rhs: Rhs) -> Self;
+}
+
 macro_rules! bulk_impl_const_rhs_op {
   (($op:ident,$method:ident) => [$(($lhs:ty,$rhs:ty),)+]) => {
     $(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -949,17 +949,6 @@ pub trait CmpLe<Rhs = Self> {
   fn cmp_le(self, rhs: Rhs) -> Self::Output;
 }
 
-pub trait MulScaleRound<Rhs = Self> {
-  /// Multiply and scale equivilent to ((self * rhs) + 0x4000) >> 15 on each
-  /// lane, effectively multiplying by a 16 bit fixed point number between -1
-  /// and 1. This corresponds to the following instructions:
-  /// - vqrdmulhq_n_s16 instruction on neon
-  /// - i16x8_q15mulr_sat on simd128
-  /// - _mm_mulhrs_epi16 on ssse3
-  /// - emulated via mul_i16_* on sse2
-  fn mul_scale_round(self, rhs: Rhs) -> Self;
-}
-
 macro_rules! bulk_impl_const_rhs_op {
   (($op:ident,$method:ident) => [$(($lhs:ty,$rhs:ty),)+]) => {
     $(

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -4,13 +4,13 @@ pick! {
   if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct u16x8 { sse: m128i }
+    pub struct u16x8 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct u16x8 { simd: v128 }
+    pub struct u16x8 { pub(crate) simd: v128 }
 
     impl Default for u16x8 {
       fn default() -> Self {
@@ -29,7 +29,7 @@ pick! {
       use core::arch::aarch64::*;
       #[repr(C)]
       #[derive(Copy, Clone)]
-      pub struct u16x8 { neon : uint16x8_t }
+      pub struct u16x8 { pub(crate) neon : uint16x8_t }
 
       impl Default for u16x8 {
         #[inline]
@@ -51,7 +51,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct u16x8 { arr: [u16;8] }
+    pub struct u16x8 { pub(crate) arr: [u16;8] }
   }
 }
 

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -4,13 +4,13 @@ pick! {
   if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct u32x4 { sse: m128i }
+    pub struct u32x4 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct u32x4 { simd: v128 }
+    pub struct u32x4 { pub(crate) simd: v128 }
 
     impl Default for u32x4 {
       fn default() -> Self {
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u32x4 { neon : uint32x4_t }
+    pub struct u32x4 { pub(crate) neon : uint32x4_t }
 
     impl Default for u32x4 {
       #[inline]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -4,7 +4,7 @@ pick! {
   if #[cfg(target_feature="avx2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u32x8 { avx2: m256i }
+    pub struct u32x8 { pub(crate) avx2: m256i }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u32x8 { a : u32x4, b : u32x4 }
+    pub struct u32x8 { pub(crate) a : u32x4, pub(crate) b : u32x4 }
   }
 }
 

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -4,13 +4,13 @@ pick! {
   if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct u64x2 { sse: m128i }
+    pub struct u64x2 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct u64x2 { simd: v128 }
+    pub struct u64x2 { pub(crate) simd: v128 }
 
     impl Default for u64x2 {
       fn default() -> Self {
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u64x2 { neon : uint64x2_t }
+    pub struct u64x2 { pub(crate) neon : uint64x2_t }
 
     impl Default for u64x2 {
       #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u64x4 { a : u64x2, b : u64x2 }
+    pub struct u64x4 { pub(crate) a : u64x2, pub(crate) b : u64x2 }
   }
 }
 

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -4,7 +4,7 @@ pick! {
   if #[cfg(target_feature="avx2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u64x4 { avx2: m256i }
+    pub struct u64x4 { pub(crate) avx2: m256i }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -10,7 +10,7 @@ pick! {
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct u8x16 { simd: v128 }
+    pub struct u8x16 { pub(crate) simd: v128 }
 
     impl Default for u8x16 {
       fn default() -> Self {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u8x16 { neon : uint8x16_t }
+    pub struct u8x16 { pub(crate) neon : uint8x16_t }
 
     impl Default for u8x16 {
       #[inline]
@@ -51,7 +51,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct u8x16 { arr: [u8;16] }
+    pub struct u8x16 { pub(crate) arr: [u8;16] }
   }
 }
 

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -213,6 +213,14 @@ fn impl_i16x8_abs() {
 }
 
 #[test]
+fn impl_i16x8_unsigned_abs() {
+  let a = i16x8::from([1, -2, 3, -4, 5, -6, -7, i16::MIN]);
+  let expected = u16x8::from([1, 2, 3, 4, 5, 6, 7, i16::MIN as u16]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i16x8_max() {
   let a = i16x8::from([1, 2, 3, 4, 5, 6, i16::MIN + 1, i16::MIN]);
   let b = i16x8::from([17, -18, 190, -20, 21, -22, 1, 1]);

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -131,6 +131,14 @@ fn impl_i32x4_abs() {
 }
 
 #[test]
+fn impl_i32x4_unsigned_abs() {
+  let a = i32x4::from([-1, 2, -3, i32::MIN]);
+  let expected = u32x4::from([1, 2, 3, i32::MIN as u32]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i32x4_max() {
   let a = i32x4::from([1, 2, i32::MIN + 1, i32::MIN]);
   let b = i32x4::from([17, -18, 1, 1]);

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -148,6 +148,14 @@ fn impl_i32x8_abs() {
 }
 
 #[test]
+fn impl_i32x8_unsigned_abs() {
+  let a = i32x8::from([-1, 2, -3, i32::MIN, 6, -15, -19, 9]);
+  let expected = u32x8::from([1, 2, 3, i32::MIN as u32, 6, 15, 19, 9]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i32x8_max() {
   let a = i32x8::from([1, 2, i32::MIN + 1, i32::MIN, 6, -8, 12, 9]);
   let b = i32x8::from([17, -18, 1, 1, 19, -5, -1, -9]);

--- a/tests/all_tests/t_i64x2.rs
+++ b/tests/all_tests/t_i64x2.rs
@@ -81,6 +81,22 @@ fn impl_i64x2_blend() {
 }
 
 #[test]
+fn impl_i64x2_abs() {
+  let a = i64x2::from([-1, i64::MIN]);
+  let expected = i64x2::from([1, i64::MIN]);
+  let actual = a.abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_i64x2_unsigned_abs() {
+  let a = i64x2::from([-1, i64::MIN]);
+  let expected = u64x2::from([1, i64::MIN as u64]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i64x2_cmp_eq() {
   let a = i64x2::from([1_i64, 4]);
   let b = i64x2::from([3_i64, 4]);

--- a/tests/all_tests/t_i64x4.rs
+++ b/tests/all_tests/t_i64x4.rs
@@ -98,6 +98,22 @@ fn impl_i64x4_blend() {
 }
 
 #[test]
+fn impl_i64x4_abs() {
+  let a = i64x4::from([-1, 2, -3, i64::MIN]);
+  let expected = i64x4::from([1, 2, 3, i64::MIN]);
+  let actual = a.abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_i64x4_unsigned_abs() {
+  let a = i64x4::from([-1, 2, -3, i64::MIN]);
+  let expected = u64x4::from([1, 2, 3, i64::MIN as u64]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i64x4_cmp_eq() {
   let a = i64x4::from([1_i64, 4, i64::MAX, 5]);
   let b = i64x4::from([3_i64, 4, i64::MAX, 1]);

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -225,6 +225,48 @@ fn impl_i8x16_abs() {
 }
 
 #[test]
+fn impl_i8x16_unsigned_abs() {
+  let a = i8x16::from([
+    -1,
+    2,
+    -3,
+    4,
+    5,
+    -6,
+    7,
+    8,
+    9,
+    -10,
+    -11,
+    12,
+    13,
+    -14,
+    -126,
+    i8::MIN,
+  ]);
+  let expected = u8x16::from([
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    126,
+    i8::MIN as u8,
+  ]);
+  let actual = a.unsigned_abs();
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_i8x16_max() {
   let a =
     i8x16::from([10, 2, -3, 4, 5, -6, 7, 8, 9, 7, -11, 12, 13, 6, 55, i8::MIN]);


### PR DESCRIPTION
Add equivalent unsigned_abs that will not fail and returns the proper unsigned integer type. It's possible to do something similar with bitmuck and casts but the code looks horrible. Also added abs to i64 although intel doesn't support it, the other platforms do.