### PR TITLE
Adds conversion functions from integers to floats

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -4,13 +4,13 @@ pick! {
   if #[cfg(target_feature="sse")] {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
-    pub struct f32x4 { sse: m128 }
+    pub struct f32x4 { pub(crate) sse: m128 }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct f32x4 { simd: v128 }
+    pub struct f32x4 { pub(crate) simd: v128 }
 
     impl Default for f32x4 {
       fn default() -> Self {
@@ -27,7 +27,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct f32x4 { neon : float32x4_t }
+    pub struct f32x4 { pub(crate) neon : float32x4_t }
 
     impl Default for f32x4 {
       #[inline]
@@ -48,7 +48,7 @@ pick! {
     } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
-    pub struct f32x4 { arr: [f32;4] }
+    pub struct f32x4 { pub(crate) arr: [f32;4] }
   }
 }
 
@@ -1578,16 +1578,18 @@ impl f32x4 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 4] {
     cast_mut(self)
   }
+}
 
+impl From<i32x4> for f32x4 {
   #[inline]
-  pub fn from_i32x4(v: i32x4) -> Self {
+  fn from(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128_from_i32_m128i(v.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: core::arch::wasm::f32x4_convert_i32x4(v.simd) }
+        Self { simd: f32x4_convert_i32x4(v.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        Self { neon: unsafe { core::arch::aarch64::vcvtq_f32_s32(v.neon) }}
+        Self { neon: unsafe { vcvtq_f32_s32(v.neon) }}
       } else {
         Self { arr: [
             v.as_array_ref()[0] as f32,

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1578,11 +1578,9 @@ impl f32x4 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 4] {
     cast_mut(self)
   }
-}
 
-impl From<i32x4> for f32x4 {
   #[inline]
-  fn from(v: i32x4) -> Self {
+  pub fn from_i32x4(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128_from_i32_m128i(v.sse) }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1578,4 +1578,24 @@ impl f32x4 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 4] {
     cast_mut(self)
   }
+
+  #[inline]
+  pub fn from_i32x4(v: i32x4) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: convert_to_m128_from_i32_m128i(v.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: core::arch::wasm::f32x4_convert_i32x4(v.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        Self { neon: unsafe { core::arch::aarch64::vcvtq_f32_s32(v.neon) }}
+      } else {
+        Self { arr: [
+            v.as_array_ref()[0] as f32,
+            v.as_array_ref()[1] as f32,
+            v.as_array_ref()[2] as f32,
+            v.as_array_ref()[3] as f32,
+          ] }
+      }
+    }
+  }
 }

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1418,6 +1418,26 @@ impl f32x8 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 8] {
     cast_mut(self)
   }
+
+  #[inline]
+  pub fn from_i32x8(v: i32x8) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: safe_arch::convert_to_m256_from_i32_m256i(v.avx2) }
+      } else {
+        Self::new([
+            v.as_array_ref()[0] as f32,
+            v.as_array_ref()[1] as f32,
+            v.as_array_ref()[2] as f32,
+            v.as_array_ref()[3] as f32,
+            v.as_array_ref()[4] as f32,
+            v.as_array_ref()[5] as f32,
+            v.as_array_ref()[6] as f32,
+            v.as_array_ref()[7] as f32,
+          ])
+      }
+    }
+  }
 }
 
 impl Not for f32x8 {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1418,12 +1418,14 @@ impl f32x8 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 8] {
     cast_mut(self)
   }
+}
 
