### PR TITLE
Use wrapping shifts in fallback implementations

### DIFF
--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -301,14 +301,14 @@ macro_rules! impl_shl_t_for_i16x8 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-              self.arr[4] << u,
-              self.arr[5] << u,
-              self.arr[6] << u,
-              self.arr[7] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
+              self.arr[2].wrapping_shl(u),
+              self.arr[3].wrapping_shl(u),
+              self.arr[4].wrapping_shl(u),
+              self.arr[5].wrapping_shl(u),
+              self.arr[6].wrapping_shl(u),
+              self.arr[7].wrapping_shl(u),
             ]}
           }
         }
@@ -337,14 +337,14 @@ macro_rules! impl_shr_t_for_i16x8 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-              self.arr[4] >> u,
-              self.arr[5] >> u,
-              self.arr[6] >> u,
-              self.arr[7] >> u,
+              self.arr[0].wrapping_shr(u),
+              self.arr[1].wrapping_shr(u),
+              self.arr[2].wrapping_shr(u),
+              self.arr[3].wrapping_shr(u),
+              self.arr[4].wrapping_shr(u),
+              self.arr[5].wrapping_shr(u),
+              self.arr[6].wrapping_shr(u),
+              self.arr[7].wrapping_shr(u),
             ]}
           }
         }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -279,10 +279,10 @@ macro_rules! impl_shl_t_for_i32x4 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
+              self.arr[2].wrapping_shl(u),
+              self.arr[3].wrapping_shl(u),
             ]}
           }
         }
@@ -311,10 +311,10 @@ macro_rules! impl_shr_t_for_i32x4 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
+              self.arr[0].wrapping_shr(u),
+              self.arr[1].wrapping_shr(u),
+              self.arr[2].wrapping_shr(u),
+              self.arr[3].wrapping_shr(u),
             ]}
           }
         }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -266,8 +266,8 @@ macro_rules! impl_shl_t_for_i64x2 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
             ]}
           }
         }
@@ -289,11 +289,11 @@ macro_rules! impl_shr_t_for_i64x2 {
           if #[cfg(target_feature="simd128")] {
             Self { simd: i64x2_shr(self.simd, rhs as u32) }
           } else {
-            let u = rhs as u64;
+            let u = rhs as u32;
             let arr: [i64; 2] = cast(self);
             cast([
-              arr[0] >> u,
-              arr[1] >> u,
+              arr[0].wrapping_shr(u),
+              arr[1].wrapping_shr(u),
             ])
           }
         }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -301,14 +301,14 @@ macro_rules! impl_shl_t_for_u16x8 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
-              self.arr[4] << u,
-              self.arr[5] << u,
-              self.arr[6] << u,
-              self.arr[7] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
+              self.arr[2].wrapping_shl(u),
+              self.arr[3].wrapping_shl(u),
+              self.arr[4].wrapping_shl(u),
+              self.arr[5].wrapping_shl(u),
+              self.arr[6].wrapping_shl(u),
+              self.arr[7].wrapping_shl(u),
             ]}
           }
         }
@@ -337,14 +337,14 @@ macro_rules! impl_shr_t_for_u16x8 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
-              self.arr[4] >> u,
-              self.arr[5] >> u,
-              self.arr[6] >> u,
-              self.arr[7] >> u,
+              self.arr[0].wrapping_shr(u),
+              self.arr[1].wrapping_shr(u),
+              self.arr[2].wrapping_shr(u),
+              self.arr[3].wrapping_shr(u),
+              self.arr[4].wrapping_shr(u),
+              self.arr[5].wrapping_shr(u),
+              self.arr[6].wrapping_shr(u),
+              self.arr[7].wrapping_shr(u),
             ]}
           }
         }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -279,10 +279,10 @@ macro_rules! impl_shl_t_for_u32x4 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
-              self.arr[2] << u,
-              self.arr[3] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
+              self.arr[2].wrapping_shl(u),
+              self.arr[3].wrapping_shl(u),
             ]}
           }
         }
@@ -311,10 +311,10 @@ macro_rules! impl_shr_t_for_u32x4 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
-              self.arr[2] >> u,
-              self.arr[3] >> u,
+              self.arr[0].wrapping_shr(u),
+              self.arr[1].wrapping_shr(u),
+              self.arr[2].wrapping_shr(u),
+              self.arr[3].wrapping_shr(u),
             ]}
           }
         }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -266,8 +266,8 @@ macro_rules! impl_shl_t_for_u64x2 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] << u,
-              self.arr[1] << u,
+              self.arr[0].wrapping_shl(u),
+              self.arr[1].wrapping_shl(u),
             ]}
           }
         }
@@ -296,8 +296,8 @@ macro_rules! impl_shr_t_for_u64x2 {
           } else {
             let u = rhs as u64;
             Self { arr: [
-              self.arr[0] >> u,
-              self.arr[1] >> u,
+              self.arr[0].wrapping_shr(u),
+              self.arr[1].wrapping_shr(u),
             ]}
           }
         }


### PR DESCRIPTION
The current fallback implementations of left/right shifts for integers use `<<`/`>>`, which panics when the shift amount is greater than the lane width (e.g. shifting a `u32x4` by 32).
Using `wrapping_shl`/`wrapping_shr` instead would solve this issue and match the behavior of the vectorized versions, which only keep the low bits of the shift amount (see e.g. https://doc.rust-lang.org/core/arch/wasm/fn.u32x4_shr.html).