### PR TITLE
Update MSRV to 1.60 from 1.56

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,22 +11,22 @@ jobs:
       matrix:
         rust:
         # x86 without sse/sse2 on by default
-        - { target: i586-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86
-        - { target: i686-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86_64
-        - { target: x86_64-pc-windows-msvc, toolchain: 1.56.0, os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # wasm32
-        - { target: wasm32-wasi, toolchain: 1.56.0, os: ubuntu-latest, wasmtime: v5.0.0 }
+        - { target: wasm32-wasi, toolchain: "1.60", os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: stable, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: beta, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: nightly, os: ubuntu-latest, wasmtime: v5.0.0 }
@@ -69,7 +69,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.59,stable,nightly]
+        rust: ["1.60", stable, nightly]
         features: ["", "std"]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ categories = ["data-structures", "hardware-support"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 
-# minimum version supported with WASM and all intrinsics for safe_arch (also first version to support this config option)
-rust-version = "1.56"
+# Aarch64 needs 1.59 while others need 1.56
+# When updating, also update CI workflows and the badge in the README.
+rust-version = "1.60"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License:Zlib](https://img.shields.io/badge/License-Zlib-brightgreen.svg)](https://opensource.org/licenses/Zlib)
-![Minimum Rust Version](https://img.shields.io/badge/Min%20Rust-1.52-green.svg)
+![Minimum Rust Version](https://img.shields.io/badge/Min%20Rust-1.60-green.svg)
 [![crates.io](https://img.shields.io/crates/v/wide.svg)](https://crates.io/crates/wide)
 [![docs.rs](https://docs.rs/wide/badge.svg)](https://docs.rs/wide/)
 


### PR DESCRIPTION
Builds on aarch64 need 1.59 and @Lokathor was okay with just going to 1.60

Fixes #169.