### PR TITLE
ci: Run on macos-latest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,11 @@ jobs:
         - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }
+        # aarch64
+        - { target: aarch64-apple-darwin, toolchain: "1.60", os: macos-latest }
+        - { target: aarch64-apple-darwin, toolchain: stable, os: macos-latest }
+        - { target: aarch64-apple-darwin, toolchain: beta, os: macos-latest }
+        - { target: aarch64-apple-darwin, toolchain: nightly, os: macos-latest }
         # wasm32
         - { target: wasm32-wasi, toolchain: 1.56.0, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: stable, os: ubuntu-latest, wasmtime: v5.0.0 }

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -407,7 +407,7 @@ fn impl_f32x4_sin_cos() {
         let actual_arr: [f32; 4] = cast(vals);
         let actual = actual_arr[i];
         assert!(
-          (actual - expected).abs() < 0.00000006,
+          (actual - expected).abs() < 0.0000002,
           "Wanted {name}({angle}) to be {expected} but got {actual}",
           name = name,
           angle = angle,

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -651,7 +651,7 @@ fn impl_f32x8_sin_cos() {
         let actual_arr: [f32; 8] = cast(vals);
         let actual = actual_arr[i];
         assert!(
-          (actual - expected).abs() < 0.00000006,
+          (actual - expected).abs() < 0.0000002,
           "Wanted {name}({angle}) to be {expected} but got {actual}",
           name = name,
           angle = angle,


### PR DESCRIPTION
Since `macos-latest` is an Apple Silicon machine now, aarch64 CI can be run natively.
