### PR TITLE
make ::new usable in a const context to avoid need of using const union hack

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -55,8 +55,7 @@ pick! {
 macro_rules! const_f32_as_f32x4 {
   ($i:ident, $f:expr) => {
     #[allow(non_upper_case_globals)]
-    pub const $i: f32x4 =
-      unsafe { ConstUnionHack128bit { f32a4: [$f; 4] }.f32x4 };
+    pub const $i: f32x4 = f32x4::new([$f; 4]);
   };
 }
 
@@ -475,8 +474,11 @@ impl CmpLt for f32x4 {
 impl f32x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [f32; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [f32; 4]) -> Self {
+    #[allow(non_upper_case_globals)]
+    unsafe {
+      std::mem::transmute(array)
+    }
   }
 
   #[inline]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -477,7 +477,7 @@ impl f32x4 {
   pub const fn new(array: [f32; 4]) -> Self {
     #[allow(non_upper_case_globals)]
     unsafe {
-      std::mem::transmute(array)
+      core::intrinsics::transmute(array)
     }
   }
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -15,8 +15,7 @@ pick! {
 macro_rules! const_f32_as_f32x8 {
   ($i:ident, $f:expr) => {
     #[allow(non_upper_case_globals)]
-    pub const $i: f32x8 =
-      unsafe { ConstUnionHack256bit { f32a8: [$f; 8] }.f32x8 };
+    pub const $i: f32x8 = f32x8::new([$f; 8]);
   };
 }
 
@@ -357,8 +356,8 @@ impl CmpLt for f32x8 {
 impl f32x8 {
   #[inline]
   #[must_use]
-  pub fn new(array: [f32; 8]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [f32; 8]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -357,7 +357,7 @@ impl f32x8 {
   #[inline]
   #[must_use]
   pub const fn new(array: [f32; 8]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -454,7 +454,7 @@ impl f64x2 {
   #[inline]
   #[must_use]
   pub const fn new(array: [f64; 2]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -58,8 +58,7 @@ pick! {
 macro_rules! const_f64_as_f64x2 {
   ($i:ident, $f:expr) => {
     #[allow(non_upper_case_globals)]
-    pub const $i: f64x2 =
-      unsafe { ConstUnionHack128bit { f64a2: [$f; 2] }.f64x2 };
+    pub const $i: f64x2 = f64x2::new([$f; 2]);
   };
 }
 
@@ -454,8 +453,8 @@ impl CmpLt for f64x2 {
 impl f64x2 {
   #[inline]
   #[must_use]
-  pub fn new(array: [f64; 2]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [f64; 2]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -357,7 +357,7 @@ impl f64x4 {
   #[inline]
   #[must_use]
   pub const fn new(array: [f64; 4]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -14,8 +14,8 @@ pick! {
 
 macro_rules! const_f64_as_f64x4 {
   ($i:ident, $f:expr) => {
-    pub const $i: f64x4 =
-      unsafe { ConstUnionHack256bit { f64a4: [$f; 4] }.f64x4 };
+    #[allow(non_upper_case_globals)]
+    pub const $i: f64x4 = f64x4::new([$f; 4]);
   };
 }
 
@@ -356,8 +356,8 @@ impl CmpLt for f64x4 {
 impl f64x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [f64; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [f64; 4]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]
@@ -616,7 +616,6 @@ impl f64x4 {
     (self & magnitude_mask) | (sign & Self::from(-0.0))
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn asin_acos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
@@ -709,7 +708,6 @@ impl f64x4 {
     (asin, acos)
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn acos(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -797,7 +795,6 @@ impl f64x4 {
   }
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn asin(self) -> Self {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -883,7 +880,6 @@ impl f64x4 {
     asin
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan(self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -940,7 +936,6 @@ impl f64x4 {
     re
   }
 
-  #[allow(non_upper_case_globals)]
   #[inline]
   pub fn atan2(self, x: Self) -> Self {
     // Based on the Agner Fog "vector class library":
@@ -1023,7 +1018,6 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn sin_cos(self) -> (Self, Self) {
     // Based on the Agner Fog "vector class library":
     // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
@@ -1165,7 +1159,6 @@ impl f64x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn vm_pow2n(self) -> Self {
     const_f64_as_f64x4!(pow2_52, 4503599627370496.0);
     const_f64_as_f64x4!(bias, 1023.0);
@@ -1177,7 +1170,6 @@ impl f64x4 {
   /// Calculate the exponent of a packed `f64x4`
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn exp(self) -> Self {
     const_f64_as_f64x4!(P2, 1.0 / 2.0);
     const_f64_as_f64x4!(P3, 1.0 / 6.0);
@@ -1208,7 +1200,6 @@ impl f64x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn exponent(self) -> f64x4 {
     const_f64_as_f64x4!(pow2_52, 4503599627370496.0);
     const_f64_as_f64x4!(bias, 1023.0);
@@ -1221,7 +1212,6 @@ impl f64x4 {
   }
 
   #[inline]
-  #[allow(non_upper_case_globals)]
   fn fraction_2(self) -> Self {
     let t1 = cast::<_, u64x4>(self);
     let t2 = cast::<_, u64x4>(
@@ -1275,7 +1265,6 @@ impl f64x4 {
   /// Natural log (ln(x))
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn ln(self) -> Self {
     const_f64_as_f64x4!(HALF, 0.5);
     const_f64_as_f64x4!(P0, 7.70838733755885391666E0);
@@ -1337,7 +1326,6 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
-  #[allow(non_upper_case_globals)]
   pub fn pow_f64x4(self, y: Self) -> Self {
     const_f64_as_f64x4!(ln2d_hi, 0.693145751953125);
     const_f64_as_f64x4!(ln2d_lo, 1.42860682030941723212E-6);

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -305,7 +305,7 @@ impl i16x16 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i16; 16]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
 
   #[inline]

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i16, 16, i16x16, i16x16, i16a16, const_i16_as_i16x16, 256);
+int_uint_consts!(i16, 16, i16x16, 256);
 
 unsafe impl Zeroable for i16x16 {}
 unsafe impl Pod for i16x16 {}
@@ -304,8 +304,8 @@ impl From<u8x16> for i16x16 {
 impl i16x16 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i16; 16]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i16; 16]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
 
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -442,7 +442,7 @@ impl i16x8 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i16; 8]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
 
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i16, 8, i16x8, i16x8, i16a8, const_i16_as_i16x8, 128);
+int_uint_consts!(i16, 8, i16x8, 128);
 
 unsafe impl Zeroable for i16x8 {}
 unsafe impl Pod for i16x8 {}
@@ -441,8 +441,8 @@ impl CmpLt for i16x8 {
 impl i16x8 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i16; 8]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i16; 8]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
 
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -473,7 +473,7 @@ impl i32x4 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i32; 4]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i32, 4, i32x4, i32x4, i32a4, const_i32_as_i32x4, 128);
+int_uint_consts!(i32, 4, i32x4, 128);
 
 unsafe impl Zeroable for i32x4 {}
 unsafe impl Pod for i32x4 {}
@@ -472,8 +472,8 @@ impl CmpLt for i32x4 {
 impl i32x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i32; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i32; 4]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -348,7 +348,7 @@ impl i32x8 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i32; 8]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
 
   /// widens and sign extends to `i32x8`

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i32, 8, i32x8, i32x8, i32a8, const_i32_as_i32x8, 256);
+int_uint_consts!(i32, 8, i32x8, 256);
 
 unsafe impl Zeroable for i32x8 {}
 unsafe impl Pod for i32x8 {}
@@ -347,8 +347,8 @@ impl From<i16x8> for i32x8 {
 impl i32x8 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i32; 8]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i32; 8]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
 
   /// widens and sign extends to `i32x8`

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -380,7 +380,7 @@ impl i64x2 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i64; 2]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -57,7 +57,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i64, 2, i64x2, i64x2, i64a2, const_i64_as_i64x2, 128);
+int_uint_consts!(i64, 2, i64x2, 128);
 
 unsafe impl Zeroable for i64x2 {}
 unsafe impl Pod for i64x2 {}
@@ -379,8 +379,8 @@ impl CmpLt for i64x2 {
 impl i64x2 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i64; 2]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i64; 2]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i64, 4, i64x4, i64x4, i64a4, const_i64_as_i64x4, 256);
+int_uint_consts!(i64, 4, i64x4, 256);
 
 unsafe impl Zeroable for i64x4 {}
 unsafe impl Pod for i64x4 {}
@@ -290,8 +290,8 @@ impl CmpLt for i64x4 {
 impl i64x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i64; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i64; 4]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -291,7 +291,7 @@ impl i64x4 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i64; 4]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -388,7 +388,7 @@ impl i8x16 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i8; 16]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
 
   /// converts `i16` to `i8`, saturating values that are too large

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i8, 16, i8x16, i8x16, i8a16, const_i8_as_i8x16, 128);
+int_uint_consts!(i8, 16, i8x16, 128);
 
 unsafe impl Zeroable for i8x16 {}
 unsafe impl Pod for i8x16 {}
@@ -387,8 +387,8 @@ impl CmpLt for i8x16 {
 impl i8x16 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i8; 16]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i8; 16]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
 
   /// converts `i16` to `i8`, saturating values that are too large

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(i8, 32, i8x32, i8x32, i8a32, const_i8_as_i8x32, 256);
+int_uint_consts!(i8, 32, i8x32, 256);
 
 unsafe impl Zeroable for i8x32 {}
 unsafe impl Pod for i8x32 {}
@@ -200,8 +200,8 @@ impl CmpLt for i8x32 {
 impl i8x32 {
   #[inline]
   #[must_use]
-  pub fn new(array: [i8; 32]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [i8; 32]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -201,7 +201,7 @@ impl i8x32 {
   #[inline]
   #[must_use]
   pub const fn new(array: [i8; 32]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,60 +271,6 @@ pub use u64x2_::*;
 mod u64x4_;
 pub use u64x4_::*;
 
-#[allow(non_camel_case_types)]
-#[repr(C, align(16))]
-#[rustfmt::skip]
-union ConstUnionHack128bit {
-  f32a4: [f32; 4],
-  f64a2: [f64; 2],
-  i8a16: [i8; 16],
-  i16a8: [i16; 8],
-  i32a4: [i32; 4],
-  i64a2: [i64; 2],
-  u8a16: [u8; 16],
-  u16a8: [u16; 8],
-  u32a4: [u32; 4],
-  u64a2: [u64; 2],
-  f32x4: f32x4,
-  f64x2: f64x2,
-  i8x16: i8x16,
-  i16x8: i16x8,
-  i32x4: i32x4,
-  i64x2: i64x2,
-  u8x16: u8x16,
-  u16x8: u16x8,
-  u32x4: u32x4,
-  u64x2: u64x2,
-  u128:  u128,
-}
-
-#[allow(non_camel_case_types)]
-#[repr(C, align(16))]
-#[rustfmt::skip]
-union ConstUnionHack256bit {
-  f32a8:  [f32; 8],
-  f64a4:  [f64; 4],
-  i8a32:  [i8; 32],
-  i16a16: [i16; 16],
-  i32a8:  [i32; 8],
-  i64a4:  [i64; 4],
-  u8a32:  [u8; 32],
-  u16a16: [u16; 16],
-  u32a8:  [u32; 8],
-  u64a4:  [u64; 4],
-  u128x2: [u128; 2],
-  f32x8:  f32x8,
-  f64x4:  f64x4,
-  i8x32:  i8x32,
-  i16x16: i16x16,
-  i32x8:  i32x8,
-  i64x4:  i64x4,
-  // u8x32:  u8x32,
-  u16x16: u16x16,
-  u32x8:  u32x8,
-  u64x4:  u64x4,
-}
-
 #[allow(dead_code)]
 fn generic_bit_blend<T>(mask: T, y: T, n: T) -> T
 where

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,8 +2,8 @@ macro_rules! int_uint_consts {
   ($type:ty, $lanes:expr, $simd:ty, $bits:expr) => {
     // ensure the size of the SIMD type is the same as the size of the array and number of bits is OK
     const _: () = assert!(
-      std::mem::size_of::<$simd>() == std::mem::size_of::<[$type; $lanes]>()
-        && std::mem::size_of::<$simd>() * 8 == $bits as usize
+      core::mem::size_of::<$simd>() == core::mem::size_of::<[$type; $lanes]>()
+        && core::mem::size_of::<$simd>() * 8 == $bits as usize
     );
 
     impl $simd {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,10 +1,16 @@
-macro_rules! int_uint_consts_inner {
-  ($type:ty, $lanes:expr, $simd:ty, $macro_name:ident, $bits:expr) => {
+macro_rules! int_uint_consts {
+  ($type:ty, $lanes:expr, $simd:ty, $bits:expr) => {
+    // ensure the size of the SIMD type is the same as the size of the array and number of bits is OK
+    const _: () = assert!(
+      std::mem::size_of::<$simd>() == std::mem::size_of::<[$type; $lanes]>()
+        && std::mem::size_of::<$simd>() * 8 == $bits as usize
+    );
+
     impl $simd {
-      $macro_name!(ONE, 1);
-      $macro_name!(ZERO, 0);
-      $macro_name!(MAX, <$type>::MAX);
-      $macro_name!(MIN, <$type>::MIN);
+      pub const ONE: $simd = <$simd>::new([1; $lanes]);
+      pub const ZERO: $simd = <$simd>::new([0; $lanes]);
+      pub const MAX: $simd = <$simd>::new([<$type>::MAX; $lanes]);
+      pub const MIN: $simd = <$simd>::new([<$type>::MIN; $lanes]);
 
       /// The number of lanes in this SIMD vector.
       pub const LANES: u16 = $lanes;
@@ -12,30 +18,5 @@ macro_rules! int_uint_consts_inner {
       /// The size of this SIMD vector in bits.
       pub const BITS: u16 = $bits;
     }
-  };
-}
-
-macro_rules! int_uint_consts {
-  ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 128) => {
-    macro_rules! $macro_name {
-      ($i: ident, $f: expr) => {
-        pub const $i: $simd_type = unsafe {
-          ConstUnionHack128bit { $aligned: [$f; $lanes] }.$simd_ident
-        };
-      };
-    }
-
-    int_uint_consts_inner!($type, $lanes, $simd_type, $macro_name, 128);
-  };
-  ($type:ty, $lanes:expr, $simd_type:ty, $simd_ident:ident, $aligned:ident, $macro_name:ident, 256) => {
-    macro_rules! $macro_name {
-      ($i: ident, $f: expr) => {
-        pub const $i: $simd_type = unsafe {
-          ConstUnionHack256bit { $aligned: [$f; $lanes] }.$simd_ident
-        };
-      };
-    }
-
-    int_uint_consts_inner!($type, $lanes, $simd_type, $macro_name, 256);
   };
 }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u16, 16, u16x16, u16x16, u16a16, const_u16_as_u16x16, 256);
+int_uint_consts!(u16, 16, u16x16, 256);
 
 unsafe impl Zeroable for u16x16 {}
 unsafe impl Pod for u16x16 {}
@@ -271,8 +271,8 @@ impl From<u8x16> for u16x16 {
 impl u16x16 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u16; 16]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u16; 16]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
 
   #[inline]

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -272,7 +272,7 @@ impl u16x16 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u16; 16]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
 
   #[inline]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -358,7 +358,7 @@ impl u16x8 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u16; 8]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u16, 8, u16x8, u16x8, u16a8, const_u16_as_u16x8, 128);
+int_uint_consts!(u16, 8, u16x8, 128);
 
 unsafe impl Zeroable for u16x8 {}
 unsafe impl Pod for u16x8 {}
@@ -357,8 +357,8 @@ impl_shr_t_for_u16x8!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 impl u16x8 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u16; 8]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u16; 8]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -399,7 +399,7 @@ impl u32x4 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u32; 4]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u32, 4, u32x4, u32x4, u32a4, const_u32_as_u32x4, 128);
+int_uint_consts!(u32, 4, u32x4, 128);
 
 unsafe impl Zeroable for u32x4 {}
 unsafe impl Pod for u32x4 {}
@@ -398,8 +398,8 @@ impl Shl<u32x4> for u32x4 {
 impl u32x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u32; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u32; 4]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u32, 8, u32x8, u32x8, u32a8, const_u32_as_u32x8, 256);
+int_uint_consts!(u32, 8, u32x8, 256);
 
 unsafe impl Zeroable for u32x8 {}
 unsafe impl Pod for u32x8 {}
@@ -260,8 +260,8 @@ impl Shl<u32x8> for u32x8 {
 impl u32x8 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u32; 8]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u32; 8]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -261,7 +261,7 @@ impl u32x8 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u32; 8]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -57,7 +57,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u64, 2, u64x2, u64x2, u64a2, const_u64_as_u64x2, 128);
+int_uint_consts!(u64, 2, u64x2, 128);
 
 unsafe impl Zeroable for u64x2 {}
 unsafe impl Pod for u64x2 {}
@@ -310,8 +310,8 @@ impl_shr_t_for_u64x2!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 impl u64x2 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u64; 2]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u64; 2]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -311,7 +311,7 @@ impl u64x2 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u64; 2]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -237,7 +237,7 @@ impl u64x4 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u64; 4]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -12,7 +12,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u64, 4, u64x4, u64x4, u64a4, const_u64_as_u64x4, 256);
+int_uint_consts!(u64, 4, u64x4, 256);
 
 unsafe impl Zeroable for u64x4 {}
 unsafe impl Pod for u64x4 {}
@@ -236,8 +236,8 @@ impl_shr_t_for_u64x4!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 impl u64x4 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u64; 4]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u64; 4]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -280,7 +280,7 @@ impl u8x16 {
   #[inline]
   #[must_use]
   pub const fn new(array: [u8; 16]) -> Self {
-    unsafe { std::mem::transmute(array) }
+    unsafe { core::intrinsics::transmute(array) }
   }
   #[inline]
   #[must_use]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -55,7 +55,7 @@ pick! {
   }
 }
 
-int_uint_consts!(u8, 16, u8x16, u8x16, u8a16, const_u8_as_u8x16, 128);
+int_uint_consts!(u8, 16, u8x16, 128);
 
 unsafe impl Zeroable for u8x16 {}
 unsafe impl Pod for u8x16 {}
@@ -279,8 +279,8 @@ impl BitXor for u8x16 {
 impl u8x16 {
   #[inline]
   #[must_use]
-  pub fn new(array: [u8; 16]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [u8; 16]) -> Self {
+    unsafe { std::mem::transmute(array) }
   }
   #[inline]
   #[must_use]


### PR DESCRIPTION
Making new const simplified a bunch of code and allows users of this library to define their own constants without having to do anything hacky. 

It does mean that it uses transmute directly, but we know the source and destination types, and alignment isn't an issue since the parameters are by value. 