### PR TITLE
fix CI problems by bumping msrv

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,27 +11,27 @@ jobs:
       matrix:
         rust:
         # x86 without sse/sse2 on by default
-        - { target: i586-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
+        - { target: i586-pc-windows-msvc, toolchain: "1.61", os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i586-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86
-        - { target: i686-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
+        - { target: i686-pc-windows-msvc, toolchain: "1.61", os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: i686-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # x86_64
-        - { target: x86_64-pc-windows-msvc, toolchain: "1.60", os: windows-latest }
+        - { target: x86_64-pc-windows-msvc, toolchain: "1.61", os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: stable, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: beta, os: windows-latest }
         - { target: x86_64-pc-windows-msvc, toolchain: nightly, os: windows-latest }
         # aarch64
-        - { target: aarch64-apple-darwin, toolchain: "1.60", os: macos-latest }
+        - { target: aarch64-apple-darwin, toolchain: "1.61", os: macos-latest }
         - { target: aarch64-apple-darwin, toolchain: stable, os: macos-latest }
         - { target: aarch64-apple-darwin, toolchain: beta, os: macos-latest }
         - { target: aarch64-apple-darwin, toolchain: nightly, os: macos-latest }
         # wasm32
-        - { target: wasm32-wasi, toolchain: "1.60", os: ubuntu-latest, wasmtime: v5.0.0 }
+        - { target: wasm32-wasi, toolchain: "1.61", os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: stable, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: beta, os: ubuntu-latest, wasmtime: v5.0.0 }
         - { target: wasm32-wasi, toolchain: nightly, os: ubuntu-latest, wasmtime: v5.0.0 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Zlib OR Apache-2.0 OR MIT"
 
 # Aarch64 needs 1.59 while others need 1.56
 # When updating, also update CI workflows and the badge in the README.
-rust-version = "1.60"
+rust-version = "1.61"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This isn't strictly necessary since the problem is that we're running against the MSRV of a dev-dependency and we could probably just replace that dev dependency, but I don't see a strong need to stick to the oldest possible minimum rust in this case.