### PR TITLE
Added widening multiply for u16x8, u32x4, u32x8, i32x4 and i32x8

### DIFF
--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1598,7 +1598,8 @@ impl f64x2 {
     cast_mut(self)
   }
 
-  /// Converts the lower two `i32` lanes to two `f64` lanes (and dropping the higher two `i32` lanes)
+  /// Converts the lower two `i32` lanes to two `f64` lanes (and dropping the
+  /// higher two `i32` lanes)
   #[inline]
   pub fn from_i32x4_lower2(v: i32x4) -> Self {
     pick! {
@@ -1619,7 +1620,8 @@ impl f64x2 {
 }
 
 impl From<i32x4> for f64x2 {
-  /// Converts the lower two `i32` lanes to two `f64` lanes (and dropping the higher two `i32` lanes)
+  /// Converts the lower two `i32` lanes to two `f64` lanes (and dropping the
+  /// higher two `i32` lanes)
   #[inline]
   fn from(v: i32x4) -> Self {
     Self::from_i32x4_lower2(v)

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -491,11 +491,16 @@ impl i32x4 {
     }
   }
 
+  /// Multiplies corresponding 32 bit lanes and returns the 64 bit result
+  /// on the corresponding lanes.
+  ///
+  /// Effectively does two multiplies on 128 bit platforms, but is easier
+  /// to use than wrapping mul_widen_i32_odd_m128i individually.
   #[inline]
   #[must_use]
   pub fn mul_widen(self, rhs: Self) -> i64x4 {
     // todo: WASM simd128, but not sure it would really be faster
-    // than what the compiler comes up with.
+    // since simd128 only has full 64 bit i64x2 multiplies.
     pick! {
       if #[cfg(target_feature="avx2")] {
         let a = convert_to_i64_m256i_from_i32_m128i(self.sse);

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -490,6 +490,28 @@ impl i32x4 {
       }
     }
   }
+
+  #[inline]
+  #[must_use]
+  pub fn mul_widen(self, rhs: Self) -> i64x4 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
+        let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
+        cast(mul_i64_low_bits_m256i(a,b))
+      } else {
+        let a: [i32; 4] = cast(self);
+        let b: [i32; 4] = cast(rhs);
+        cast([
+          i64::from(a[0]) * i64::from(b[0]),
+          i64::from(a[1]) * i64::from(b[1]),
+          i64::from(a[2]) * i64::from(b[2]),
+          i64::from(a[3]) * i64::from(b[3]),
+        ])
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn abs(self) -> Self {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -232,8 +232,8 @@ impl_shr_t_for_i32x8!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 /// Shifts lanes by the corresponding lane.
 ///
 /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
-/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of
-/// the type. (same as `wrapping_shr`)
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
 impl Shr<i32x8> for i32x8 {
   type Output = Self;
 
@@ -258,8 +258,8 @@ impl Shr<i32x8> for i32x8 {
 /// Shifts lanes by the corresponding lane.
 ///
 /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of
-/// the type. (same as `wrapping_shl`)
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
 impl Shl<i32x8> for i32x8 {
   type Output = Self;
 

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -4,11 +4,11 @@ pick! {
   if #[cfg(target_feature="avx2")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i64x4 { avx2: m256i }
+    pub struct i64x4 { pub(crate) avx2: m256i }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i64x4 { a : i64x2, b : i64x2 }
+    pub struct i64x4 { pub(crate) a : i64x2, pub(crate) b : i64x2 }
   }
 }
 

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -700,7 +700,8 @@ impl i8x16 {
   /// `rhs`.
   ///
   /// * Index values in the range `[0, 15]` select the i-th element of `self`.
-  /// * Index values that are out of range will cause that output lane to be `0`.
+  /// * Index values that are out of range will cause that output lane to be
+  ///   `0`.
   #[inline]
   pub fn swizzle(self, rhs: i8x16) -> i8x16 {
     pick! {
@@ -727,7 +728,8 @@ impl i8x16 {
     }
   }
 
-  /// Works like [`swizzle`](Self::swizzle) with the following additional details
+  /// Works like [`swizzle`](Self::swizzle) with the following additional
+  /// details
   ///
   /// * Indices in the range `[0, 15]` will select the i-th element of `self`.
   /// * If the high bit of any index is set (meaning that the index is

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -331,13 +331,14 @@ impl i8x32 {
     !self.any()
   }
 
-  /// Returns a new vector with lanes selected from the lanes of the first input vector
-  /// a specified in the second input vector `rhs`.
-  /// The indices i in range `[0, 15]` select the i-th element of `self`. For indices
-  /// outside of the range the resulting lane is `0`.
+  /// Returns a new vector with lanes selected from the lanes of the first input
+  /// vector a specified in the second input vector `rhs`.
+  /// The indices i in range `[0, 15]` select the i-th element of `self`. For
+  /// indices outside of the range the resulting lane is `0`.
   ///
-  /// This note that is the equivalent of two parallel swizzle operations on the two halves of the vector,
-  /// and the indexes each refer to the corresponding half.
+  /// This note that is the equivalent of two parallel swizzle operations on the
+  /// two halves of the vector, and the indexes each refer to the
+  /// corresponding half.
   #[inline]
   pub fn swizzle_half(self, rhs: i8x32) -> i8x32 {
     pick! {
@@ -352,13 +353,15 @@ impl i8x32 {
     }
   }
 
-  /// Indices in the range `[0, 15]` will select the i-th element of `self`. If the high bit
-  /// of any element of `rhs` is set (negative) then the corresponding output
-  /// lane is guaranteed to be zero. Otherwise if the element of `rhs` is within the range `[32, 127]`
-  /// then the output lane is either `0` or `self[rhs[i] % 16]` depending on the implementation.
+  /// Indices in the range `[0, 15]` will select the i-th element of `self`. If
+  /// the high bit of any element of `rhs` is set (negative) then the
+  /// corresponding output lane is guaranteed to be zero. Otherwise if the
+  /// element of `rhs` is within the range `[32, 127]` then the output lane is
+  /// either `0` or `self[rhs[i] % 16]` depending on the implementation.
   ///
-  /// This is the equivalent to two parallel swizzle operations on the two halves of the vector,
-  /// and the indexes each refer to their corresponding half.
+  /// This is the equivalent to two parallel swizzle operations on the two
+  /// halves of the vector, and the indexes each refer to their corresponding
+  /// half.
   #[inline]
   pub fn swizzle_half_relaxed(self, rhs: i8x32) -> i8x32 {
     pick! {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -594,36 +594,36 @@ impl u16x8 {
   /// Multiples two `u16x8` and return the high part of intermediate `u32x8`
   #[inline]
   #[must_use]
-  pub fn mul_keep_high(lhs: Self, rhs: Self) -> Self {
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        Self { sse: mul_u16_keep_high_m128i(lhs.sse, rhs.sse) }
+        Self { sse: mul_u16_keep_high_m128i(self.sse, rhs.sse) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        let lhs_low = unsafe { vget_low_u16(lhs.neon) };
+        let lhs_low = unsafe { vget_low_u16(self.neon) };
         let rhs_low = unsafe { vget_low_u16(rhs.neon) };
 
-        let lhs_high = unsafe { vget_high_u16(lhs.neon) };
+        let lhs_high = unsafe { vget_high_u16(self.neon) };
         let rhs_high = unsafe { vget_high_u16(rhs.neon) };
 
         let low = unsafe { vmull_u16(lhs_low, rhs_low) };
         let high = unsafe { vmull_u16(lhs_high, rhs_high) };
 
-        i16x8 { neon: unsafe { vuzpq_u16(vreinterpretq_u16_u32(low), vreinterpretq_u16_u32(high)).1 } }
+        u16x8 { neon: unsafe { vuzpq_u16(vreinterpretq_u16_u32(low), vreinterpretq_u16_u32(high)).1 } }
       } else if #[cfg(target_feature="simd128")] {
-        let low =  u32x4_extmul_low_u16x8(lhs.simd, rhs.simd);
-        let high = u32x4_extmul_high_u16x8(lhs.simd, rhs.simd);
+        let low =  u32x4_extmul_low_u16x8(self.simd, rhs.simd);
+        let high = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
 
-        Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
+        Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
       } else {
         u16x8::new([
-          ((u32::from(rhs.as_array_ref()[0]) * u32::from(lhs.as_array_ref()[0])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[1]) * u32::from(lhs.as_array_ref()[1])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[2]) * u32::from(lhs.as_array_ref()[2])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[3]) * u32::from(lhs.as_array_ref()[3])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[4]) * u32::from(lhs.as_array_ref()[4])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[5]) * u32::from(lhs.as_array_ref()[5])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[6]) * u32::from(lhs.as_array_ref()[6])) >> 16) as u16,
-          ((u32::from(rhs.as_array_ref()[7]) * u32::from(lhs.as_array_ref()[7])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[0]) * u32::from(self.as_array_ref()[0])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[1]) * u32::from(self.as_array_ref()[1])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[2]) * u32::from(self.as_array_ref()[2])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[3]) * u32::from(self.as_array_ref()[3])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[4]) * u32::from(self.as_array_ref()[4])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[5]) * u32::from(self.as_array_ref()[5])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[6]) * u32::from(self.as_array_ref()[6])) >> 16) as u16,
+          ((u32::from(rhs.as_array_ref()[7]) * u32::from(self.as_array_ref()[7])) >> 16) as u16,
         ])
       }
     }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -481,6 +481,8 @@ impl u32x4 {
     }
   }
 
