### PR TITLE
Add `u8x32`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,9 @@ pub use i64x4_::*;
 mod u8x16_;
 pub use u8x16_::*;
 
+mod u8x32_;
+pub use u8x32_::*;
+
 mod u16x8_;
 pub use u16x8_::*;
 
@@ -298,13 +301,13 @@ macro_rules! bulk_impl_op_ref_self_for {
 }
 
 bulk_impl_op_ref_self_for! {
-  (Add, add) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
-  (Sub, sub) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (Add, add) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (Sub, sub) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
   (Mul, mul) => [f32x8, f32x4, f64x4, f64x2, i16x8, i16x16, i32x8, i32x4, u16x8, u16x16],
   (Div, div) => [f32x8, f32x4, f64x4, f64x2],
-  (BitAnd, bitand) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16,u32x8, u32x4, u64x4, u64x2],
-  (BitOr, bitor) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
-  (BitXor, bitxor) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (BitAnd, bitand) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16,u32x8, u32x4, u64x4, u64x2],
+  (BitOr, bitor) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (BitXor, bitxor) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
 }
 
 /// given `type.op(rhs)` and type is Copy, impls `type.op_assign(rhs)`
@@ -326,20 +329,20 @@ macro_rules! bulk_impl_op_assign_for {
 // Note: remember to update bulk_impl_op_ref_self_for first or this will give
 // weird errors!
 bulk_impl_op_assign_for! {
-  (AddAssign<Self>, add, add_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
-  (AddAssign<&Self>, add, add_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
-  (SubAssign<Self>, sub, sub_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
-  (SubAssign<&Self>, sub, sub_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (AddAssign<Self>, add, add_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (AddAssign<&Self>, add, add_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (SubAssign<Self>, sub, sub_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
+  (SubAssign<&Self>, sub, sub_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x4, u64x2],
   (MulAssign<Self>, mul, mul_assign) => [f32x8, f32x4, f64x4, f64x2, i16x8, i16x16, i32x8, i32x4, u16x8, u16x16],
   (MulAssign<&Self>, mul, mul_assign) => [f32x8, f32x4, f64x4, f64x2, i16x8, i16x16, i32x8, i32x4, u16x8, u16x16],
   (DivAssign<Self>, div, div_assign) => [f32x8, f32x4, f64x4, f64x2],
   (DivAssign<&Self>, div, div_assign) => [f32x8, f32x4, f64x4, f64x2],
-  (BitAndAssign<Self>, bitand, bitand_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
-  (BitAndAssign<&Self>, bitand, bitand_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
-  (BitOrAssign<Self>, bitor, bitor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
-  (BitOrAssign<&Self>, bitor, bitor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
-  (BitXorAssign<Self>, bitxor, bitxor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
-  (BitXorAssign<&Self>, bitxor, bitxor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitAndAssign<Self>, bitand, bitand_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitAndAssign<&Self>, bitand, bitand_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitOrAssign<Self>, bitor, bitor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitOrAssign<&Self>, bitor, bitor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitXorAssign<Self>, bitxor, bitxor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
+  (BitXorAssign<&Self>, bitxor, bitxor_assign) => [f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, u16x16, i32x8, i32x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x4, u64x2],
 }
 
 macro_rules! impl_simple_neg {
@@ -366,7 +369,7 @@ macro_rules! impl_simple_neg {
 }
 
 impl_simple_neg! {
-  f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x16, u16x8, u32x8, u32x4, u64x2, u64x4
+  f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x2, u64x4
 }
 
 macro_rules! impl_simple_not {
@@ -393,7 +396,7 @@ macro_rules! impl_simple_not {
 }
 
 impl_simple_not! {
-  f32x4, i8x32, i8x16, i16x8, i16x16, i32x4, i64x2, u8x16, u16x8, u16x16, u32x4, u64x2,
+  f32x4, i8x32, i8x16, i16x8, i16x16, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x4, u64x2,
 }
 
 macro_rules! impl_simple_sum {
@@ -414,7 +417,7 @@ macro_rules! impl_simple_sum {
 }
 
 impl_simple_sum! {
-  f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x16, u16x8, u16x16, u32x8, u32x4, u64x2, u64x4
+  f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x2, u64x4
 }
 
 macro_rules! impl_floating_product {
@@ -483,7 +486,7 @@ impl_from_a_for_b_with_cast! {
   ([f32;8], f32x8),
   ([f32;4], f32x4), ([f64;4], f64x4), ([f64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2), ([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2), ([u64;4], u64x4),
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2), ([u64;4], u64x4),
 }
 
 macro_rules! impl_from_single_value {
@@ -510,7 +513,7 @@ impl_from_single_value! {
   ([f32;8], f32x8),
   ([f32;4], f32x4), ([f64;4], f64x4), ([f64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2), ([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2), ([u64;4], u64x4),
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2), ([u64;4], u64x4),
 }
 
 /// formatter => [(arr, simd)+],+
@@ -540,28 +543,28 @@ macro_rules! impl_formatter_for {
 impl_formatter_for! {
   Binary => [([u32;8], f32x8), ([u32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   Debug => [([f32;8], f32x8), ([f32;4], f32x4), ([f64;4], f64x4), ([f64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   Display => [([f32;8], f32x8), ([f32;4], f32x4), ([f64;4], f64x4), ([f64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   LowerExp => [([f32;8], f32x8), ([f32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   LowerHex => [([u32;8], f32x8), ([u32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   Octal => [([u32;8], f32x8), ([u32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   UpperExp => [([u32;8], f32x8), ([u32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
   UpperHex => [([u32;8], f32x8), ([u32;4], f32x4), ([u64;4], f64x4), ([u64;2], f64x2),
   ([i8;32], i8x32), ([i8;16], i8x16), ([i16;8], i16x8), ([i16;16], i16x16), ([i32;8], i32x8), ([i32;4], i32x4), ([i64;2], i64x2),([i64;4], i64x4),
-  ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
+  ([u8;32], u8x32), ([u8;16], u8x16), ([u16;8], u16x8), ([u16;16], u16x16), ([u32;8], u32x8), ([u32;4], u32x4), ([u64;2], u64x2),([u64;4], u64x4)],
 }
 
 // With const generics this could be simplified I hope
@@ -681,6 +684,7 @@ from_array!(i8, i8, i8x32, 32);
 from_array!(i8, i8, i8x16, 16);
 from_array!(i8, i32, i32x8, 8);
 from_array!(u8, u8, u8x16, 16);
+from_array!(u8, u8, u8x32, 32);
 from_array!(i16, i16, i16x16, 16);
 from_array!(u16, u16, u16x16, 16);
 from_array!(i32, i32, i32x8, 8);
@@ -969,6 +973,7 @@ impl_serde!(i32x8, [i32; 8]);
 impl_serde!(i64x2, [i64; 2]);
 impl_serde!(i64x4, [i64; 4]);
 impl_serde!(u8x16, [u8; 16]);
+impl_serde!(u8x32, [u8; 32]);
 impl_serde!(u16x8, [u16; 8]);
 impl_serde!(u16x16, [u16; 16]);
 impl_serde!(u32x4, [u32; 4]);

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -1,0 +1,256 @@
+use super::*;
+
+pick! {
+  if #[cfg(target_feature="avx2")] {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[repr(C, align(32))]
+    pub struct u8x32 { avx: m256i }
+  } else {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[repr(C, align(32))]
+    pub struct u8x32 { a : u8x16, b : u8x16 }
+  }
+}
+
+int_uint_consts!(u8, 32, u8x32, 256);
+
+unsafe impl Zeroable for u8x32 {}
+unsafe impl Pod for u8x32 {}
+
+impl Add for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: add_i8_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.add(rhs.a),
+          b : self.b.add(rhs.b),
+        }
+      }
+    }
+  }
+}
+
+impl Sub for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: sub_i8_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.sub(rhs.a),
+          b : self.b.sub(rhs.b),
+        }
+      }
+    }
+  }
+}
+
+impl Add<u8> for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u8) -> Self::Output {
+    self.add(Self::splat(rhs))
+  }
+}
+
+impl Sub<u8> for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u8) -> Self::Output {
+    self.sub(Self::splat(rhs))
+  }
+}
+
+impl Add<u8x32> for u8 {
+  type Output = u8x32;
+  #[inline]
+  #[must_use]
+  fn add(self, rhs: u8x32) -> Self::Output {
+    u8x32::splat(self).add(rhs)
+  }
+}
+
+impl Sub<u8x32> for u8 {
+  type Output = u8x32;
+  #[inline]
+  #[must_use]
+  fn sub(self, rhs: u8x32) -> Self::Output {
+    u8x32::splat(self).sub(rhs)
+  }
+}
+
+impl BitAnd for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn bitand(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+          Self { avx : bitand_m256i(self.avx,rhs.avx) }
+      } else {
+          Self {
+            a : self.a.bitand(rhs.a),
+            b : self.b.bitand(rhs.b),
+          }
+      }
+    }
+  }
+}
+
+impl BitOr for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn bitor(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx : bitor_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.bitor(rhs.a),
+          b : self.b.bitor(rhs.b),
+        }
+      }
+    }
+  }
+}
+
+impl BitXor for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn bitxor(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx : bitxor_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.bitxor(rhs.a),
+          b : self.b.bitxor(rhs.b),
+        }
+      }
+    }
+  }
+}
+
+impl CmpEq for u8x32 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx : cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.cmp_eq(rhs.a),
+          b : self.b.cmp_eq(rhs.b),
+        }
+      }
+    }
+  }
+}
+
+impl u8x32 {
+  #[inline]
+  #[must_use]
+  pub const fn new(array: [u8; 32]) -> Self {
+    unsafe { core::intrinsics::transmute(array) }
+  }
+  #[inline]
+  #[must_use]
+  pub fn blend(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+      } else {
+        Self {
+          a : self.a.blend(t.a, f.a),
+          b : self.b.blend(t.b, f.b),
+        }
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn max(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: max_u8_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.max(rhs.a),
+          b : self.b.max(rhs.b),
+        }
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn min(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: min_u8_m256i(self.avx,rhs.avx) }
+      } else {
+        Self {
+          a : self.a.min(rhs.a),
+          b : self.b.min(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn saturating_add(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: add_saturating_u8_m256i(self.avx, rhs.avx) }
+      } else {
+        Self {
+          a : self.a.saturating_add(rhs.a),
+          b : self.b.saturating_add(rhs.b),
+        }
+      }
+    }
+  }
+  #[inline]
+  #[must_use]
+  pub fn saturating_sub(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: sub_saturating_u8_m256i(self.avx, rhs.avx) }
+      } else {
+        Self {
+          a : self.a.saturating_sub(rhs.a),
+          b : self.b.saturating_sub(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn to_array(self) -> [u8; 32] {
+    cast(self)
+  }
+
+  #[inline]
+  pub fn as_array_ref(&self) -> &[u8; 32] {
+    cast_ref(self)
+  }
+
+  #[inline]
+  pub fn as_array_mut(&mut self) -> &mut [u8; 32] {
+    cast_mut(self)
+  }
+}


### PR DESCRIPTION
The lack of `u8x32` seems to be to just be an oversight, so I added it. If there's a reason it's not supported, please let me know.