+impl From<i32x8> for f32x8 {
   #[inline]
-  pub fn from_i32x8(v: i32x8) -> Self {
+  fn from(v: i32x8) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: safe_arch::convert_to_m256_from_i32_m256i(v.avx2) }
+        Self { avx: convert_to_m256_from_i32_m256i(v.avx2) }
       } else {
         Self::new([
             v.as_array_ref()[0] as f32,

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1418,11 +1418,9 @@ impl f32x8 {
   pub fn as_array_mut(&mut self) -> &mut [f32; 8] {
     cast_mut(self)
   }
-}
 
-impl From<i32x8> for f32x8 {
   #[inline]
-  fn from(v: i32x8) -> Self {
+  pub fn from_i32x8(v: i32x8) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: convert_to_m256_from_i32_m256i(v.avx2) }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1608,12 +1608,10 @@ impl f64x2 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 2] {
     cast_mut(self)
   }
-}
 
-impl From<i32x4> for f64x2 {
   /// Converts the lower two i32 lanes to two f64 lanes (and dropping ther higher two i32 lanes)
   #[inline]
-  fn from(v: i32x4) -> Self {
+  pub fn from_i32x4(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128d_from_lower2_i32_m128i(v.sse) }
@@ -1628,6 +1626,14 @@ impl From<i32x4> for f64x2 {
         ]}
       }
     }
+  }
+}
+
+impl From<i32x4> for f64x2 {
+  /// Converts the lower two i32 lanes to two f64 lanes (and dropping ther higher two i32 lanes)
+  #[inline]
+  fn from(v: i32x4) -> Self {
+    Self::from_i32x4(v)
   }
 }
 

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -4,13 +4,13 @@ pick! {
   if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
-    pub struct f64x2 { sse: m128d }
+    pub struct f64x2 { pub(crate) sse: m128d }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct f64x2 { simd: v128 }
+    pub struct f64x2 { pub(crate) simd: v128 }
 
     impl Default for f64x2 {
       fn default() -> Self {
@@ -27,7 +27,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct f64x2 { neon : float64x2_t }
+    pub struct f64x2 { pub(crate) neon: float64x2_t }
 
     impl Default for f64x2 {
       #[inline]
@@ -51,7 +51,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(16))]
-    pub struct f64x2 { arr: [f64;2] }
+    pub struct f64x2 { pub(crate) arr: [f64;2] }
   }
 }
 
@@ -1608,13 +1608,19 @@ impl f64x2 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 2] {
     cast_mut(self)
   }
+}
 
-  /// Converts the lower two i32 lanes to two f64 lanes
+impl From<i32x4> for f64x2 {
+  /// Converts the lower two i32 lanes to two f64 lanes (and dropping ther higher two i32 lanes)
   #[inline]
-  pub fn from_i32x4(v: i32x4) -> Self {
+  fn from(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128d_from_lower2_i32_m128i(v.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd128: f64x2_convert_low_i32x4(v.simd128)}
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        Self { neon: unsafe { vcvtq_f64_s64(vmovl_s32(vget_low_s32(v.neon))) }}
       } else {
         Self { arr: [
             v.as_array_ref()[0] as f64,

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1608,6 +1608,21 @@ impl f64x2 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 2] {
     cast_mut(self)
   }
+
+  /// Converts the lower two i32 lanes to two f64 lanes
+  #[inline]
+  pub fn from_i32x4(v: i32x4) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: convert_to_m128d_from_lower2_i32_m128i(v.sse) }
+      } else {
+        Self { arr: [
+            v.as_array_ref()[0] as f64,
+            v.as_array_ref()[1] as f64,
+        ]}
+      }
+    }
+  }
 }
 
 impl Not for f64x2 {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1616,7 +1616,7 @@ impl f64x2 {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128d_from_lower2_i32_m128i(v.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd128: f64x2_convert_low_i32x4(v.simd128)}
+        Self { simd: f64x2_convert_low_i32x4(v.simd)}
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         Self { neon: unsafe { vcvtq_f64_s64(vmovl_s32(vget_low_s32(v.neon))) }}
       } else {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1611,7 +1611,7 @@ impl f64x2 {
 
   /// Converts the lower two i32 lanes to two f64 lanes (and dropping ther higher two i32 lanes)
   #[inline]
-  pub fn from_i32x4(v: i32x4) -> Self {
+  pub fn from_i32x4_lower2(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self { sse: convert_to_m128d_from_lower2_i32_m128i(v.sse) }
@@ -1633,7 +1633,7 @@ impl From<i32x4> for f64x2 {
   /// Converts the lower two i32 lanes to two f64 lanes (and dropping ther higher two i32 lanes)
   #[inline]
   fn from(v: i32x4) -> Self {
-    Self::from_i32x4(v)
+    Self::from_i32x4_lower2(v)
   }
 }
 

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1473,6 +1473,22 @@ impl f64x4 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 4] {
     cast_mut(self)
   }
+
+  #[inline]
+  pub fn from_i32x4(v: i32x4) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: convert_to_m256d_from_i32_m128i(v.sse) }
+      } else {
+        Self::new([
+          v.as_array_ref()[0] as f64,
+          v.as_array_ref()[1] as f64,
+          v.as_array_ref()[2] as f64,
+          v.as_array_ref()[3] as f64,
+        ])
+      }
+    }
+  }
 }
 
 impl Not for f64x4 {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -4,11 +4,11 @@ pick! {
   if #[cfg(target_feature="avx")] {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f64x4 { avx: m256d }
+    pub struct f64x4 { pub(crate) avx: m256d }
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f64x4 { a : f64x2, b : f64x2 }
+    pub struct f64x4 { pub(crate) a: f64x2, pub(crate) b: f64x2 }
   }
 }
 