+  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the result.
+  /// Useful for implementing divide constant value (see t_usefulness example)
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -454,6 +454,8 @@ impl u32x4 {
     pick! {
       if #[cfg(target_feature="sse2")] {
         cast(mul_widen_u32_odd_m128i(self.sse, rhs.sse))
+      } else if #[cfg(target_feature="simd128")] {
+        u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs.simd & i64x2::splat(0xffffffff))).simd }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
           u64x2 { neon: vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)) }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -455,7 +455,9 @@ impl u32x4 {
       if #[cfg(target_feature="sse2")] {
         cast(mul_widen_u32_odd_m128i(self.sse, rhs.sse))
       } else if #[cfg(target_feature="simd128")] {
-        u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs & i64x2::splat(0xffffffff)).simd) }
+        u64x2 { simd: i64x2_mul(
+          v128_and(self.simd, u64x2_splat(0xffffffff)), 
+          v128_and(rhs.simd, u64x2_splat(0xffffffff)) ) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
           let a = vget_low_u32(vuzpq_u32(self.neon, self.neon).0);

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -491,9 +491,8 @@ impl u32x4 {
 
     pick! {
       if #[cfg(target_feature="avx2")] {
-        // ok to sign extend since we are throwing away the high half of the result anyway
-        let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
-        let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
+        let a = convert_to_i64_m256i_from_u32_m128i(self.sse);
+        let b = convert_to_i64_m256i_from_u32_m128i(rhs.sse);
         let r = mul_u64_low_bits_m256i(a, b);
 
         // the compiler does a good job shuffling the lanes around

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -458,10 +458,10 @@ impl u32x4 {
         u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs.simd & i64x2::splat(0xffffffff))).simd }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
-          let a = vuzpq_u32(self.neon, self.neon);
-          let b = vuzpq_u32(rhs.neon, rhs.neon);
+          let a = vget_low_u32(vuzpq_u32(self.neon, self.neon).0);
+          let b = vget_low_u32(vuzpq_u32(rhs.neon, rhs.neon).0);
 
-          u64x2 { neon: vmull_u32(vget_low_u32(a), vget_low_u32(b)) }
+          u64x2 { neon: vmull_u32(a, b) }
         }
       } else {
         let a: [u32; 4] = cast(self);

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -455,7 +455,7 @@ impl u32x4 {
       if #[cfg(target_feature="sse2")] {
         cast(mul_widen_u32_odd_m128i(self.sse, rhs.sse))
       } else if #[cfg(target_feature="simd128")] {
-        u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs.simd & i64x2::splat(0xffffffff))).simd }
+        u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs & i64x2::splat(0xffffffff)).simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
           let a = vget_low_u32(vuzpq_u32(self.neon, self.neon).0);

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -513,16 +513,16 @@ impl u32x4 {
         unsafe {
           let l = vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon));
           let h = vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon));
