### PR TITLE
fix u32 sign bugs

### DIFF
--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -404,7 +404,7 @@ impl u16x8 {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: max_u8_m128i(self.sse, rhs.sse) }
+        Self { sse: max_u16_m128i(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u16x8_max(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
@@ -430,7 +430,7 @@ impl u16x8 {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: min_u8_m128i(self.sse, rhs.sse) }
+        Self { sse: min_u16_m128i(self.sse, rhs.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u16x8_min(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -355,7 +355,9 @@ impl u32x4 {
   pub fn cmp_gt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        Self { sse: cmp_gt_mask_i32_m128i(self.sse,rhs.sse) }
+        // no unsigned less than so inverting the high bit will get the correct result
+        let h = u32x4::splat(0x80000000);
+        Self { sse: cmp_gt_mask_i32_m128i((self ^ h).sse, (rhs ^ h).sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u32x4_gt(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
@@ -375,7 +377,9 @@ impl u32x4 {
   pub fn cmp_lt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        Self { sse: cmp_lt_mask_i32_m128i(self.sse,rhs.sse) }
+        // no unsigned less than so inverting the high bit will get the correct result
+        let h = u32x4::splat(0x80000000);
+        Self { sse: cmp_lt_mask_i32_m128i((self ^ h).sse, (rhs ^ h).sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u32x4_lt(self.simd, rhs.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -356,7 +356,7 @@ impl u32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         // no unsigned less than so inverting the high bit will get the correct result
-        let h = u32x4::splat(0x80000000);
+        let h = u32x4::splat(1 << 31);
         Self { sse: cmp_gt_mask_i32_m128i((self ^ h).sse, (rhs ^ h).sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: u32x4_gt(self.simd, rhs.simd) }
@@ -375,25 +375,10 @@ impl u32x4 {
   #[inline]
   #[must_use]
   pub fn cmp_lt(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse2")] {
-        // no unsigned less than so inverting the high bit will get the correct result
-        let h = u32x4::splat(0x80000000);
-        Self { sse: cmp_lt_mask_i32_m128i((self ^ h).sse, (rhs ^ h).sse) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd: u32x4_lt(self.simd, rhs.simd) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vcltq_u32(self.neon, rhs.neon) }}
-      } else {
-        Self { arr: [
-          if self.arr[0] < rhs.arr[0] { u32::MAX } else { 0 },
-          if self.arr[1] < rhs.arr[1] { u32::MAX } else { 0 },
-          if self.arr[2] < rhs.arr[2] { u32::MAX } else { 0 },
-          if self.arr[3] < rhs.arr[3] { u32::MAX } else { 0 },
-        ]}
-      }
-    }
+    // lt is just gt the other way around
+    rhs.cmp_gt(self)
   }
+
   #[inline]
   #[must_use]
   pub fn blend(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -201,8 +201,8 @@ impl u32x8 {
   pub fn cmp_gt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        // no unsigned less than so inverting the high bit will get the correct result
-        let highbit = u32x8::splat(0x80000000);
+        // no unsigned gt than so inverting the high bit will get the correct result
+        let highbit = u32x8::splat(1 << 31);
         Self { avx2: cmp_gt_mask_i32_m256i((self ^ highbit).avx2, (rhs ^ highbit).avx2 ) }
       } else {
         Self {
@@ -212,22 +212,14 @@ impl u32x8 {
       }
     }
   }
+
   #[inline]
   #[must_use]
   pub fn cmp_lt(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        // no unsigned less than so inverting the high bit will get the correct result
-        let highbit = u32x8::splat(0x80000000);
-        Self { avx2: cmp_gt_mask_i32_m256i((rhs ^ highbit).avx2, (self ^ highbit).avx2) }
-      } else {
-        Self {
-          a : self.a.cmp_lt(rhs.a),
-          b : self.b.cmp_lt(rhs.b),
-        }
-      }
-    }
+    // lt is just gt the other way around
+    rhs.cmp_gt(self)
   }
+
   #[inline]
   #[must_use]
   pub fn blend(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -201,7 +201,9 @@ impl u32x8 {
   pub fn cmp_gt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2 ) }
+        // no unsigned less than so inverting the high bit will get the correct result
+        let highbit = u32x8::splat(0x80000000);
+        Self { avx2: cmp_gt_mask_i32_m256i((self ^ highbit).avx2, (rhs ^ highbit).avx2 ) }
       } else {
         Self {
           a : self.a.cmp_gt(rhs.a),
@@ -215,7 +217,9 @@ impl u32x8 {
   pub fn cmp_lt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: !cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i32_m256i(self.avx2,rhs.avx2) }
+        // no unsigned less than so inverting the high bit will get the correct result
+        let highbit = u32x8::splat(0x80000000);
+        Self { avx2: cmp_gt_mask_i32_m256i((rhs ^ highbit).avx2, (self ^ highbit).avx2) }
       } else {
         Self {
           a : self.a.cmp_lt(rhs.a),
@@ -244,7 +248,7 @@ impl u32x8 {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
+        Self { avx2: max_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
           a : self.a.max(rhs.a),
@@ -258,7 +262,7 @@ impl u32x8 {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: max_i32_m256i(self.avx2, rhs.avx2 ) }
+        Self { avx2: min_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
           a : self.a.min(rhs.a),

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -258,7 +258,9 @@ impl u64x4 {
   pub fn cmp_gt(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) }
+        // no unsigned gt than so inverting the high bit will get the correct result
+        let highbit = u64x4::splat(1 << 63);
+        Self { avx2: cmp_gt_mask_i64_m256i((self ^ highbit).avx2, (rhs ^ highbit).avx2) }
       } else {
         Self {
           a : self.a.cmp_gt(rhs.a),
@@ -266,6 +268,13 @@ impl u64x4 {
         }
       }
     }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn cmp_lt(self, rhs: Self) -> Self {
+    // lt is just gt the other way around
+    rhs.cmp_gt(self)
   }
 
   #[inline]

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -23,9 +23,11 @@ mod t_u64x4;
 mod t_u8x16;
 mod t_usefulness;
 
-/// Test a vector operation against a scalar operation for random values to make sure that the behavior is the same.
-/// This allows for easier for correctness for various values of the vector.
-/// Uses a simple linear congruential generator to generate random values to avoid pulling in a pile of dependencies.
+/// Test a vector operation against a scalar operation for random values to make
+/// sure that the behavior is the same. This allows for easier for correctness
+/// for various values of the vector. Uses a simple linear congruential
+/// generator to generate random values to avoid pulling in a pile of
+/// dependencies.
 fn test_random_vector_vs_scalar<
   V,
   T,

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -96,3 +96,27 @@ impl GenSample for u8 {
     v as u8
   }
 }
+
+impl GenSample for i64 {
+  fn get_sample(v: u64) -> Self {
+    v as i64
+  }
+}
+
+impl GenSample for i32 {
+  fn get_sample(v: u64) -> Self {
+    v as i32
+  }
+}
+
+impl GenSample for i16 {
+  fn get_sample(v: u64) -> Self {
+    v as i16
+  }
+}
+
+impl GenSample for i8 {
+  fn get_sample(v: u64) -> Self {
+    v as i8
+  }
+}

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -22,3 +22,75 @@ mod t_u64x2;
 mod t_u64x4;
 mod t_u8x16;
 mod t_usefulness;
+
+/// Test a vector operation against a scalar operation for random values to make sure that the behavior is the same.
+/// This allows for easier for correctness for various values of the vector.
+/// Uses a simple linear congruential generator to generate random values to avoid pulling in a pile of dependencies.
+fn test_random_vector_vs_scalar<
+  V,
+  T,
+  FnVec: Fn(V, V) -> V,
+  FnScalar: Fn(T, T) -> T,
+  const N: usize,
+>(
+  vector_fn: FnVec,
+  scalar_fn: FnScalar,
+) where
+  V: From<[T; N]> + Into<[T; N]> + Copy + std::fmt::Debug,
+  T: Copy + PartialEq + std::fmt::Debug + Default + GenSample,
+{
+  let mut a_arr = [T::default(); N];
+  let mut b_arr: [T; N] = [T::default(); N];
+
+  // simple linear congruential generator
+  const A: u64 = 2862933555777941757;
+  const B: u64 = 3037000493;
+  let mut var = 1;
+
+  // do 100 iterations
+  for _i in 0..100 {
+    for i in 0..N {
+      a_arr[i] = T::get_sample(var);
+      var = var.wrapping_mul(A).wrapping_add(B);
+      b_arr[i] = T::get_sample(var);
+      var = var.wrapping_mul(A).wrapping_add(B);
+    }
+
+    let mut expected_arr: [T; N] = [T::default(); N];
+    for i in 0..N {
+      expected_arr[i] = scalar_fn(a_arr[i], b_arr[i]);
+    }
+
+    let expected_vec = vector_fn(V::from(a_arr), V::from(b_arr));
+    assert_eq!(expected_arr, expected_vec.into());
+  }
+}
+
+/// trait to reduce a 64 bit pseudo-random number to a random sample value
+trait GenSample {
+  fn get_sample(v: u64) -> Self;
+}
+
+impl GenSample for u64 {
+  fn get_sample(v: u64) -> Self {
+    v
+  }
+}
+
+impl GenSample for u32 {
+  fn get_sample(v: u64) -> Self {
+    v as u32
+  }
+}
+
+impl GenSample for u16 {
+  fn get_sample(v: u64) -> Self {
+    v as u16
+  }
+}
+
+impl GenSample for u8 {
+  fn get_sample(v: u64) -> Self {
+    v as u8
+  }
+}

--- a/tests/all_tests/t_i16x16.rs
+++ b/tests/all_tests/t_i16x16.rs
@@ -492,6 +492,8 @@ fn impl_i16x16_max() {
     i16x16::from([17, 2, 1, 1, 19, -5, 12, 9, 17, 2, 1, 1, 19, -5, 12, 9]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i16x16, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -537,6 +539,8 @@ fn impl_i16x16_min() {
   ]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i16x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -227,6 +227,8 @@ fn impl_i16x8_max() {
   let expected = i16x8::from([17, 2, 190, 4, 21, 6, 1, 1]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i16x8, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -236,6 +238,8 @@ fn impl_i16x8_min() {
   let expected = i16x8::from([1, -18, 3, -20, 5, -22, i16::MIN + 1, i16::MIN]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i16x8, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -145,6 +145,8 @@ fn impl_i32x4_max() {
   let expected = i32x4::from([17, 2, 1, 1]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i32x4, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -154,6 +156,8 @@ fn impl_i32x4_min() {
   let expected = i32x4::from([1, -18, i32::MIN + 1, i32::MIN]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i32x4, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -162,6 +162,8 @@ fn impl_i32x8_max() {
   let expected = i32x8::from([17, 2, 1, 1, 19, -5, 12, 9]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i32x8, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -171,6 +173,8 @@ fn impl_i32x8_min() {
   let expected = i32x8::from([1, -18, i32::MIN + 1, i32::MIN, 6, -8, -1, -9]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i32x8, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -292,6 +292,8 @@ fn impl_i8x16_max() {
     i8x16::from([10, 2, -3, 4, 5, -6, 7, 8, 9, 7, -11, 12, 13, 6, 55, -127]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i8x16, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -336,6 +336,8 @@ fn impl_i8x16_min() {
   ]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i8x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_i8x32.rs
+++ b/tests/all_tests/t_i8x32.rs
@@ -418,6 +418,8 @@ fn impl_i8x32_max() {
   ]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i8x32, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -526,6 +528,8 @@ fn impl_i8x32_min() {
   ]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: i8x32, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_u16x16.rs
+++ b/tests/all_tests/t_u16x16.rs
@@ -127,6 +127,11 @@ fn impl_saturating_add_for_u16x16() {
   ]);
   let actual = a.saturating_add(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x16, b| a.saturating_add(b),
+    |a, b| a.saturating_add(b),
+  );
 }
 
 #[test]
@@ -142,6 +147,11 @@ fn impl_saturating_sub_for_u16x16() {
   ]);
   let actual = a.saturating_sub(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x16, b| a.saturating_sub(b),
+    |a, b| a.saturating_sub(b),
+  );
 }
 
 #[test]
@@ -151,6 +161,8 @@ fn impl_bitand_for_u16x16() {
   let expected = u16x16::from([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, b| a & b, |a, b| a & b);
 }
 
 #[test]
@@ -160,6 +172,8 @@ fn impl_bitor_for_u16x16() {
   let expected = u16x16::from([0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, b| a | b, |a, b| a | b);
 }
 
 #[test]
@@ -169,6 +183,8 @@ fn impl_bitxor_for_u16x16() {
   let expected = u16x16::from([0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
@@ -308,6 +324,8 @@ fn impl_u16x16_max() {
     u16x16::from([u16::MAX, 2, 1, 1, 19, 8, 12, 9, 17, 2, 1, 1, 19, 8, 12, 9]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -318,6 +336,8 @@ fn impl_u16x16_min() {
   let expected = u16x16::from([1, 0, 1, 0, 6, 0, 0, 0, 1, 0, 1, 0, 6, 0, 0, 0]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]
@@ -363,4 +383,9 @@ fn impl_mul_for_u16x16() {
   ]);
   let actual = a * b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x16, b| a * b,
+    |a, b| a.wrapping_mul(b),
+  );
 }

--- a/tests/all_tests/t_u16x16.rs
+++ b/tests/all_tests/t_u16x16.rs
@@ -51,6 +51,11 @@ fn impl_add_for_u16x16() {
   ]);
   let actual = a + b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x16, b| a + b,
+    |a, b| a.wrapping_add(b),
+  );
 }
 
 #[test]
@@ -82,6 +87,11 @@ fn impl_sub_for_u16x16() {
   ]);
   let actual = a - b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x16, b| a - b,
+    |a, b| a.wrapping_sub(b),
+  );
 }
 
 #[test]
@@ -228,6 +238,8 @@ fn impl_shl_for_u16x16() {
   ]);
   let actual = a << b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, _b| a << 3, |a, _b| a << 3);
 }
 
 #[test]
@@ -271,6 +283,8 @@ fn impl_shr_for_u16x16() {
   ]);
   let actual = a >> b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x16, _b| a >> 3, |a, _b| a >> 3);
 }
 
 #[test]

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -32,6 +32,11 @@ fn impl_saturating_add_for_u16x8() {
   let expected = u16x8::from([18, 20, 22, 24, 26, 28, u16::MAX, u16::MAX]);
   let actual = a.saturating_add(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| a.saturating_add(b),
+    |a, b| a.saturating_add(b),
+  );
 }
 
 #[test]
@@ -41,6 +46,11 @@ fn impl_saturating_sub_for_u16x8() {
   let expected = u16x8::from([1451, 40, 0, 4256, 0, 6875, 0, 0]);
   let actual = a.saturating_sub(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| a.saturating_sub(b),
+    |a, b| a.saturating_sub(b),
+  );
 }
 
 #[test]
@@ -59,6 +69,11 @@ fn impl_mul_for_u16x8() {
   ]);
   let actual = a * b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| a * b,
+    |a, b| a.wrapping_mul(b),
+  );
 }
 
 #[test]
@@ -68,6 +83,8 @@ fn impl_bitand_for_u8x16() {
   let expected = u8x16::from([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, b| a & b, |a, b| a & b);
 }
 
 #[test]
@@ -77,6 +94,8 @@ fn impl_bitor_for_u8x16() {
   let expected = u8x16::from([0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, b| a | b, |a, b| a | b);
 }
 
 #[test]
@@ -86,6 +105,8 @@ fn impl_bitxor_for_u8x16() {
   let expected = u8x16::from([0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
@@ -151,6 +172,8 @@ fn impl_u16x8_max() {
   let expected = u16x8::from([37000, 37001, 19, 20, 5, 6, 7, 24]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -160,4 +183,6 @@ fn impl_u16x8_min() {
   let expected = u16x8::from([1, 37000, 3, 4, 2, 2, 2, 8]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, b| a.min(b), |a, b| a.min(b));
 }

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -146,18 +146,18 @@ fn impl_u16x8_blend() {
 
 #[test]
 fn impl_u16x8_max() {
-  let a = u16x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
-  let b = u16x8::from([17, 18, 19, 20, 2, 2, 2, 24]);
-  let expected = u16x8::from([17, 18, 19, 20, 5, 6, 7, 24]);
+  let a = u16x8::from([1, 37001, 3, 4, 5, 6, 7, 8]);
+  let b = u16x8::from([37000, 37000, 19, 20, 2, 2, 2, 24]);
+  let expected = u16x8::from([37000, 37001, 19, 20, 5, 6, 7, 24]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_u16x8_min() {
-  let a = u16x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
-  let b = u16x8::from([17, 18, 19, 20, 2, 2, 2, 24]);
-  let expected = u16x8::from([1, 2, 3, 4, 2, 2, 2, 8]);
+  let a = u16x8::from([1, 37001, 3, 4, 5, 6, 7, 8]);
+  let b = u16x8::from([37000, 37000, 19, 20, 2, 2, 2, 24]);
+  let expected = u16x8::from([1, 37000, 3, 4, 2, 2, 2, 8]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -14,6 +14,11 @@ fn impl_add_for_u16x8() {
   let expected = u16x8::from([18, 20, 22, 24, 26, 28, u16::MAX, 0]);
   let actual = a + b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| a + b,
+    |a, b| a.wrapping_add(b),
+  );
 }
 
 #[test]
@@ -23,6 +28,11 @@ fn impl_sub_for_u16x8() {
   let expected = u16x8::from([1451, 40, 65347, 4256, 65420, 6875, 0, u16::MAX]);
   let actual = a - b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| a - b,
+    |a, b| a.wrapping_sub(b),
+  );
 }
 
 #[test]
@@ -125,6 +135,8 @@ fn impl_shl_for_u16x8() {
   ]);
   let actual = a << b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, _b| a << 3, |a, _b| a << 3);
 }
 
 #[test]
@@ -143,6 +155,8 @@ fn impl_shr_for_u16x8() {
   ]);
   let actual = a >> b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u16x8, _b| a >> 3, |a, _b| a >> 3);
 }
 
 #[test]

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -47,6 +47,8 @@ fn impl_bitand_for_u32x4() {
   let expected = u32x4::from([0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, b| a & b, |a, b| a & b);
 }
 
 #[test]
@@ -56,6 +58,8 @@ fn impl_bitor_for_u32x4() {
   let expected = u32x4::from([0, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, b| a | b, |a, b| a | b);
 }
 
 #[test]
@@ -65,6 +69,8 @@ fn impl_bitxor_for_u32x4() {
   let expected = u32x4::from([0, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
@@ -75,6 +81,8 @@ fn impl_shl_for_u32x4() {
     u32x4::from([1 << 2, 2 << 2, (u32::MAX - 1) << 2, (u32::MAX - 1) << 2]);
   let actual = a << b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, _b| a << 3, |a, _b| a << 3);
 }
 
 #[test]
@@ -85,6 +93,8 @@ fn impl_shr_for_u32x4() {
     u32x4::from([1 >> 2, 2 >> 2, (u32::MAX - 1) >> 2, (u32::MAX - 1) >> 2]);
   let actual = a >> b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, _b| a >> 3, |a, _b| a >> 3);
 }
 
 #[test]

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -93,8 +93,8 @@ fn impl_u32x4_cmp_eq() {
 
 #[test]
 fn impl_u32x4_cmp_gt() {
-  let a = u32x4::from([1, 2, 3, 4]);
-  let b = u32x4::from([2_u32; 4]);
+  let a = u32x4::from([1, 2, 3, u32::MAX]);
+  let b = u32x4::from([u32::MAX, 2, 2, 2]);
   let expected = u32x4::from([0, 0, u32::MAX, u32::MAX]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
@@ -102,9 +102,9 @@ fn impl_u32x4_cmp_gt() {
 
 #[test]
 fn impl_u32x4_cmp_lt() {
-  let a = u32x4::from([1, 2, 3, 4]);
-  let b = u32x4::from([2_u32; 4]);
-  let expected = u32x4::from([u32::MAX, 0, 0, 0]);
+  let a = u32x4::from([1, 2, 3, u32::MAX]);
+  let b = u32x4::from([u32::MAX, 3, 3, 3]);
+  let expected = u32x4::from([u32::MAX, u32::MAX, 0, 0]);
   let actual = a.cmp_lt(b);
   assert_eq!(expected, actual);
 

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -33,6 +33,11 @@ fn impl_mul_for_u32x4() {
     u32x4::from([17, 36, 1, (Wrapping(u32::MAX) * Wrapping(32)).0]);
   let actual = a * b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x4, b| a * b,
+    |a, b| a.wrapping_mul(b),
+  );
 }
 
 #[test]
@@ -98,6 +103,11 @@ fn impl_u32x4_cmp_gt() {
   let expected = u32x4::from([0, 0, u32::MAX, u32::MAX]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x4, b| a.cmp_gt(b),
+    |a, b| if a > b { u32::MAX } else { 0 },
+  );
 }
 
 #[test]
@@ -111,6 +121,11 @@ fn impl_u32x4_cmp_lt() {
   let expected = u32x4::from([0, 0, 0, 0]);
   let actual = a.cmp_lt(a);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x4, b| a.cmp_lt(b),
+    |a, b| if a < b { u32::MAX } else { 0 },
+  );
 }
 
 #[test]
@@ -131,6 +146,8 @@ fn impl_u32x4_max() {
   let expected = u32x4::from([17, 2, 3, 20]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -140,4 +157,6 @@ fn impl_u32x4_min() {
   let expected = u32x4::from([0, 1, 0, 4]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x4, b| a.min(b), |a, b| a.min(b));
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -42,6 +42,11 @@ fn impl_mul_for_u32x8() {
   ]);
   let actual = a * b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a * b,
+    |a, b| a.wrapping_mul(b),
+  );
 }
 
 #[test]
@@ -51,6 +56,8 @@ fn impl_bitand_for_u32x8() {
   let expected = u32x8::from([0, 0, 0, 1, 0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a | b, |a, b| a | b);
 }
 
 #[test]
@@ -125,6 +132,11 @@ fn impl_u32x8_cmp_gt() {
   let expected = u32x8::from([0, 0, u32::MAX, 0, 0, 0, u32::MAX, u32::MAX]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a.cmp_gt(b),
+    |a, b| if a > b { u32::MAX } else { 0 },
+  );
 }
 
 #[test]
@@ -134,6 +146,11 @@ fn impl_u32x8_cmp_lt() {
   let expected = u32x8::from([0, 0, u32::MAX, 0, 0, 0, u32::MAX, u32::MAX]);
   let actual = a.cmp_lt(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a.cmp_lt(b),
+    |a, b| if a < b { u32::MAX } else { 0 },
+  );
 }
 
 #[test]
@@ -154,6 +171,8 @@ fn impl_u32x8_max() {
   let expected = u32x8::from([17, 2, 1, 1, 19, 0, 12, u32::MAX]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -163,4 +182,6 @@ fn impl_u32x8_min() {
   let expected = u32x8::from([1, 0, 1, 0, 6, 0, 0, 1000]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a.max(b), |a, b| a.max(b));
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -183,5 +183,5 @@ fn impl_u32x8_min() {
   let actual = a.min(b);
   assert_eq!(expected, actual);
 
-  crate::test_random_vector_vs_scalar(|a: u32x8, b| a.max(b), |a, b| a.max(b));
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a.min(b), |a, b| a.min(b));
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -14,6 +14,11 @@ fn impl_add_for_u32x8() {
   let expected = u32x8::from([18, 20, u32::MAX, u32::MIN, 43, 84, 647, 68]);
   let actual = a + b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a + b,
+    |a, b| a.wrapping_add(b),
+  );
 }
 
 #[test]
@@ -24,6 +29,11 @@ fn impl_sub_for_u32x8() {
     u32x8::from([8984, 4294967280, 0, u32::MAX, 4294967293, 0, 7, 5]);
   let actual = a - b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a - b,
+    |a, b| a.wrapping_sub(b),
+  );
 }
 
 #[test]
@@ -67,6 +77,8 @@ fn impl_bitor_for_u32x8() {
   let expected = u32x8::from([0, 1, 1, 1, 1, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a & b, |a, b| a & b);
 }
 
 #[test]
@@ -76,6 +88,8 @@ fn impl_bitxor_for_u32x8() {
   let expected = u32x8::from([0, 1, 1, 0, 1, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
@@ -95,6 +109,8 @@ fn impl_shl_for_u32x8() {
   ]);
   let actual = a << b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, _b| a << 3, |a, _b| a << 3);
 }
 
 #[test]
@@ -114,6 +130,8 @@ fn impl_shr_for_u32x8() {
   ]);
   let actual = a >> b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u32x8, _b| a >> 3, |a, _b| a >> 3);
 }
 
 #[test]

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -55,31 +55,32 @@ fn impl_bitand_for_u32x8() {
 
 #[test]
 fn impl_bitor_for_u32x8() {
-  let a = i32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i32x8::from([0, 1, 1, 1, 1, 1, 1, 1]);
+  let a = u32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = u32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
+  let expected = u32x8::from([0, 1, 1, 1, 1, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_bitxor_for_u32x8() {
-  let a = i32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
-  let b = i32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
-  let expected = i32x8::from([0, 1, 1, 0, 1, 1, 1, 0]);
+  let a = u32x8::from([0, 0, 1, 1, 1, 0, 0, 1]);
+  let b = u32x8::from([0, 1, 0, 1, 0, 1, 1, 1]);
+  let expected = u32x8::from([0, 1, 1, 0, 1, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_shl_for_u32x8() {
-  let a = i32x8::from([1, 2, i32::MAX - 1, i32::MAX - 1, 128, 255, 590, 5667]);
+  let a =
+    u32x8::from([1, 2, u32::MAX - 1, i32::MAX as u32 - 1, 128, 255, 590, 5667]);
   let b = 2;
-  let expected = i32x8::from([
+  let expected = u32x8::from([
     1 << 2,
     2 << 2,
-    (i32::MAX - 1) << 2,
-    (i32::MAX - 1) << 2,
+    (u32::MAX - 1) << 2,
+    (i32::MAX as u32 - 1) << 2,
     128 << 2,
     255 << 2,
     590 << 2,
@@ -91,13 +92,14 @@ fn impl_shl_for_u32x8() {
 
 #[test]
 fn impl_shr_for_u32x8() {
-  let a = i32x8::from([1, 2, i32::MAX - 1, i32::MAX - 1, 128, 255, 590, 5667]);
+  let a =
+    u32x8::from([1, 2, u32::MAX - 1, i32::MAX as u32 - 1, 128, 255, 590, 5667]);
   let b = 2;
-  let expected = i32x8::from([
+  let expected = u32x8::from([
     1 >> 2,
     2 >> 2,
-    (i32::MAX - 1) >> 2,
-    (i32::MAX - 1) >> 2,
+    (u32::MAX - 1) >> 2,
+    (i32::MAX as u32 - 1) >> 2,
     128 >> 2,
     255 >> 2,
     590 >> 2,
@@ -109,47 +111,56 @@ fn impl_shr_for_u32x8() {
 
 #[test]
 fn impl_u32x8_cmp_eq() {
-  let a = i32x8::from([1, 2, 3, 4, 2, 1, 8, 2]);
-  let b = i32x8::from([2_i32; 8]);
-  let expected = i32x8::from([0, -1, 0, 0, -1, 0, 0, -1]);
+  let a = u32x8::from([1, 2, 3, 4, 2, 1, 8, 2]);
+  let b = u32x8::from([2_u32; 8]);
+  let expected = u32x8::from([0, u32::MAX, 0, 0, u32::MAX, 0, 0, u32::MAX]);
   let actual = a.cmp_eq(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_u32x8_cmp_gt() {
-  let a = i32x8::from([1, 2, 9, 4, 1, 2, 8, 10]);
-  let b = i32x8::from([5_i32; 8]);
-  let expected = i32x8::from([0, 0, -1, 0, 0, 0, -1, -1]);
+  let a = u32x8::from([1, 2, u32::MAX, 4, 1, 2, 8, 10]);
+  let b = u32x8::from([5, 5, 5, 5, 5, 5, 5, 5]);
+  let expected = u32x8::from([0, 0, u32::MAX, 0, 0, 0, u32::MAX, u32::MAX]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
+fn impl_u32x8_cmp_lt() {
+  let a = u32x8::from([5, 5, 5, 5, 5, 5, 5, 5]);
+  let b = u32x8::from([1, 2, u32::MAX, 4, 1, 2, 8, 10]);
+  let expected = u32x8::from([0, 0, u32::MAX, 0, 0, 0, u32::MAX, u32::MAX]);
+  let actual = a.cmp_lt(b);
+  assert_eq!(expected, actual);
+}
+
+#[test]
 fn impl_u32x8_blend() {
-  let use_t: i32 = -1;
-  let t = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
-  let f = i32x8::from([17, 18, 19, 20, 25, 30, 50, 90]);
-  let mask = i32x8::from([use_t, 0, use_t, 0, 0, 0, 0, use_t]);
-  let expected = i32x8::from([1, 18, 3, 20, 25, 30, 50, 8]);
+  let use_t: u32 = u32::MAX;
+  let t = u32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+  let f = u32x8::from([17, 18, 19, 20, 25, 30, 50, 90]);
+  let mask = u32x8::from([use_t, 0, use_t, 0, 0, 0, 0, use_t]);
+  let expected = u32x8::from([1, 18, 3, 20, 25, 30, 50, 8]);
   let actual = mask.blend(t, f);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_u32x8_max() {
-  let a = i32x8::from([1, 2, i32::MIN + 1, i32::MIN, 6, -8, 12, 9]);
-  let b = i32x8::from([17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i32x8::from([17, 2, 1, 1, 19, -5, 12, 9]);
+  let a = u32x8::from([1, 2, 1, 0, 6, 0, 12, u32::MAX]);
+  let b = u32x8::from([17, 0, 1, 1, 19, 0, 0, 1000]);
+  let expected = u32x8::from([17, 2, 1, 1, 19, 0, 12, u32::MAX]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
 }
 
 #[test]
 fn impl_u32x8_min() {
-  let a = i32x8::from([1, 2, i32::MIN + 1, i32::MIN, 6, -8, 12, 9]);
-  let b = i32x8::from([17, -18, 1, 1, 19, -5, -1, -9]);
-  let expected = i32x8::from([1, -18, i32::MIN + 1, i32::MIN, 6, -8, -1, -9]);
+  let a = u32x8::from([1, 2, 1, 0, 6, 0, 12, u32::MAX]);
+  let b = u32x8::from([17, 0, 1, 1, 19, 0, 0, 1000]);
+  let expected = u32x8::from([1, 0, 1, 0, 6, 0, 0, 1000]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
 }

--- a/tests/all_tests/t_u64x2.rs
+++ b/tests/all_tests/t_u64x2.rs
@@ -32,6 +32,11 @@ fn impl_mul_for_u64x2() {
   let expected = u64x2::from([2, (Wrapping(u64::MAX) * Wrapping(2)).0]);
   let actual = a * b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x2, b| a * b,
+    |a, b| a.wrapping_mul(b),
+  );
 }
 
 #[test]
@@ -106,4 +111,23 @@ fn impl_u64x2_cmp_gt() {
   let expected = u64x2::from([0, 0]);
   let actual = a.cmp_gt(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x2, b| a.cmp_gt(b),
+    |a, b| if a > b { u64::MAX } else { 0 },
+  );
+}
+
+#[test]
+fn impl_u64x2_cmp_lt() {
+  let a = u64x2::from([3_u64, 4]);
+  let b = u64x2::from([1_u64, 4]);
+  let expected = u64x2::from([0, 0]);
+  let actual = a.cmp_lt(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x2, b| a.cmp_lt(b),
+    |a, b| if a < b { u64::MAX } else { 0 },
+  );
 }

--- a/tests/all_tests/t_u64x4.rs
+++ b/tests/all_tests/t_u64x4.rs
@@ -101,3 +101,31 @@ fn impl_u64x4_cmp_eq() {
   let actual = a.cmp_eq(b);
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn impl_u64x4_cmp_gt() {
+  let a = u64x4::from([1_u64, 4, u64::MAX, 5]);
+  let b = u64x4::from([3_u64, 4, 1, u64::MAX]);
+  let expected = u64x4::from([0, 0, u64::MAX, 0]);
+  let actual = a.cmp_gt(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x4, b| a.cmp_gt(b),
+    |a, b| if a > b { u64::MAX } else { 0 },
+  );
+}
+
+#[test]
+fn impl_u64x4_cmp_lt() {
+  let a = u64x4::from([3_u64, 4, 1, u64::MAX]);
+  let b = u64x4::from([1_u64, 4, u64::MAX, 5]);
+  let expected = u64x4::from([0, 0, u64::MAX, 0]);
+  let actual = a.cmp_lt(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x4, b| a.cmp_lt(b),
+    |a, b| if a < b { u64::MAX } else { 0 },
+  );
+}

--- a/tests/all_tests/t_u8x16.rs
+++ b/tests/all_tests/t_u8x16.rs
@@ -17,6 +17,11 @@ fn impl_add_for_u8x16() {
   ]);
   let actual = a + b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u8x16, b| a + b,
+    |a, b| a.wrapping_add(b),
+  );
 }
 
 #[test]
@@ -44,6 +49,11 @@ fn impl_sub_for_u8x16() {
   ]);
   let actual = a - b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u8x16, b| a - b,
+    |a, b| a.wrapping_sub(b),
+  );
 }
 
 #[test]
@@ -57,6 +67,11 @@ fn impl_saturating_add_for_u8x16() {
   ]);
   let actual = a.saturating_add(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u8x16, b| a.saturating_add(b),
+    |a, b| a.saturating_add(b),
+  );
 }
 
 #[test]
@@ -67,6 +82,11 @@ fn impl_saturating_sub_for_u8x16() {
   let expected = u8x16::from([0, 0, 0, 0, 0, 4, 0, 4, 0, 2, 0, 0, 0, 0, 0, 0]);
   let actual = a.saturating_sub(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u8x16, b| a.saturating_sub(b),
+    |a, b| a.saturating_sub(b),
+  );
 }
 
 #[test]
@@ -76,6 +96,8 @@ fn impl_bitand_for_u8x16() {
   let expected = u8x16::from([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]);
   let actual = a & b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a & b, |a, b| a & b);
 }
 
 #[test]
@@ -85,6 +107,8 @@ fn impl_bitor_for_u8x16() {
   let expected = u8x16::from([0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1]);
   let actual = a | b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a | b, |a, b| a | b);
 }
 
 #[test]
@@ -94,6 +118,8 @@ fn impl_bitxor_for_u8x16() {
   let expected = u8x16::from([0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0]);
   let actual = a ^ b;
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a ^ b, |a, b| a ^ b);
 }
 
 #[test]
@@ -137,8 +163,6 @@ fn impl_u8x16_blend() {
     u8x16::from([1, 18, 3, 20, 5, 22, 7, 24, 9, 26, 11, 28, 13, 30, 126, 1]);
   let actual = mask.blend(t, f);
   assert_eq!(expected, actual);
-
-  crate::test_random_vector_vs_scalar(|a: u8x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]

--- a/tests/all_tests/t_u8x16.rs
+++ b/tests/all_tests/t_u8x16.rs
@@ -137,6 +137,8 @@ fn impl_u8x16_blend() {
     u8x16::from([1, 18, 3, 20, 5, 22, 7, 24, 9, 26, 11, 28, 13, 30, 126, 1]);
   let actual = mask.blend(t, f);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]
@@ -150,6 +152,8 @@ fn impl_u8x16_max() {
   ]);
   let actual = a.max(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a.max(b), |a, b| a.max(b));
 }
 
 #[test]
@@ -162,6 +166,8 @@ fn impl_u8x16_min() {
     u8x16::from([1, 2, 3, 4, 2, 2, 2, 8, 9, 10, 11, 12, 13, 14, 5, 6]);
   let actual = a.min(b);
   assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(|a: u8x16, b| a.min(b), |a, b| a.min(b));
 }
 
 #[test]


### PR DESCRIPTION
Couple bugs in u32x8 and u32x4 where i32 operations were used instead. Also fixed tests that were testing i32x8 instead of u32x8.