### PR TITLE
fix serialize impl of SIMD types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ serde = ["dep:serde"]
 safe_arch = { version = "0.7", features = ["bytemuck"] }
 serde = { version = "1", default-features = false, optional = true }
 bytemuck = "1"
+
+[dev-dependencies]
+bincode = { version = "1.3.3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use safe_arch::*;
 use bytemuck::*;
 
 #[cfg(feature = "serde")]
-use serde::{ser::SerializeSeq, Deserialize, Serialize};
+use serde::{ser::SerializeTuple, Deserialize, Serialize};
 
 #[macro_use]
 mod macros;
@@ -926,7 +926,7 @@ bulk_impl_const_rhs_op!((CmpLe, cmp_le) => [(f64x4, f64), (f64x2, f64), (f32x4,f
 bulk_impl_const_rhs_op!((CmpGe, cmp_ge) => [(f64x4, f64), (f64x2, f64), (f32x4,f32), (f32x8,f32),]);
 
 macro_rules! impl_serde {
-  ($i:ident, $t:ty) => {
+  ($i:ident, [$t:ty; $len:expr]) => {
     #[cfg(feature = "serde")]
     impl Serialize for $i {
       #[inline]
@@ -935,7 +935,7 @@ macro_rules! impl_serde {
         S: serde::Serializer,
       {
         let array = self.as_array_ref();
-        let mut seq = serializer.serialize_seq(Some(array.len()))?;
+        let mut seq = serializer.serialize_tuple($len)?;
         for e in array {
           seq.serialize_element(e)?;
         }
@@ -950,7 +950,7 @@ macro_rules! impl_serde {
       where
         D: serde::Deserializer<'de>,
       {
-        Ok(<$t>::deserialize(deserializer)?.into())
+        Ok(<[$t; $len]>::deserialize(deserializer)?.into())
       }
     }
   };

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -839,3 +839,13 @@ fn impl_f32x4_from_i32x4() {
   let f = f32x4::from([1.0, 2.0, 3.0, 4.0]);
   assert_eq!(f32x4::from_i32x4(i), f)
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_f32x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&f32x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(f32x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -956,3 +956,13 @@ fn impl_f32x8_from_i32x8() {
   let f = f32x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
   assert_eq!(f32x8::from_i32x8(i), f)
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_f32x8_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&f32x8::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(f32x8::ZERO, deserialized);
+}

--- a/tests/all_tests/t_f64x2.rs
+++ b/tests/all_tests/t_f64x2.rs
@@ -850,3 +850,13 @@ fn impl_f64x2_from_i32x4() {
   let f = f64x2::from([1.0, 2.0]);
   assert_eq!(f64x2::from_i32x4_lower2(i), f)
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_f64x2_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&f64x2::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(f64x2::ZERO, deserialized);
+}

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -735,3 +735,13 @@ fn impl_f64x4_from_i32x4() {
   assert_eq!(f64x4::from(i), f);
   assert_eq!(f64x4::from_i32x4(i), f);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_f64x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&f64x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(f64x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i16x16.rs
+++ b/tests/all_tests/t_i16x16.rs
@@ -700,3 +700,13 @@ fn impl_i16x16_reduce_max() {
     assert_eq!(p.reduce_min(), i16::MIN);
   }
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i16x16_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i16x16::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i16x16::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -414,3 +414,13 @@ fn impl_i16x8_mul_widen() {
     |a, b| i32::from(a) * i32::from(b),
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i16x8_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i16x8::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i16x8::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -285,3 +285,13 @@ fn impl_i32x4_mul_widen() {
     |a, b| a as i64 * b as i64,
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i32x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i32x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i32x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -379,3 +379,13 @@ fn impl_i32x8_shl_each() {
     |a, b| a.wrapping_shl(b as u32),
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i32x8_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i32x8::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i32x8::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i64x2.rs
+++ b/tests/all_tests/t_i64x2.rs
@@ -159,3 +159,13 @@ fn test_i64x2_move_mask() {
     |acc, a, idx| acc | if a < 0 { 1 << idx } else { 0 },
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i64x2_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i64x2::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i64x2::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i64x4.rs
+++ b/tests/all_tests/t_i64x4.rs
@@ -185,3 +185,13 @@ fn test_i32x4_none() {
     |acc, a, _idx| acc & !(a < 0),
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i64x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i64x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i64x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -461,3 +461,13 @@ fn test_i8x16_swizzle_relaxed() {
   let actual = a.swizzle_relaxed(b);
   assert_eq!(expected, actual);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i8x16_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i8x16::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i8x16::ZERO, deserialized);
+}

--- a/tests/all_tests/t_i8x32.rs
+++ b/tests/all_tests/t_i8x32.rs
@@ -610,3 +610,13 @@ fn test_i8x32_swizzle_half() {
   let actual = a.swizzle_half(b);
   assert_eq!(expected, actual);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_i8x32_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&i8x32::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(i8x32::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u16x16.rs
+++ b/tests/all_tests/t_u16x16.rs
@@ -418,3 +418,13 @@ fn impl_mul_for_u16x16() {
     |a, b| a.wrapping_mul(b),
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u16x16_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u16x16::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u16x16::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -265,3 +265,13 @@ fn impl_u16x8_mul_widen() {
     |a, b| u32::from(a) * u32::from(b),
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u16x8_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u16x8::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u16x8::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -274,3 +274,13 @@ fn impl_u32x4_mul_keep_high() {
     |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32,
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u32x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u32x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u32x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -303,3 +303,13 @@ fn impl_u32x8_mul_keep_high() {
     |a, b| ((u64::from(a) * u64::from(b)) >> 32) as u32,
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u32x8_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u32x8::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u32x8::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u64x2.rs
+++ b/tests/all_tests/t_u64x2.rs
@@ -131,3 +131,13 @@ fn impl_u64x2_cmp_lt() {
     |a, b| if a < b { u64::MAX } else { 0 },
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u64x2_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u64x2::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u64x2::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u64x4.rs
+++ b/tests/all_tests/t_u64x4.rs
@@ -129,3 +129,13 @@ fn impl_u64x4_cmp_lt() {
     |a, b| if a < b { u64::MAX } else { 0 },
   );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u64x4_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u64x4::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u64x4::ZERO, deserialized);
+}

--- a/tests/all_tests/t_u8x16.rs
+++ b/tests/all_tests/t_u8x16.rs
@@ -219,3 +219,13 @@ fn impl_narrow_i16x8() {
   let c: [u8; 16] = u8x16::narrow_i16x8(a, b).into();
   assert_eq!(c, [0, 2, 0, 4, 0, 6, 0, 8, 9, 10, 11, 12, 13, 0, 15, 0]);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_u8x16_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&u8x16::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(u8x16::ZERO, deserialized);
+}


### PR DESCRIPTION
change serialization of SIMD types to use serde::Serializer::serialize_tuple

The Serialize implementation of all types used Serializer::serialize_seq whereas the deserialize implementation delegated to that of the corresponding [T; LEN] type, which is implemented by serde using serialize_tuple. Formats like bincode will emit the lenght of the sequence but not of a tuple, leading to wrong deserialization.

Previously the following code would fail:
```rust
let ser = dbg!(bincode::DefaultOptions::new()
    .serialize(&u8x16::ZERO)
    .unwrap());
let der: u8x16 = bincode::DefaultOptions::new().deserialize(&ser).unwrap();
```
Output:
```
bincode::DefaultOptions::new().serialize(&u8x16::ZERO).unwrap() = [
    16,
    0,
    // 15 more zeros
]
thread 'block::tests::failing_deser' panicked at seec-core/src/block.rs:104:75:
called `Result::unwrap()` on an `Err` value: Custom("Slice had bytes remaining after deserialization")
```

and the following shows the difference between serialization and deserialization:
```rust
let ser = dbg!(bincode::serialize(&u8x16::ZERO).unwrap());
let der: u8x16 = dbg!(bincode::deserialize(&ser).unwrap());
```
Output:
```
[
    16,
    0,
    // 15 more zeros
]
[seec-core/src/block.rs:107:26] bincode::deserialize(&ser).unwrap() = (16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
```

where we can see that the serialized data contains the length of the sequence which ends up in the deserialized vector type. In this case, deserialization does not panic because of the difference between `bincode::DefaultOptions` and the free functions in regards to trailing data.