-          u32x4 { neon: vcombine_u32(vshrn_n_u64(l,32), vshrn_n_u64(l,32)) }
+          u32x4 { neon: vcombine_u32(vshrn_n_u64(l,32), vshrn_n_u64(h,32)) }
         }
       } else {
         let a: [u32; 4] = cast(self);
         let b: [u32; 4] = cast(rhs);
         cast([
           ((u64::from(a[0]) * u64::from(b[0])) >> 32) as u32,
-          ((u64::from(a[1]) * u64::from(b[1])) >> 32) as u32
-          ((u64::from(a[2]) * u64::from(b[2])) >> 32) as u32
-          ((u64::from(a[3]) * u64::from(b[3])) >> 32) as u32
+          ((u64::from(a[1]) * u64::from(b[1])) >> 32) as u32,
+          ((u64::from(a[2]) * u64::from(b[2])) >> 32) as u32,
+          ((u64::from(a[3]) * u64::from(b[3])) >> 32) as u32,
         ])
       }
     }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -458,7 +458,10 @@ impl u32x4 {
         u64x2 { simd: i64x2_mul((self & i64x2::splat(0xffffffff)).simd, (rhs.simd & i64x2::splat(0xffffffff))).simd }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
-          u64x2 { neon: vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)) }
+          let a = vuzpq_u32(self.neon, self.neon);
+          let b = vuzpq_u32(rhs.neon, rhs.neon);
+
+          u64x2 { neon: vmull_u32(vget_low_u32(a), vget_low_u32(b)) }
         }
       } else {
         let a: [u32; 4] = cast(self);

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -502,12 +502,12 @@ impl u32x4 {
   /// on the corresponding lanes.
   ///
   /// Effectively does two multiplies on 128 bit platforms, but is easier
-  /// to use than the even version, and runs fast on AVX2.
+  /// to use than wrapping mul_widen_u32_odd_m128i individually.
   #[inline]
   #[must_use]
   pub fn mul_widen(self, rhs: Self) -> u64x4 {
     // todo: WASM simd128, but not sure it would really be faster
-    // than what the compiler comes up with.
+    // since simd128 only has full 64 bit i64x2 multiplies.
 
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -301,14 +301,18 @@ impl u32x8 {
     rhs.cmp_gt(self)
   }
 
-  pub fn mul_widen_odd(self: u32x8, rhs: u32x8) -> u64x4 {
+  /// Multiplies the 32 bit values lane 0, 2, 4, 6
+  /// returns the corresponding 64 bit result in lanes 0,1,2,3.
+  #[inline]
+  #[must_use]
+  pub fn mul_widen_even(self: u32x8, rhs: u32x8) -> u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         cast(mul_u64_low_bits_m256i(self.avx2, rhs.avx2))
       } else {
         u64x4 {
-          a : self.a.mul_widen_odd(rhs.a),
-          b : self.b.mul_widen_odd(rhs.b),
+          a : self.a.mul_widen_even(rhs.a),
+          b : self.b.mul_widen_even(rhs.b),
         }
       }
     }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -325,7 +325,10 @@ impl u32x8 {
   pub fn mul_keep_high(self: u32x8, rhs: u32x8) -> u32x8 {
     // avx2 doesn't benefit here sice the u32x4 is already using it,
     // maybe it might help with the shuffling afterwards
-    u32x8 { a: self.a.mul_keep_high(rhs.a), b: self.b.mul_keep_high(rhs.b) }
+    let a: [u32x4; 2] = cast(self);
+    let b: [u32x4; 2] = cast(rhs);
+
+    cast([a[0].mul_keep_high(b[0]), a[1].mul_keep_high(b[1])])
   }
 
   #[inline]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -304,7 +304,7 @@ impl u32x8 {
   pub fn mul_widen_odd(self: u32x8, rhs: u32x8) -> u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        cast(mul_widen_u32_odd_m256i(self.avx2, rhs.avx2))
+        cast(mul_u64_low_bits_m256i(self.avx2, rhs.avx2))
       } else {
         u64x4 {
           a : self.a.mul_widen_odd(rhs.a),

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -301,6 +301,19 @@ impl u32x8 {
     rhs.cmp_gt(self)
   }
 
+  pub fn mul_widen_odd(self: u32x8, rhs: u32x8) -> u64x4 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        cast(mul_widen_u32_odd_m256i(self.avx2, rhs.avx2))
+      } else {
+        u64x4 {
+          a : self.a.mul_widen_odd(rhs.a),
+          b : self.b.mul_widen_odd(rhs.b),
+        }
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn blend(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -208,8 +208,8 @@ impl_shr_t_for_u32x8!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 /// Shifts lanes by the corresponding lane.
 ///
 /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
-/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of
-/// the type. (same as `wrapping_shr`)
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
 impl Shr<u32x8> for u32x8 {
   type Output = Self;
 
@@ -234,8 +234,8 @@ impl Shr<u32x8> for u32x8 {
 /// Shifts lanes by the corresponding lane.
 ///
 /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of
-/// the type. (same as `wrapping_shl`)
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
 impl Shl<u32x8> for u32x8 {
   type Output = Self;
 
@@ -301,8 +301,9 @@ impl u32x8 {
     rhs.cmp_gt(self)
   }
 
-  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the result.
-  /// Useful for implementing divide constant value (see t_usefulness example)
+  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the
+  /// result. Useful for implementing divide constant value (see t_usefulness
+  /// example)
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: u32x8) -> u32x8 {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -301,28 +301,11 @@ impl u32x8 {
     rhs.cmp_gt(self)
   }
 
-  /// Multiplies the 32 bit values lane 0, 2, 4, 6
-  /// returns the corresponding 64 bit result in lanes 0,1,2,3.
-  #[inline]
-  #[must_use]
-  pub fn mul_widen_even(self: u32x8, rhs: u32x8) -> u64x4 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        cast(mul_u64_low_bits_m256i(self.avx2, rhs.avx2))
-      } else {
-        u64x4 {
-          a : self.a.mul_widen_even(rhs.a),
-          b : self.b.mul_widen_even(rhs.b),
-        }
-      }
-    }
-  }
-
   /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the result.
   /// Useful for implementing divide constant value (see t_usefulness example)
   #[inline]
   #[must_use]
-  pub fn mul_keep_high(self: u32x8, rhs: u32x8) -> u32x8 {
+  pub fn mul_keep_high(self, rhs: u32x8) -> u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let a : [u32;8]= cast(self);
@@ -334,10 +317,10 @@ impl u32x8 {
 
         cast([r1[1], r1[3], r1[5], r1[7], r2[1], r2[3], r2[5], r2[7]])
       } else {
-        let a: [u32x4; 2] = cast(self);
-        let b: [u32x4; 2] = cast(rhs);
-
-        cast([a[0].mul_keep_high(b[0]), a[1].mul_keep_high(b[1])])
+        Self {
+          a : self.a.mul_keep_high(rhs.a),
+          b : self.b.mul_keep_high(rhs.b),
+        }
       }
     }
   }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -318,6 +318,16 @@ impl u32x8 {
     }
   }
 
+  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the result.
+  /// Useful for implementing divide constant value (see t_usefulness example)
+  #[inline]
+  #[must_use]
+  pub fn mul_keep_high(self: u32x8, rhs: u32x8) -> u32x8 {
+    // avx2 doesn't benefit here sice the u32x4 is already using it,
+    // maybe it might help with the shuffling afterwards
+    u32x8 { a: self.a.mul_keep_high(rhs.a), b: self.b.mul_keep_high(rhs.b) }
+  }
+
   #[inline]
   #[must_use]
   pub fn blend(self, t: Self, f: Self) -> Self {

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -32,7 +32,8 @@ fn next_rand_u64(state: &mut u64) -> u64 {
   const A: u64 = 6364136223846793005;
   const C: u64 = 1442695040888963407;
 
-  // Update the state and calculate the next number (rotate to avoid lack of randomness in low bits)
+  // Update the state and calculate the next number (rotate to avoid lack of
+  // randomness in low bits)
   *state = state.wrapping_mul(A).wrapping_add(C).rotate_left(31);
 
   *state

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -369,10 +369,27 @@ fn impl_i16x8_reduce_max() {
 
 #[test]
 fn impl_mul_keep_high() {
-  let a = i16x8::from([1, 200, 300, 4568, -1, -2, -3, -4]);
-  let b = i16x8::from([5, 600, 700, 8910, -15, -26, -37, 48]);
+  let a = i16x8::from([i16::MAX, 200, 300, 4568, -1, -2, -3, -4]);
+  let b = i16x8::from([i16::MIN, 600, 700, 8910, -15, -26, -37, 48]);
   let c: [i16; 8] = i16x8::mul_keep_high(a, b).into();
-  assert_eq!(c, [0, 1, 3, 621, 0, 0, 0, -1]);
+  assert_eq!(
+    c,
+    [
+      (i32::from(i16::MAX) * i32::from(i16::MIN) >> 16) as i16,
+      1,
+      3,
+      621,
+      0,
+      0,
+      0,
+      -1
+    ]
+  );
+
+  crate::test_random_vector_vs_scalar(
+    |a: i16x8, b| i16x8::mul_keep_high(a, b),
+    |a, b| ((i32::from(a) * i32::from(b)) >> 16) as i16,
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -266,3 +266,22 @@ fn impl_i32x4_shl_each() {
     |a, b| a.wrapping_shl(b as u32),
   );
 }
+
+#[test]
+fn impl_i32x4_mul_widen() {
+  let a = i32x4::from([1, 2, 3 * -1000000, i32::MAX]);
+  let b = i32x4::from([5, 6, 7 * -1000000, i32::MIN]);
+  let expected = i64x4::from([
+    1 * 5,
+    2 * 6,
+    3 * 7 * 1000000 * 1000000,
+    i32::MIN as i64 * i32::MAX as i64,
+  ]);
+  let actual = a.mul_widen(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: i32x4, b| a.mul_widen(b),
+    |a, b| a as i64 * b as i64,
+  );
+}

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -219,6 +219,31 @@ fn impl_u16x8_from_u8x16_high() {
 }
 
 #[test]
+fn impl_u16x8_mul_keep_high() {
+  let a = u16x8::from([u16::MAX, 200, 300, 4568, 1, 2, 3, 200]);
+  let b = u16x8::from([u16::MAX, 600, 700, 8910, 15, 26, 37, 600]);
+  let c: [u16; 8] = u16x8::mul_keep_high(a, b).into();
+  assert_eq!(
+    c,
+    [
+      (u32::from(u16::MAX) * u32::from(u16::MAX) >> 16) as u16,
+      1,
+      3,
+      621,
+      0,
+      0,
+      0,
+      1
+    ]
+  );
+
+  crate::test_random_vector_vs_scalar(
+    |a: u16x8, b| u16x8::mul_keep_high(a, b),
+    |a, b| ((u32::from(a) * u32::from(b)) >> 16) as u16,
+  );
+}
+
+#[test]
 fn impl_u16x8_mul_widen() {
   let a = u16x8::from([1, 2, 3, 4, 5, 6, i16::MAX as u16, u16::MAX]);
   let b = u16x8::from([17, 18, 190, 20, 21, 22, i16::MAX as u16, u16::MAX]);

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -236,11 +236,30 @@ fn test_u32x4_none() {
 }
 
 #[test]
-fn test_u32x4_mul_widen_odd() {
-  let a = u32x4::from([10, 2, 0xffffffff, 4]);
-  let b = u32x4::from([50, 6, 0xffffffff, 8]);
+fn test_u32x4_mul_widen_even() {
+  let a = u32x4::from([10, 2 /*ignored*/, 0xffffffff, 4 /*ignored*/]);
+  let b = u32x4::from([50, 6 /*ignored*/, 0xffffffff, 8 /*ignored*/]);
 
   let expected = u64x2::from([10 * 50, 0xffffffff * 0xffffffff]);
-  let actual = a.mul_widen_odd(b);
+  let actual = a.mul_widen_even(b);
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_u32x4_mul_widen() {
+  let a = u32x4::from([1, 2, 3 * 1000000, u32::MAX]);
+  let b = u32x4::from([5, 6, 7 * 1000000, u32::MAX]);
+  let expected = u64x4::from([
+    1 * 5,
+    2 * 6,
+    3 * 7 * 1000000 * 1000000,
+    u32::MAX as u64 * u32::MAX as u64,
+  ]);
+  let actual = a.mul_widen(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x4, b| a.mul_widen(b),
+    |a, b| u64::from(a) * u64::from(b),
+  );
 }

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -237,10 +237,10 @@ fn test_u32x4_none() {
 
 #[test]
 fn test_u32x4_mul_widen_odd() {
-  let a = u32x4::from([1, 2, 3 * 1000000, 4]);
-  let b = u32x4::from([5, 6, 7 * 1000000, 8]);
+  let a = u32x4::from([10, 2, 0xffffffff, 4]);
+  let b = u32x4::from([50, 6, 0xffffffff, 8]);
 
-  let expected = u64x2::from([5 * 1, 3 * 7 * 1000000 * 1000000]);
+  let expected = u64x2::from([10 * 50, 0xffffffff * 0xffffffff]);
   let actual = a.mul_widen_odd(b);
   assert_eq!(expected, actual);
 }

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -237,16 +237,6 @@ fn test_u32x4_none() {
 }
 
 #[test]
-fn test_u32x4_mul_widen_even() {
-  let a = u32x4::from([10, 2 /*ignored*/, 0xffffffff, 4 /*ignored*/]);
-  let b = u32x4::from([50, 6 /*ignored*/, 0xffffffff, 8 /*ignored*/]);
-
-  let expected = u64x2::from([10 * 50, 0xffffffff * 0xffffffff]);
-  let actual = a.mul_widen_even(b);
-  assert_eq!(expected, actual);
-}
-
-#[test]
 fn impl_u32x4_mul_widen() {
   let a = u32x4::from([1, 2, 3 * 1000000, u32::MAX]);
   let b = u32x4::from([5, 6, 7 * 1000000, u32::MAX]);

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -234,3 +234,13 @@ fn test_u32x4_none() {
   let a = u32x4::from([0; 4]);
   assert!(a.none());
 }
+
+#[test]
+fn test_u32x4_mul_widen_odd() {
+  let a = u32x4::from([1, 2, 3 * 1000000, 4]);
+  let b = u32x4::from([5, 6, 7 * 1000000, 8]);
+
+  let expected = u64x2::from([5 * 1, 3 * 7 * 1000000 * 1000000]);
+  let actual = a.mul_widen_odd(b);
+  assert_eq!(expected, actual);
+}

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -1,4 +1,5 @@
 use std::num::Wrapping;
+
 use wide::*;
 
 #[test]
@@ -261,5 +262,25 @@ fn impl_u32x4_mul_widen() {
   crate::test_random_vector_vs_scalar(
     |a: u32x4, b| a.mul_widen(b),
     |a, b| u64::from(a) * u64::from(b),
+  );
+}
+
+#[test]
+fn impl_u32x4_mul_keep_high() {
+  let mul_high = |a: u32, b: u32| ((u64::from(a) * u64::from(b)) >> 32) as u32;
+  let a = u32x4::from([1, 2 * 10000000, 3 * 1000000, u32::MAX]);
+  let b = u32x4::from([5, 6 * 100, 7 * 1000000, u32::MAX]);
+  let expected = u32x4::from([
+    mul_high(1, 5),
+    mul_high(2 * 10000000, 6 * 100),
+    mul_high(3 * 1000000, 7 * 1000000),
+    mul_high(u32::MAX, u32::MAX),
+  ]);
+  let actual = a.mul_keep_high(b);
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u32x4, b| a.mul_keep_high(b),
+    |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32,
   );
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -297,12 +297,21 @@ fn test_u32x8_none() {
 }
 
 #[test]
-fn test_u32x8_mul_widen_odd() {
-  let a = u32x8::from([1, 2, 3, 4, 5, 6, 0xffffffff, 8]);
-  let b = u32x8::from([9, 10, 11, 12, 13, 14, 0xffffffff, 16]);
+fn test_u32x8_mul_widen_even() {
+  let a = u32x8::from([
+    1, 2, /*odd ignored*/
+    3, 4, /*odd ignored*/
+    5, 6, /*odd ignored*/
+    0xffffffff, 8, /*odd ignored*/
+  ]);
+  let b = u32x8::from([
+    9, 10, /*odd ignored*/
+    11, 12, /*odd ignored*/
+    13, 14, /*odd ignored*/
+    0xffffffff, 16, /*odd ignored*/
+  ]);
 
-  let expected =
-    u64x4::from([1 * 9, 3 * 11, 5 * 13, 0xffffffff * 0xffffffff]);
-  let actual = a.mul_widen_odd(b);
+  let expected = u64x4::from([1 * 9, 3 * 11, 5 * 13, 0xffffffff * 0xffffffff]);
+  let actual = a.mul_widen_even(b);
   assert_eq!(expected, actual);
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -295,3 +295,14 @@ fn test_u32x8_none() {
   let a = u32x8::from([0; 8]);
   assert!(a.none());
 }
+
+#[test]
+fn test_u32x8_mul_widen_odd() {
+  let a = u32x8::from([1, 2, 3, 4, 5, 6, 7 * 1000000, 8]);
+  let b = u32x8::from([9, 10, 11, 12, 13, 14, 15 * 1000000, 16]);
+
+  let expected =
+    u64x4::from([1 * 9, 3 * 11, 5 * 13, 7 * 15 * 1000000 * 1000000]);
+  let actual = a.mul_widen_odd(b);
+  assert_eq!(expected, actual);
+}

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -297,29 +297,9 @@ fn test_u32x8_none() {
 }
 
 #[test]
-fn test_u32x8_mul_widen_even() {
-  let a = u32x8::from([
-    1, 2, /*odd ignored*/
-    3, 4, /*odd ignored*/
-    5, 6, /*odd ignored*/
-    0xffffffff, 8, /*odd ignored*/
-  ]);
-  let b = u32x8::from([
-    9, 10, /*odd ignored*/
-    11, 12, /*odd ignored*/
-    13, 14, /*odd ignored*/
-    0xffffffff, 16, /*odd ignored*/
-  ]);
-
-  let expected = u64x4::from([1 * 9, 3 * 11, 5 * 13, 0xffffffff * 0xffffffff]);
-  let actual = a.mul_widen_even(b);
-  assert_eq!(expected, actual);
-}
-
-#[test]
 fn impl_u32x8_mul_keep_high() {
   crate::test_random_vector_vs_scalar(
-    |a: u32x8, b| a.mul_keep_high(b),
+    |a: u32x8, b| u32x8::mul_keep_high(a, b),
     |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32,
   );
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -298,11 +298,11 @@ fn test_u32x8_none() {
 
 #[test]
 fn test_u32x8_mul_widen_odd() {
-  let a = u32x8::from([1, 2, 3, 4, 5, 6, 7 * 1000000, 8]);
-  let b = u32x8::from([9, 10, 11, 12, 13, 14, 15 * 1000000, 16]);
+  let a = u32x8::from([1, 2, 3, 4, 5, 6, 0xffffffff, 8]);
+  let b = u32x8::from([9, 10, 11, 12, 13, 14, 0xffffffff, 16]);
 
   let expected =
-    u64x4::from([1 * 9, 3 * 11, 5 * 13, 7 * 15 * 1000000 * 1000000]);
+    u64x4::from([1 * 9, 3 * 11, 5 * 13, 0xffffffff * 0xffffffff]);
   let actual = a.mul_widen_odd(b);
   assert_eq!(expected, actual);
 }

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -315,3 +315,11 @@ fn test_u32x8_mul_widen_even() {
   let actual = a.mul_widen_even(b);
   assert_eq!(expected, actual);
 }
+
+#[test]
+fn impl_u32x8_mul_keep_high() {
+  crate::test_random_vector_vs_scalar(
+    |a: u32x8, b| a.mul_keep_high(b),
+    |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32,
+  );
+}

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -391,22 +391,12 @@ fn generate_branch_free_divide_magic_shift(denom: u32x8) -> (u32x8, u32x8) {
 
 // using the previously generated magic and shift, calculate the division
 fn branch_free_divide(numerator: u32x8, magic: u32x8, shift: u32x8) -> u32x8 {
-  // Returns 32 high bits of the 64 bit result of multiplication of two u32s
-  let mul_hi = |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32;
+  let a: [u32x4; 2] = cast(numerator);
+  let b: [u32x4; 2] = cast(magic);
 
-  let a = numerator.as_array_ref();
-  let b = magic.as_array_ref();
+  let q = [a[0].mul_keep_high(b[0]), a[1].mul_keep_high(b[1])];
 
-  let q = u32x8::from([
-    mul_hi(a[0], b[0]),
-    mul_hi(a[1], b[1]),
-    mul_hi(a[2], b[2]),
-    mul_hi(a[3], b[3]),
-    mul_hi(a[4], b[4]),
-    mul_hi(a[5], b[5]),
-    mul_hi(a[6], b[6]),
-    mul_hi(a[7], b[7]),
-  ]);
+  let q: u32x8 = cast(q);
 
   let t = ((numerator - q) >> 1) + q;
   t >> shift

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -391,7 +391,7 @@ fn generate_branch_free_divide_magic_shift(denom: u32x8) -> (u32x8, u32x8) {
 
 // using the previously generated magic and shift, calculate the division
 fn branch_free_divide(numerator: u32x8, magic: u32x8, shift: u32x8) -> u32x8 {
-  let q = numerator.mul_keep_high(magic);
+  let q = u32x8::mul_keep_high(numerator, magic);
 
   let t = ((numerator - q) >> 1) + q;
   t >> shift

--- a/tests/all_tests/t_usefulness.rs
+++ b/tests/all_tests/t_usefulness.rs
@@ -391,12 +391,7 @@ fn generate_branch_free_divide_magic_shift(denom: u32x8) -> (u32x8, u32x8) {
 
 // using the previously generated magic and shift, calculate the division
 fn branch_free_divide(numerator: u32x8, magic: u32x8, shift: u32x8) -> u32x8 {
-  let a: [u32x4; 2] = cast(numerator);
-  let b: [u32x4; 2] = cast(magic);
-
-  let q = [a[0].mul_keep_high(b[0]), a[1].mul_keep_high(b[1])];
-
-  let q: u32x8 = cast(q);
+  let q = numerator.mul_keep_high(magic);
 
   let t = ((numerator - q) >> 1) + q;
   t >> shift


### PR DESCRIPTION
Add implementations for all the intrinsics @Melirius might be interested

Also ran cargo fmt +nightly, so some comments got wrapped
