### PR TITLE
Implement variable shift left/right and ease of test coverage with generic trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -976,17 +976,8 @@ pub trait SimdType<T, const N: usize> {
   #[must_use]
   fn from_array(array: [T; N]) -> Self;
 
-  /// Performs a binary operation corresponding elements
-  /// on two SIMD types and returns the result.
-  ///
-  /// This is useful for implementing
-  /// operations that the compiler vectorizes but this library
-  /// don't provide explicit support  for.
-  fn binary_op<FN: Fn(T, T) -> T>(self, rhs: Self, op: FN) -> Self;
-
-  /// performs a unary operation on each element of the SIMD type
-  /// and returns the result.
-  fn unary_op<FN: Fn(T) -> T>(self, op: FN) -> Self;
+  /// provide same functionarlity as array from_fn
+  fn from_fn<F: Fn(usize) -> T>(cb: F) -> Self;
 }
 
 macro_rules! bulk_impl_const_rhs_op {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -977,7 +977,7 @@ pub trait SimdType<T, const N: usize> {
   fn from_array(array: [T; N]) -> Self;
 
   /// provide same functionarlity as array from_fn
-  fn from_fn<F: Fn(usize) -> T>(cb: F) -> Self;
+  fn from_fn<F: FnMut(usize) -> T>(cb: F) -> Self;
 }
 
 macro_rules! bulk_impl_const_rhs_op {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,6 +953,42 @@ pub trait CmpLe<Rhs = Self> {
   fn cmp_le(self, rhs: Rhs) -> Self::Output;
 }
 
+/// Common trait similar to portable SIMD library to make it easier to
+/// write tests or other generic code that work with all defined SIMD types
+/// Also makes porting to eventual portable SIMD library easier for generic code
+pub trait SimdType<T, const N: usize> {
+  const LEN: usize = N;
+
+  #[must_use]
+  fn len(&self) -> usize {
+    N
+  }
+
+  #[must_use]
+  fn splat(value: T) -> Self;
+
+  #[must_use]
+  fn as_array(&self) -> &[T; N];
+
+  #[must_use]
+  fn as_mut_array(&mut self) -> &mut [T; N];
+
+  #[must_use]
+  fn from_array(array: [T; N]) -> Self;
+
+  /// Performs a binary operation corresponding elements
+  /// on two SIMD types and returns the result.
+  ///
+  /// This is useful for implementing
+  /// operations that the compiler vectorizes but this library
+  /// don't provide explicit support  for.
+  fn binary_op<FN: Fn(T, T) -> T>(self, rhs: Self, op: FN) -> Self;
+
+  /// performs a unary operation on each element of the SIMD type
+  /// and returns the result.
+  fn unary_op<FN: Fn(T) -> T>(self, op: FN) -> Self;
+}
+
 macro_rules! bulk_impl_const_rhs_op {
   (($op:ident,$method:ident) => [$(($lhs:ty,$rhs:ty),)+]) => {
     $(

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -546,15 +546,7 @@ impl SimdType<u32, 4> for u32x4 {
   }
 
   #[inline]
-  fn binary_op<FN: Fn(u32, u32) -> u32>(self, rhs: Self, op: FN) -> Self {
-    let a: [u32; 4] = cast(self);
-    let b: [u32; 4] = cast(rhs);
-    cast([op(a[0], b[0]), op(a[1], b[1]), op(a[2], b[2]), op(a[3], b[3])])
-  }
-
-  #[inline]
-  fn unary_op<FN: Fn(u32) -> u32>(self, op: FN) -> Self {
-    let a: [u32; 4] = cast(self);
-    cast([op(a[0]), op(a[1]), op(a[2]), op(a[3])])
+  fn from_fn<F: Fn(usize) -> u32>(cb: F) -> Self {
+    cast([cb(0), cb(1), cb(2), cb(3)])
   }
 }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -332,8 +332,8 @@ impl Shl<u32x4> for u32x4 {
         Self { sse: shl_each_u32_m128i(self.sse, shift_by) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {
-        // mask the shift count to 31 to have same behavior on all platforms
-        let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
+          // mask the shift count to 31 to have same behavior on all platforms
+          let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
           Self { neon: vshlq_u32(self.neon, shift_by) }
         }
       } else {
@@ -361,8 +361,8 @@ impl Shr<u32x4> for u32x4 {
         Self { sse: shr_each_u32_m128i(self.sse, shift_by) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {
-        // mask the shift count to 31 to have same behavior on all platforms
-        let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
+          // mask the shift count to 31 to have same behavior on all platforms
+          let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
           Self { neon: vshlq_u32(self.neon, shift_by) }
         }
       } else {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -264,6 +264,7 @@ macro_rules! impl_shl_t_for_u32x4 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for u32x4 {
       type Output = Self;
+      /// Shifts all lanes by the value given.
       #[inline]
       #[must_use]
       fn shl(self, rhs: $shift_type) -> Self::Output {
@@ -295,6 +296,7 @@ macro_rules! impl_shr_t_for_u32x4 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shr<$shift_type> for u32x4 {
       type Output = Self;
+      /// Shifts all lanes by the value given.
       #[inline]
       #[must_use]
       fn shr(self, rhs: $shift_type) -> Self::Output {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -333,7 +333,7 @@ impl Shl<u32x4> for u32x4 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {
           // mask the shift count to 31 to have same behavior on all platforms
-          let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
+          let shift_by = vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31)));
           Self { neon: vshlq_u32(self.neon, shift_by) }
         }
       } else {
@@ -362,6 +362,7 @@ impl Shr<u32x4> for u32x4 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {
           // mask the shift count to 31 to have same behavior on all platforms
+          // no right shift, have to pass negative value to left shift on neon
           let shift_by = vnegq_s32(vreinterpretq_s32_u32(vandq_u32(rhs.neon, vmovq_n_u32(31))));
           Self { neon: vshlq_u32(self.neon, shift_by) }
         }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -546,7 +546,7 @@ impl SimdType<u32, 4> for u32x4 {
   }
 
   #[inline]
-  fn from_fn<F: Fn(usize) -> u32>(cb: F) -> Self {
+  fn from_fn<F: FnMut(usize) -> u32>(mut cb: F) -> Self {
     cast([cb(0), cb(1), cb(2), cb(3)])
   }
 }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -359,33 +359,7 @@ impl SimdType<u32, 8> for u32x8 {
   }
 
   #[inline]
-  fn binary_op<FN: Fn(u32, u32) -> u32>(self, rhs: Self, op: FN) -> Self {
-    let a: [u32; 8] = cast(self);
-    let b: [u32; 8] = cast(rhs);
-    cast([
-      op(a[0], b[0]),
-      op(a[1], b[1]),
-      op(a[2], b[2]),
-      op(a[3], b[3]),
-      op(a[4], b[4]),
-      op(a[5], b[5]),
-      op(a[6], b[6]),
-      op(a[7], b[7]),
-    ])
-  }
-
-  #[inline]
-  fn unary_op<FN: Fn(u32) -> u32>(self, op: FN) -> Self {
-    let a: [u32; 8] = cast(self);
-    cast([
-      op(a[0]),
-      op(a[1]),
-      op(a[2]),
-      op(a[3]),
-      op(a[4]),
-      op(a[5]),
-      op(a[6]),
-      op(a[7]),
-    ])
+  fn from_fn<F: Fn(usize) -> u32>(cb: F) -> Self {
+    cast([cb(0), cb(1), cb(2), cb(3), cb(4), cb(5), cb(6), cb(7)])
   }
 }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -276,7 +276,7 @@ impl u32x8 {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
+        Self { avx2: max_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
           a : self.a.max(rhs.a),
@@ -290,7 +290,7 @@ impl u32x8 {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
+        Self { avx2: min_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
           a : self.a.min(rhs.a),

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -181,7 +181,9 @@ impl Shr<u32x8> for u32x8 {
   fn shr(self, rhs: u32x8) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: shr_each_u32_m256i(self.avx2, rhs.avx2) }
+        // ensure same behavior as scalar
+        let shift_by = bitand_m256i(rhs.avx2, set_splat_i32_m256i(31));
+        Self { avx2: shr_each_u32_m256i(self.avx2, shift_by ) }
       } else {
         Self {
           a : self.a.shr(rhs.a),
@@ -197,7 +199,9 @@ impl Shl<u32x8> for u32x8 {
   fn shl(self, rhs: u32x8) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: shl_each_u32_m256i(self.avx2, rhs.avx2) }
+        // ensure same behavior as scalar
+        let shift_by = bitand_m256i(rhs.avx2, set_splat_i32_m256i(31));
+        Self { avx2: shl_each_u32_m256i(self.avx2, shift_by) }
       } else {
         Self {
           a : self.a.shl(rhs.a),

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -359,7 +359,7 @@ impl SimdType<u32, 8> for u32x8 {
   }
 
   #[inline]
-  fn from_fn<F: Fn(usize) -> u32>(cb: F) -> Self {
+  fn from_fn<F: FnMut(usize) -> u32>(mut cb: F) -> Self {
     cast([cb(0), cb(1), cb(2), cb(3), cb(4), cb(5), cb(6), cb(7)])
   }
 }

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unnecessary_cast)]
 #![allow(clippy::assertions_on_constants)]
 
+mod t_common;
 mod t_f32x4;
 mod t_f32x8;
 mod t_f64x2;

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -1,7 +1,8 @@
 use wide::SimdType;
 
-/// Performs a binary operation both in scalar and vector form and compares the results.
-/// This makes it less error prone to test the binary operations and makes it easier to add new tests.
+/// Performs a binary operation both in scalar and vector form and compares the
+/// results. This makes it less error prone to test the binary operations and
+/// makes it easier to add new tests.
 pub fn test_binary_op<
   T: SimdType<V, N> + Default + PartialEq + std::fmt::Debug + Copy,
   V: Copy,

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -22,10 +22,16 @@ pub fn test_binary_op<
   let actual = fn_vector(a, b);
 
   // assert equality for manually calculated result
-  assert_eq!(expected, actual);
+  assert_eq!(expected, actual, "scalar={:?} vector={:?}", expected, actual);
 
   // assert equality using the binary_op method as well
-  assert_eq!(expected, a.binary_op(b, fn_scalar))
+  assert_eq!(
+    expected,
+    a.binary_op(b, fn_scalar),
+    "scalar={:?} binary_op={:?}",
+    expected,
+    actual
+  );
 }
 
 pub fn test_unary_op<
@@ -47,8 +53,14 @@ pub fn test_unary_op<
   let actual = fn_vector(a);
 
   // assert equality for manually calculated result
-  assert_eq!(expected, actual);
+  assert_eq!(expected, actual, "scalar={:?} vector={:?}", expected, actual);
 
   // assert equality using the unary_op method as well
-  assert_eq!(expected, a.unary_op(fn_scalar))
+  assert_eq!(
+    expected,
+    a.unary_op(fn_scalar),
+    "scalar={:?} unary_op={:?}",
+    expected,
+    actual
+  );
 }

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -49,6 +49,6 @@ pub fn test_unary_op<
   // assert equality for manually calculated result
   assert_eq!(expected, actual);
 
-  // assert equality using the binary_op method as well
+  // assert equality using the unary_op method as well
   assert_eq!(expected, a.unary_op(fn_scalar))
 }

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -1,0 +1,54 @@
+use wide::SimdType;
+
+/// Performs a binary operation both in scalar and vector form and compares the results.
+/// This makes it less error prone to test the binary operations and makes it easier to add new tests.
+pub fn test_binary_op<
+  T: SimdType<V, N> + Default + PartialEq + std::fmt::Debug + Copy,
+  V: Copy,
+  FnVector: Fn(T, T) -> T,
+  FnScalar: Fn(V, V) -> V,
+  const N: usize,
+>(
+  a: T,
+  b: T,
+  fn_scalar: FnScalar,
+  fn_vector: FnVector,
+) {
+  let mut expected = T::default();
+  for i in 0..N {
+    expected.as_mut_array()[i] = fn_scalar(a.as_array()[i], b.as_array()[i]);
+  }
+
+  let actual = fn_vector(a, b);
+
+  // assert equality for manually calculated result
+  assert_eq!(expected, actual);
+
+  // assert equality using the binary_op method as well
+  assert_eq!(expected, a.binary_op(b, fn_scalar))
+}
+
+pub fn test_unary_op<
+  T: SimdType<V, N> + Default + PartialEq + std::fmt::Debug + Copy,
+  V: Copy,
+  FnVector: Fn(T) -> T,
+  FnScalar: Fn(V) -> V,
+  const N: usize,
+>(
+  a: T,
+  fn_scalar: FnScalar,
+  fn_vector: FnVector,
+) {
+  let mut expected = T::default();
+  for i in 0..N {
+    expected.as_mut_array()[i] = fn_scalar(a.as_array()[i]);
+  }
+
+  let actual = fn_vector(a);
+
+  // assert equality for manually calculated result
+  assert_eq!(expected, actual);
+
+  // assert equality using the binary_op method as well
+  assert_eq!(expected, a.unary_op(fn_scalar))
+}

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -15,29 +15,17 @@ pub fn test_binary_op<
   fn_scalar: FnScalar,
   fn_vector: FnVector,
 ) {
-  let mut expected = T::default();
-  for i in 0..N {
-    expected.as_mut_array()[i] = fn_scalar(a.as_array()[i], b.as_array()[i]);
-  }
+  let expected = T::from_fn(|i| fn_scalar(a.as_array()[i], b.as_array()[i]));
 
   let actual = fn_vector(a, b);
 
   // assert equality for manually calculated result
   assert_eq!(expected, actual, "scalar={:?} vector={:?}", expected, actual);
-
-  // assert equality using the binary_op method as well
-  assert_eq!(
-    expected,
-    a.binary_op(b, fn_scalar),
-    "scalar={:?} binary_op={:?}",
-    expected,
-    actual
-  );
 }
 
 pub fn test_unary_op<
-  T: SimdType<V, N> + Default + PartialEq + std::fmt::Debug + Copy,
-  V: Copy,
+  T: SimdType<V, N> + PartialEq + std::fmt::Debug + Copy,
+  V: Copy + PartialEq + std::fmt::Debug,
   FnVector: Fn(T) -> T,
   FnScalar: Fn(V) -> V,
   const N: usize,
@@ -46,22 +34,14 @@ pub fn test_unary_op<
   fn_scalar: FnScalar,
   fn_vector: FnVector,
 ) {
-  let mut expected = T::default();
+  let expected = T::from_fn(|i| fn_scalar(a.as_array()[i]));
+  // ensure that the elements got put in the right place
   for i in 0..N {
-    expected.as_mut_array()[i] = fn_scalar(a.as_array()[i]);
+    assert_eq!(expected.as_array()[i], fn_scalar(a.as_array()[i]));
   }
 
   let actual = fn_vector(a);
 
   // assert equality for manually calculated result
   assert_eq!(expected, actual, "scalar={:?} vector={:?}", expected, actual);
-
-  // assert equality using the unary_op method as well
-  assert_eq!(
-    expected,
-    a.unary_op(fn_scalar),
-    "scalar={:?} unary_op={:?}",
-    expected,
-    actual
-  );
 }

--- a/tests/all_tests/t_common.rs
+++ b/tests/all_tests/t_common.rs
@@ -5,7 +5,7 @@ use wide::SimdType;
 /// makes it easier to add new tests.
 pub fn test_binary_op<
   T: SimdType<V, N> + Default + PartialEq + std::fmt::Debug + Copy,
-  V: Copy,
+  V: Copy + PartialEq + std::fmt::Debug,
   FnVector: Fn(T, T) -> T,
   FnScalar: Fn(V, V) -> V,
   const N: usize,
@@ -16,6 +16,13 @@ pub fn test_binary_op<
   fn_vector: FnVector,
 ) {
   let expected = T::from_fn(|i| fn_scalar(a.as_array()[i], b.as_array()[i]));
+  // ensure that the elements got put in the right place
+  for i in 0..N {
+    assert_eq!(
+      expected.as_array()[i],
+      fn_scalar(a.as_array()[i], b.as_array()[i])
+    );
+  }
 
   let actual = fn_vector(a, b);
 

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -145,7 +145,7 @@ fn impl_u32x4_min() {
 #[test]
 fn impl_u32x4_shr_all() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
-  let shift = u32x4::from([1, 30, 8, 33 /*test masking behavior */]);
+  let shift = u32x4::from([1, 30, 8, 33 /* test masking behavior */]);
 
   crate::t_common::test_binary_op(
     a,
@@ -157,7 +157,7 @@ fn impl_u32x4_shr_all() {
 #[test]
 fn impl_u32x4_shl_all() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
-  let shift = u32x4::from([1, 30, 8, 33 /*test masking behavior */]);
+  let shift = u32x4::from([1, 30, 8, 33 /* test masking behavior */]);
 
   crate::t_common::test_binary_op(
     a,

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -145,16 +145,26 @@ fn impl_u32x4_min() {
 #[test]
 fn impl_u32x4_shr_all() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
-  let shift = u32x4::from([1, 30, 8, 14]);
+  let shift = u32x4::from([1, 30, 8, 33 /*test masking behavior */]);
 
-  crate::t_common::test_binary_op(a, shift, |a, b| a >> b, |a, b| a >> b);
+  crate::t_common::test_binary_op(
+    a,
+    shift,
+    |a, b| a.wrapping_shr(b),
+    |a, b| a >> b,
+  );
 }
 #[test]
 fn impl_u32x4_shl_all() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
-  let shift = u32x4::from([1, 30, 8, 14]);
+  let shift = u32x4::from([1, 30, 8, 33 /*test masking behavior */]);
 
-  crate::t_common::test_binary_op(a, shift, |a, b| a << b, |a, b| a << b);
+  crate::t_common::test_binary_op(
+    a,
+    shift,
+    |a, b| a.wrapping_shl(b),
+    |a, b| a << b,
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -141,3 +141,18 @@ fn impl_u32x4_min() {
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn impl_u32x4_shr_all() {
+  let a = u32x4::from([15313, 52322, u32::MAX, 4]);
+  let shift = u32x4::from([1, 30, 8, 14]);
+
+  crate::t_common::test_binary_op(a, shift, |a, b| a >> b, |a, b| a >> b);
+}
+#[test]
+fn impl_u32x4_shl_all() {
+  let a = u32x4::from([15313, 52322, u32::MAX, 4]);
+  let shift = u32x4::from([1, 30, 8, 14]);
+
+  crate::t_common::test_binary_op(a, shift, |a, b| a << b, |a, b| a << b);
+}

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -143,7 +143,7 @@ fn impl_u32x4_min() {
 }
 
 #[test]
-fn impl_u32x4_shr_all() {
+fn impl_u32x4_shr_each() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
   let shift = u32x4::from([1, 30, 8, 33 /* test masking behavior */]);
 
@@ -155,7 +155,7 @@ fn impl_u32x4_shr_all() {
   );
 }
 #[test]
-fn impl_u32x4_shl_all() {
+fn impl_u32x4_shl_each() {
   let a = u32x4::from([15313, 52322, u32::MAX, 4]);
   let shift = u32x4::from([1, 30, 8, 33 /* test masking behavior */]);
 

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -156,3 +156,10 @@ fn impl_u32x4_shl_all() {
 
   crate::t_common::test_binary_op(a, shift, |a, b| a << b, |a, b| a << b);
 }
+
+#[test]
+fn impl_u32x4_not() {
+  let a = u32x4::from([15313, 52322, u32::MAX, 4]);
+
+  crate::t_common::test_unary_op(a, |a| !a, |a| !a);
+}

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -140,7 +140,7 @@ fn impl_u32x8_min() {
 }
 
 #[test]
-fn impl_u32x8_shr_all() {
+fn impl_u32x8_shr_each() {
   let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
   let shift =
     u32x8::from([1, 2, 3, 4, 5, 6, 33 /* test masking behavior */, 31]);
@@ -154,7 +154,7 @@ fn impl_u32x8_shr_all() {
 }
 
 #[test]
-fn impl_u32x8_shl_all() {
+fn impl_u32x8_shl_each() {
   let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
   let shift =
     u32x8::from([1, 2, 3, 4, 5, 6, 33 /* test masking behavior */, 31]);

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -156,7 +156,7 @@ fn impl_u32x8_shl_all() {
 }
 
 #[test]
-fn impl_u32_not() {
+fn impl_u32x8_not() {
   let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
 
   crate::t_common::test_unary_op(a, |a| !a, |a| !a);

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -48,108 +48,116 @@ fn impl_mul_for_u32x8() {
 fn impl_bitand_for_u32x8() {
   let a = u32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
   let b = u32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = u32x8::from([0, 0, 0, 1, 0, 0, 0, 1]);
-  let actual = a & b;
-  assert_eq!(expected, actual);
+
+  crate::t_common::test_binary_op(a, b, |a, b| a & b, |a, b| a & b);
 }
 
 #[test]
 fn impl_bitor_for_u32x8() {
-  let a = i32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i32x8::from([0, 1, 1, 1, 1, 1, 1, 1]);
-  let actual = a | b;
-  assert_eq!(expected, actual);
+  let a = u32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = u32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
+
+  crate::t_common::test_binary_op(a, b, |a, b| a | b, |a, b| a | b);
 }
 
 #[test]
 fn impl_bitxor_for_u32x8() {
-  let a = i32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i32x8::from([0, 1, 1, 0, 1, 1, 1, 0]);
-  let actual = a ^ b;
-  assert_eq!(expected, actual);
+  let a = u32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = u32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
+
+  crate::t_common::test_binary_op(a, b, |a, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
 fn impl_shl_for_u32x8() {
-  let a = i32x8::from([1, 2, i32::MAX - 1, i32::MAX - 1, 128, 255, 590, 5667]);
+  let a =
+    u32x8::from([1, 2, u32::MAX - 1, i32::MAX as u32 - 1, 128, 255, 590, 5667]);
   let b = 2;
-  let expected = i32x8::from([
-    1 << 2,
-    2 << 2,
-    (i32::MAX - 1) << 2,
-    (i32::MAX - 1) << 2,
-    128 << 2,
-    255 << 2,
-    590 << 2,
-    5667 << 2,
-  ]);
-  let actual = a << b;
-  assert_eq!(expected, actual);
+
+  crate::t_common::test_unary_op(a, |a| a << b, |a| a << b);
 }
 
 #[test]
 fn impl_shr_for_u32x8() {
-  let a = i32x8::from([1, 2, i32::MAX - 1, i32::MAX - 1, 128, 255, 590, 5667]);
+  let a =
+    u32x8::from([1, 2, u32::MAX - 1, i32::MAX as u32 - 1, 128, 255, 590, 5667]);
   let b = 2;
-  let expected = i32x8::from([
-    1 >> 2,
-    2 >> 2,
-    (i32::MAX - 1) >> 2,
-    (i32::MAX - 1) >> 2,
-    128 >> 2,
-    255 >> 2,
-    590 >> 2,
-    5667 >> 2,
-  ]);
-  let actual = a >> b;
-  assert_eq!(expected, actual);
+
+  crate::t_common::test_unary_op(a, |a| a >> b, |a| a >> b);
 }
 
 #[test]
 fn impl_u32x8_cmp_eq() {
-  let a = i32x8::from([1, 2, 3, 4, 2, 1, 8, 2]);
-  let b = i32x8::from([2_i32; 8]);
-  let expected = i32x8::from([0, -1, 0, 0, -1, 0, 0, -1]);
-  let actual = a.cmp_eq(b);
-  assert_eq!(expected, actual);
+  let a = u32x8::from([1, 2, 3, 4, 2, 1, 8, 2]);
+  let b = u32x8::from([2_u32; 8]);
+
+  crate::t_common::test_binary_op(
+    a,
+    b,
+    |a, b| if a == b { u32::MAX } else { 0 },
+    |a, b| a.cmp_eq(b),
+  );
 }
 
 #[test]
 fn impl_u32x8_cmp_gt() {
-  let a = i32x8::from([1, 2, 9, 4, 1, 2, 8, 10]);
-  let b = i32x8::from([5_i32; 8]);
-  let expected = i32x8::from([0, 0, -1, 0, 0, 0, -1, -1]);
-  let actual = a.cmp_gt(b);
-  assert_eq!(expected, actual);
+  let a = u32x8::from([1, 2, 9, 4, 1, 2, 8, 10]);
+  let b = u32x8::from([5_u32; 8]);
+
+  crate::t_common::test_binary_op(
+    a,
+    b,
+    |a, b| if a > b { u32::MAX } else { 0 },
+    |a, b| a.cmp_gt(b),
+  );
 }
 
 #[test]
 fn impl_u32x8_blend() {
-  let use_t: i32 = -1;
-  let t = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
-  let f = i32x8::from([17, 18, 19, 20, 25, 30, 50, 90]);
-  let mask = i32x8::from([use_t, 0, use_t, 0, 0, 0, 0, use_t]);
-  let expected = i32x8::from([1, 18, 3, 20, 25, 30, 50, 8]);
+  let use_t: u32 = u32::MAX;
+  let t = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+  let f = u32x8::from([17, 18, 19, 20, 25, 30, 50, 90]);
+  let mask = u32x8::from([use_t, 0, use_t, 0, 0, 0, 0, use_t]);
+  let expected = u32x8::from([1, 18, 3, 20, 25, 30, 50, 8]);
   let actual = mask.blend(t, f);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_u32x8_max() {
-  let a = i32x8::from([1, 2, i32::MIN + 1, i32::MIN, 6, -8, 12, 9]);
-  let b = i32x8::from([17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i32x8::from([17, 2, 1, 1, 19, -5, 12, 9]);
-  let actual = a.max(b);
-  assert_eq!(expected, actual);
+  let a = u32x8::from([1, 2, u32::MAX, i32::MAX as u32, 6, 8, 12, 9]);
+  let b = u32x8::from([17, 18, 1, 1, 19, 0, 1, u32::MAX]);
+
+  crate::t_common::test_binary_op(a, b, |a, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
 fn impl_u32x8_min() {
-  let a = i32x8::from([1, 2, i32::MIN + 1, i32::MIN, 6, -8, 12, 9]);
-  let b = i32x8::from([17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i32x8::from([1, -18, i32::MIN + 1, i32::MIN, 6, -8, -1, -9]);
-  let actual = a.min(b);
-  assert_eq!(expected, actual);
+  let a = u32x8::from([1, 2, u32::MAX, i32::MAX as u32, 6, 8, 12, 9]);
+  let b = u32x8::from([17, 18, 1, 1, 19, 0, 1, u32::MAX]);
+
+  crate::t_common::test_binary_op(a, b, |a, b| a.min(b), |a, b| a.min(b));
+}
+
+#[test]
+fn impl_u32x8_shr_all() {
+  let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
+  let shift = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+  crate::t_common::test_binary_op(a, shift, |a, b| a >> b, |a, b| a >> b);
+}
+
+#[test]
+fn impl_u32x8_shl_all() {
+  let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
+  let shift = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+
+  crate::t_common::test_binary_op(a, shift, |a, b| a << b, |a, b| a << b);
+}
+
+#[test]
+fn impl_u32_not() {
+  let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
+
+  crate::t_common::test_unary_op(a, |a| !a, |a| !a);
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -142,17 +142,29 @@ fn impl_u32x8_min() {
 #[test]
 fn impl_u32x8_shr_all() {
   let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
-  let shift = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+  let shift =
+    u32x8::from([1, 2, 3, 4, 5, 6, 33 /* test masking behavior */, 31]);
 
-  crate::t_common::test_binary_op(a, shift, |a, b| a >> b, |a, b| a >> b);
+  crate::t_common::test_binary_op(
+    a,
+    shift,
+    |a, b| a.wrapping_shr(b),
+    |a, b| a >> b,
+  );
 }
 
 #[test]
 fn impl_u32x8_shl_all() {
   let a = u32x8::from([15313, 52322, u32::MAX, 4, 1322, 5, 2552352, 2123]);
-  let shift = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+  let shift =
+    u32x8::from([1, 2, 3, 4, 5, 6, 33 /* test masking behavior */, 31]);
 
-  crate::t_common::test_binary_op(a, shift, |a, b| a << b, |a, b| a << b);
+  crate::t_common::test_binary_op(
+    a,
+    shift,
+    |a, b| a.wrapping_shl(b),
+    |a, b| a << b,
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -329,7 +329,8 @@ fn test_dequantize_and_idct_i32() {
 
 // Example implementation of a branch-free division algorithm using u32x8.
 
-/// Ported from libdivide. Example to show how to use the branchfree division with this library.
+/// Ported from libdivide. Example to show how to use the branchfree division
+/// with this library.
 fn internal_gen_branch_free_u32(d: u32) -> (u32, u32) {
   fn div_rem(a: u64, b: u64) -> (u64, u64) {
     (a / b, a % b)

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -394,7 +394,8 @@ fn branch_free_divide(numerator: u32x8, magic: u32x8, shift: u32x8) -> u32x8 {
   // Returns 32 high bits of the 64 bit result of multiplication of two u32s
   let mul_hi = |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32;
 
-  let q = numerator.binary_op(magic, mul_hi);
+  let q =
+    u32x8::from_fn(|i| mul_hi(numerator.as_array()[i], magic.as_array()[i]));
   let t = ((numerator - q) >> 1) + q;
   t >> shift
 }

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -394,8 +394,7 @@ fn branch_free_divide(numerator: u32x8, magic: u32x8, shift: u32x8) -> u32x8 {
   // Returns 32 high bits of the 64 bit result of multiplication of two u32s
   let mul_hi = |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32;
 
-  let q =
-    u32x8::from_fn(|i| mul_hi(numerator.as_array()[i], magic.as_array()[i]));
+  let q = numerator.binary_op(magic, mul_hi);
   let t = ((numerator - q) >> 1) + q;
   t >> shift
 }


### PR DESCRIPTION
Functionality:
Add new shl / shr to u32x8 and u32x4 that shift by the corresponding number right hand SIMD lane. This is implemented efficiently in AVX2 and Neon. Useful for dividing by constants via algorithms like libdivide. Added example implementation of branch free divide in t_usefulness.

Bug fixes:
Better testing exposed bug u32x8::max and u32x8::min on AVX2 which were calling the signed versions instead of unsigned.

Testing improvements:
Rather than manually calculate the correct scalar scalar output to verify SIMD operations, add a trait similar to the portable Simd library that implements the basic to/from so that the test code can run as a generic instead of copy/pasted. 

I can add this to the other types if you think this is a useful enhancement, but I didn't want to do too much before your getting feedback.