@@ -1473,9 +1473,11 @@ impl f64x4 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 4] {
     cast_mut(self)
   }
+}
 
+impl From<i32x4> for f64x4 {
   #[inline]
-  pub fn from_i32x4(v: i32x4) -> Self {
+  fn from(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: convert_to_m256d_from_i32_m128i(v.sse) }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1473,11 +1473,9 @@ impl f64x4 {
   pub fn as_array_mut(&mut self) -> &mut [f64; 4] {
     cast_mut(self)
   }
-}
 
-impl From<i32x4> for f64x4 {
   #[inline]
-  fn from(v: i32x4) -> Self {
+  pub fn from_i32x4(v: i32x4) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: convert_to_m256d_from_i32_m128i(v.sse) }
@@ -1490,6 +1488,13 @@ impl From<i32x4> for f64x4 {
         ])
       }
     }
+  }
+}
+
+impl From<i32x4> for f64x4 {
+  #[inline]
+  fn from(v: i32x4) -> Self {
+    Self::from_i32x4(v)
   }
 }
 

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -10,7 +10,7 @@ pick! {
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
-    pub struct i64x2 { simd: v128 }
+    pub struct i64x2 { pub(crate) simd: v128 }
 
     impl Default for i64x2 {
       fn default() -> Self {
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct i64x2 { neon : int64x2_t }
+    pub struct i64x2 { pub(crate) neon : int64x2_t }
 
     impl Default for i64x2 {
       #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -4,7 +4,7 @@ pick! {
   if #[cfg(target_feature="sse2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(16))]
-    pub struct i64x2 { sse: m128i }
+    pub struct i64x2 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
     use core::arch::wasm32::*;
 

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -821,5 +821,5 @@ fn impl_f32x4_sum() {
 fn impl_f32x4_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f32x4::from([1.0, 2.0, 3.0, 4.0]);
-  assert_eq!(f32x4::from(i), f)
+  assert_eq!(f32x4::from_i32x4(i), f)
 }

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -821,5 +821,5 @@ fn impl_f32x4_sum() {
 fn impl_f32x4_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f32x4::from([1.0, 2.0, 3.0, 4.0]);
-  assert_eq!(f32x4::from_i32x4(i), f)
+  assert_eq!(f32x4::from(i), f)
 }

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -816,3 +816,10 @@ fn impl_f32x4_sum() {
   let duration = now.elapsed().as_micros();
   println!("Time take {} {}us", sum2, duration);
 }
+
+#[test]
+fn impl_f32x4_from_i32x4() {
+  let i = i32x4::from([1, 2, 3, 4]);
+  let f = f32x4::from([1.0, 2.0, 3.0, 4.0]);
+  assert_eq!(f32x4::from_i32x4(i), f)
+}

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -935,5 +935,5 @@ fn impl_transpose_for_f32x8() {
 fn impl_f32x8_from_i32x8() {
   let i = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
   let f = f32x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
-  assert_eq!(f32x8::from(i), f)
+  assert_eq!(f32x8::from_i32x8(i), f)
 }

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -935,5 +935,5 @@ fn impl_transpose_for_f32x8() {
 fn impl_f32x8_from_i32x8() {
   let i = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
   let f = f32x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
-  assert_eq!(f32x8::from_i32x8(i), f)
+  assert_eq!(f32x8::from(i), f)
 }

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -930,3 +930,10 @@ fn impl_transpose_for_f32x8() {
 
   assert_eq!(result, expected);
 }
+
+#[test]
+fn impl_f32x8_from_i32x8() {
+  let i = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
+  let f = f32x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+  assert_eq!(f32x8::from_i32x8(i), f)
+}

--- a/tests/all_tests/t_f64x2.rs
+++ b/tests/all_tests/t_f64x2.rs
@@ -820,5 +820,5 @@ fn impl_f64x2_sum() {
 fn impl_f64x2_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f64x2::from([1.0, 2.0]);
-  assert_eq!(f64x2::from_i32x4(i), f)
+  assert_eq!(f64x2::from(i), f)
 }

--- a/tests/all_tests/t_f64x2.rs
+++ b/tests/all_tests/t_f64x2.rs
@@ -815,3 +815,10 @@ fn impl_f64x2_sum() {
   let duration = now.elapsed().as_micros();
   println!("Time take {} {}us", sum2, duration);
 }
+
+#[test]
+fn impl_f64x2_from_i32x4() {
+  let i = i32x4::from([1, 2, 3, 4]);
+  let f = f64x2::from([1.0, 2.0]);
+  assert_eq!(f64x2::from_i32x4(i), f)
+}

--- a/tests/all_tests/t_f64x2.rs
+++ b/tests/all_tests/t_f64x2.rs
@@ -820,5 +820,5 @@ fn impl_f64x2_sum() {
 fn impl_f64x2_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f64x2::from([1.0, 2.0]);
-  assert_eq!(f64x2::from(i), f)
+  assert_eq!(f64x2::from_i32x4_lower2(i), f)
 }

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -714,5 +714,5 @@ fn impl_f64x4_sum() {
 fn impl_f64x4_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f64x4::from([1.0, 2.0, 3.0, 4.0]);
-  assert_eq!(f64x4::from_i32x4(i), f)
+  assert_eq!(f64x4::from(i), f)
 }

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -714,5 +714,6 @@ fn impl_f64x4_sum() {
 fn impl_f64x4_from_i32x4() {
   let i = i32x4::from([1, 2, 3, 4]);
   let f = f64x4::from([1.0, 2.0, 3.0, 4.0]);
-  assert_eq!(f64x4::from(i), f)
+  assert_eq!(f64x4::from(i), f);
+  assert_eq!(f64x4::from_i32x4(i), f);
 }

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -709,3 +709,10 @@ fn impl_f64x4_sum() {
   let duration = now.elapsed().as_micros();
   println!("Time take {} {}us", sum2, duration);
 }
+
+#[test]
+fn impl_f64x4_from_i32x4() {
+  let i = i32x4::from([1, 2, 3, 4]);
+  let f = f64x4::from([1.0, 2.0, 3.0, 4.0]);
+  assert_eq!(f64x4::from_i32x4(i), f)
+}


### PR DESCRIPTION
This PR adds four conversion functions from integers to floats:
`f32x4::from_i32x4`
`f32x8::from_i32x8`
`f64x2::from_i32x4`
`f64x4::from_i32x4`