### PR TITLE
Remove Rand crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ std = []
 [dependencies]
 safe_arch = { version = "0.7", features = ["bytemuck"] }
 bytemuck = "1"
-
-[dev-dependencies]
-rand = "0.8"

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -54,6 +54,7 @@ pick! {
 
 macro_rules! const_f32_as_f32x4 {
   ($i:ident, $f:expr) => {
+    #[allow(non_upper_case_globals)]
     pub const $i: f32x4 =
       unsafe { ConstUnionHack128bit { f32a4: [$f; 4] }.f32x4 };
   };
@@ -871,7 +872,6 @@ impl f32x4 {
     (self & magnitude_mask) | (sign & Self::from(-0.0))
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin_acos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
@@ -911,7 +911,6 @@ impl f32x4 {
     (asin, acos)
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -948,7 +947,6 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn acos(self) -> Self {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -982,7 +980,6 @@ impl f32x4 {
     acos
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -1021,7 +1018,6 @@ impl f32x4 {
     re
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan2(self, x: Self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -1080,7 +1076,6 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn sin_cos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -1296,7 +1291,6 @@ impl f32x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn vm_pow2n(self) -> Self {
     const_f32_as_f32x4!(pow2_23, 8388608.0);
     const_f32_as_f32x4!(bias, 127.0);
@@ -1308,7 +1302,6 @@ impl f32x4 {
   /// Calculate the exponent of a packed f32x4
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn exp(self) -> Self {
     const_f32_as_f32x4!(P0, 1.0 / 2.0);
     const_f32_as_f32x4!(P1, 1.0 / 6.0);
@@ -1334,7 +1327,6 @@ impl f32x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn exponent(self) -> f32x4 {
     const_f32_as_f32x4!(pow2_23, 8388608.0);
     const_f32_as_f32x4!(bias, 127.0);
@@ -1347,7 +1339,6 @@ impl f32x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn fraction_2(self) -> Self {
     let t1 = cast::<_, u32x4>(self);
     let t2 = cast::<_, u32x4>(
@@ -1391,7 +1382,6 @@ impl f32x4 {
   /// Natural log (ln(x))
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn ln(self) -> Self {
     const_f32_as_f32x4!(HALF, 0.5);
     const_f32_as_f32x4!(P0, 3.3333331174E-1);
@@ -1447,7 +1437,6 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn pow_f32x4(self, y: f32x4) -> Self {
     const_f32_as_f32x4!(ln2f_hi, 0.693359375);
     const_f32_as_f32x4!(ln2f_lo, -2.12194440e-4);

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -14,6 +14,7 @@ pick! {
 
 macro_rules! const_f32_as_f32x8 {
   ($i:ident, $f:expr) => {
+    #[allow(non_upper_case_globals)]
     pub const $i: f32x8 =
       unsafe { ConstUnionHack256bit { f32a8: [$f; 8] }.f32x8 };
   };
@@ -680,7 +681,6 @@ impl f32x8 {
     (self & magnitude_mask) | (sign & Self::from(-0.0))
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin_acos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
@@ -722,7 +722,6 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn asin(self) -> Self {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -758,7 +757,6 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn acos(self) -> Self {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -792,7 +790,6 @@ impl f32x8 {
     acos
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -831,7 +828,6 @@ impl f32x8 {
     re
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan2(self, x: Self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -890,7 +886,6 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn sin_cos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -1053,7 +1048,6 @@ impl f32x8 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn vm_pow2n(self) -> Self {
     const_f32_as_f32x8!(pow2_23, 8388608.0);
     const_f32_as_f32x8!(bias, 127.0);
@@ -1065,7 +1059,6 @@ impl f32x8 {
   /// Calculate the exponent of a packed f32x8
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn exp(self) -> Self {
     const_f32_as_f32x8!(P0, 1.0 / 2.0);
     const_f32_as_f32x8!(P1, 1.0 / 6.0);
@@ -1091,7 +1084,6 @@ impl f32x8 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn exponent(self) -> f32x8 {
     const_f32_as_f32x8!(pow2_23, 8388608.0);
     const_f32_as_f32x8!(bias, 127.0);
@@ -1104,7 +1096,6 @@ impl f32x8 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn fraction_2(self) -> Self {
     let t1 = cast::<_, u32x8>(self);
     let t2 = cast::<_, u32x8>(
@@ -1163,7 +1154,6 @@ impl f32x8 {
   /// Natural log (ln(x))
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn ln(self) -> Self {
     const_f32_as_f32x8!(HALF, 0.5);
     const_f32_as_f32x8!(P0, 3.3333331174E-1);
@@ -1219,7 +1209,6 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn pow_f32x8(self, y: Self) -> Self {
     const_f32_as_f32x8!(ln2f_hi, 0.693359375);
     const_f32_as_f32x8!(ln2f_lo, -2.12194440e-4);

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -57,6 +57,7 @@ pick! {
 
 macro_rules! const_f64_as_f64x2 {
   ($i:ident, $f:expr) => {
+    #[allow(non_upper_case_globals)]
     pub const $i: f64x2 =
       unsafe { ConstUnionHack128bit { f64a2: [$f; 2] }.f64x2 };
   };
@@ -727,7 +728,6 @@ impl f64x2 {
     (self & magnitude_mask) | (sign & Self::from(-0.0))
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin_acos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
@@ -819,7 +819,6 @@ impl f64x2 {
     (asin, acos)
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn acos(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -906,7 +905,6 @@ impl f64x2 {
     acos
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -993,7 +991,6 @@ impl f64x2 {
     asin
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -1050,7 +1047,6 @@ impl f64x2 {
     re
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan2(self, x: Self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -1133,7 +1129,6 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn sin_cos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -1295,7 +1290,6 @@ impl f64x2 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn vm_pow2n(self) -> Self {
     const_f64_as_f64x2!(pow2_52, 4503599627370496.0);
     const_f64_as_f64x2!(bias, 1023.0);
@@ -1307,7 +1301,6 @@ impl f64x2 {
   /// Calculate the exponent of a packed f64x2
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn exp(self) -> Self {
     const_f64_as_f64x2!(P2, 1.0 / 2.0);
     const_f64_as_f64x2!(P3, 1.0 / 6.0);
@@ -1338,7 +1331,6 @@ impl f64x2 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn exponent(self) -> f64x2 {
     const_f64_as_f64x2!(pow2_52, 4503599627370496.0);
     const_f64_as_f64x2!(bias, 1023.0);
@@ -1351,7 +1343,6 @@ impl f64x2 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn fraction_2(self) -> Self {
     let t1 = cast::<_, u64x2>(self);
     let t2 = cast::<_, u64x2>(
@@ -1410,7 +1401,6 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn ln(self) -> Self {
     const_f64_as_f64x2!(P0, 7.70838733755885391666E0);
     const_f64_as_f64x2!(P1, 1.79368678507819816313E1);
@@ -1471,7 +1461,6 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn pow_f64x2(self, y: Self) -> Self {
     const_f64_as_f64x2!(ln2d_hi, 0.693145751953125);
     const_f64_as_f64x2!(ln2d_lo, 1.42860682030941723212E-6);

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -25,20 +25,22 @@ mod t_u64x4;
 mod t_u8x16;
 mod t_usefulness;
 
-// Generates the next random number
+/// Generates the next pseudo-random number.
+/// Definitely non-cryptographic, just used for generating random test values.
 fn next_rand_u64(state: &mut u64) -> u64 {
-  // Constants for the LCG (values used in glibc's rand())
+  // Constants for the LCG
   const A: u64 = 6364136223846793005;
-  const C: u64 = 1;
+  const C: u64 = 1442695040888963407;
 
-  // Update the state and calculate the next number
-  *state = state.wrapping_mul(A).wrapping_add(C);
+  // Update the state and calculate the next number (rotate to avoid lack of randomness in low bits)
+  *state = state.wrapping_mul(A).wrapping_add(C).rotate_left(31);
+
   *state
 }
 
 const RNG_SEED: u64 = 0x123456789abcdef0;
 
-/// Generate a random value for a type that implements GenSample.
+/// Generate a pseudo-random value for a type that implements GenSample.
 fn gen_random<T: GenSample>(rng: &mut u64) -> T {
   let r = next_rand_u64(rng);
 


### PR DESCRIPTION
Causing dependency problems. Replace with simple LCG since it is just used for generating test value.

Also moved non_upper_case_globals into macro so that the visual studio code analyzer doesn't complain and generate bogus warnings.