### PR TITLE
add tests to ensure trait implementation is consistent across all implementations (also fixed broken Not)

### DIFF
--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -301,6 +301,23 @@ impl From<u8x16> for i16x16 {
   }
 }
 
+impl Not for i16x16 {
+  type Output = Self;
+  #[inline]
+  fn not(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: self.avx2.not()  }
+      } else {
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
+      }
+    }
+  }
+}
+
 impl i16x16 {
   #[inline]
   #[must_use]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -203,7 +203,7 @@ impl Not for i8x32 {
   fn not(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: self.avx2.not()  }
+        Self { avx: self.avx.not()  }
       } else {
         Self {
           a : self.a.not(),

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -197,6 +197,23 @@ impl CmpLt for i8x32 {
   }
 }
 
+impl Not for i8x32 {
+  type Output = Self;
+  #[inline]
+  fn not(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: self.avx2.not()  }
+      } else {
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
+      }
+    }
+  }
+}
+
 impl i8x32 {
   #[inline]
   #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,9 +369,10 @@ macro_rules! impl_simple_neg {
 }
 
 impl_simple_neg! {
-  f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x32, u8x16, u16x8, u32x8, u32x4, u64x2, u64x4
+  f32x8, f32x4, f64x4, f64x2, i8x32, i8x16, i16x8, i16x16, i32x8, i32x4, i64x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x8, u32x4, u64x2, u64x4
 }
 
+// only works for 128 bit values
 macro_rules! impl_simple_not {
   ($($t:ty),+ $(,)?) => {
     $(
@@ -396,7 +397,7 @@ macro_rules! impl_simple_not {
 }
 
 impl_simple_not! {
-  f32x4, i8x32, i8x16, i16x8, i16x16, i32x4, i64x2, u8x32, u8x16, u16x8, u16x16, u32x4, u64x2,
+  f32x4, i8x16, i16x8, i32x4, i64x2, u8x16, u16x8, u32x4, u64x2,
 }
 
 macro_rules! impl_simple_sum {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -143,6 +143,23 @@ impl BitXor for u16x16 {
   }
 }
 
+impl Not for u16x16 {
+  type Output = Self;
+  #[inline]
+  fn not(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: self.avx2.not()  }
+      } else {
+        Self {
+          a : self.a.not(),
+          b : self.b.not(),
+        }
+      }
+    }
+  }
+}
+
 macro_rules! impl_shl_t_for_u16x16 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for u16x16 {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -354,6 +354,15 @@ macro_rules! impl_shr_t_for_u16x8 {
 }
 impl_shr_t_for_u16x8!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 
+impl CmpEq for u16x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u16x8 {
   #[inline]
   #[must_use]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -395,6 +395,15 @@ impl Shl<u32x4> for u32x4 {
   }
 }
 
+impl CmpEq for u32x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u32x4 {
   #[inline]
   #[must_use]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -257,6 +257,15 @@ impl Shl<u32x8> for u32x8 {
   }
 }
 
+impl CmpEq for u32x8 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u32x8 {
   #[inline]
   #[must_use]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -307,6 +307,15 @@ macro_rules! impl_shr_t_for_u64x2 {
 }
 impl_shr_t_for_u64x2!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 
+impl CmpEq for u64x2 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u64x2 {
   #[inline]
   #[must_use]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -233,6 +233,15 @@ macro_rules! impl_shr_t_for_u64x4 {
 }
 impl_shr_t_for_u64x4!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 
+impl CmpEq for u64x4 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u64x4 {
   #[inline]
   #[must_use]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -276,6 +276,15 @@ impl BitXor for u8x16 {
   }
 }
 
+impl CmpEq for u8x16 {
+  type Output = Self;
+  #[inline]
+  #[must_use]
+  fn cmp_eq(self, rhs: Self) -> Self::Output {
+    Self::cmp_eq(self, rhs)
+  }
+}
+
 impl u8x16 {
   #[inline]
   #[must_use]

--- a/tests/all_tests/main.rs
+++ b/tests/all_tests/main.rs
@@ -4,6 +4,9 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::nonminimal_bool)]
 
+use core::fmt;
+use std::{num::Wrapping, ops::ShlAssign};
+
 mod t_f32x4;
 mod t_f32x8;
 mod t_f64x2;
@@ -157,6 +160,72 @@ fn test_random_vector_vs_scalar_reduce<
       expected_scalar, expected_vec, a_arr
     );
   }
+}
+
+fn test_basic_traits<V, T, const N: usize>()
+where
+  V: Copy
+    + From<[T; N]>
+    + Into<[T; N]>
+    + std::ops::Add<Output = V>
+    + std::ops::Sub<Output = V>
+    + std::ops::BitXor<Output = V>
+    + std::ops::BitOr<Output = V>
+    + std::ops::BitAnd<Output = V>
+    + std::ops::Not<Output = V>
+    + std::ops::Neg<Output = V>
+    + wide::CmpEq<Output = V>
+    + PartialEq
+    + Eq
+    + fmt::Debug,
+  T: Copy
+    + Default
+    + std::fmt::Debug
+    + GenSample
+    + PartialEq
+    + Eq
+    + std::ops::BitXor<Output = T>
+    + std::ops::BitOr<Output = T>
+    + std::ops::BitAnd<Output = T>
+    + std::ops::Not<Output = T>,
+  Wrapping<T>:
+    std::ops::Add<Output = Wrapping<T>> + std::ops::Sub<Output = Wrapping<T>>,
+{
+  // test add
+  test_random_vector_vs_scalar(
+    |a: V, b| a + b,
+    |a, b| (Wrapping::<T>(a) + Wrapping::<T>(b)).0,
+  );
+
+  // test sub
+  test_random_vector_vs_scalar(
+    |a: V, b| a - b,
+    |a, b| (Wrapping::<T>(a) - Wrapping::<T>(b)).0,
+  );
+
+  // test neg
+  test_random_vector_vs_scalar(
+    |a: V, b| a - (-b),
+    |a, b| (Wrapping::<T>(a) + Wrapping::<T>(b)).0,
+  );
+
+  test_random_vector_vs_scalar(|a: V, b| a ^ b, |a, b| a ^ b);
+
+  test_random_vector_vs_scalar(|a: V, b| a & b, |a, b| a & b);
+
+  test_random_vector_vs_scalar(|a: V, b| a | b, |a, b| a | b);
+
+  test_random_vector_vs_scalar(
+    |a: V, b| a.cmp_eq(b),
+    |a, b| if a == b { !T::default() } else { T::default() },
+  );
+
+  let a = V::from([T::default(); N]);
+  let b = V::from([!T::default(); N]);
+
+  assert!(a != b);
+  assert!(a == a);
+  assert!(b == a.not());
 }
 
 /// trait to reduce a 64 bit pseudo-random number to a random sample value

--- a/tests/all_tests/t_i16x16.rs
+++ b/tests/all_tests/t_i16x16.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i16x16, _, 16>();
+}
+
+#[test]
 fn impl_add_for_i16x16() {
   let a = i16x16::from([
     1,

--- a/tests/all_tests/t_i16x8.rs
+++ b/tests/all_tests/t_i16x8.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i16x8, _, 8>();
+}
+
+#[test]
 fn impl_add_for_i16x8() {
   let a = i16x8::from([1, 2, 3, 4, 5, 6, i16::MAX - 1, i16::MAX - 1]);
   let b = i16x8::from([17, 18, 19, 20, 21, 22, 1, 2]);

--- a/tests/all_tests/t_i32x4.rs
+++ b/tests/all_tests/t_i32x4.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i32x4, _, 4>();
+}
+
+#[test]
 fn impl_add_for_i32x4() {
   let a = i32x4::from([1, 2, i32::MAX - 1, i32::MAX - 1]);
   let b = i32x4::from([17, 18, 1, 2]);

--- a/tests/all_tests/t_i32x8.rs
+++ b/tests/all_tests/t_i32x8.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i32x8, _, 8>();
+}
+
+#[test]
 fn impl_add_for_i32x8() {
   let a = i32x8::from([1, 2, i32::MAX - 1, i32::MAX - 1, 15, 20, 5000, 2990]);
   let b = i32x8::from([17, 18, 1, 2, 20, 5, 900, 900]);

--- a/tests/all_tests/t_i64x2.rs
+++ b/tests/all_tests/t_i64x2.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i64x2, _, 2>();
+}
+
+#[test]
 fn impl_add_for_i64x2() {
   let a = i64x2::from([i64::MAX - 1, i64::MAX - 1]);
   let b = i64x2::from([1, 2]);

--- a/tests/all_tests/t_i64x4.rs
+++ b/tests/all_tests/t_i64x4.rs
@@ -8,6 +8,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i64x4, _, 4>();
+}
+
+#[test]
 fn impl_add_for_i64x4() {
   let a = i64x4::from([i64::MAX - 1, i64::MAX - 1, 6, 9]);
   let b = i64x4::from([1, 2, 3, 4]);

--- a/tests/all_tests/t_i8x16.rs
+++ b/tests/all_tests/t_i8x16.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i8x16, _, 16>();
+}
+
+#[test]
 fn impl_add_for_i8x16() {
   let a =
     i8x16::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 126, 127]);

--- a/tests/all_tests/t_i8x32.rs
+++ b/tests/all_tests/t_i8x32.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<i8x32, _, 32>();
+}
+
+#[test]
 fn impl_add_for_i8x32() {
   let a = i8x32::from([
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 126, 127, 1, 2, 3, 4, 5, 6,

--- a/tests/all_tests/t_u16x16.rs
+++ b/tests/all_tests/t_u16x16.rs
@@ -9,6 +9,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u16x16, _, 16>();
+}
+
+#[test]
 fn impl_add_for_u16x16() {
   let a = u16x16::from([
     1,

--- a/tests/all_tests/t_u16x8.rs
+++ b/tests/all_tests/t_u16x8.rs
@@ -8,6 +8,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u16x16, _, 16>();
+}
+
+#[test]
 fn impl_add_for_u16x8() {
   let a = u16x8::from([1, 2, 3, 4, 5, 6, u16::MAX - 1, u16::MAX - 1]);
   let b = u16x8::from([17, 18, 19, 20, 21, 22, 1, 2]);

--- a/tests/all_tests/t_u32x4.rs
+++ b/tests/all_tests/t_u32x4.rs
@@ -9,6 +9,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u32x4, _, 4>();
+}
+
+#[test]
 fn impl_add_for_u32x4() {
   let a = u32x4::from([1, 2, u32::MAX - 1, u32::MAX - 1]);
   let b = u32x4::from([17, 18, 1, 2]);

--- a/tests/all_tests/t_u32x8.rs
+++ b/tests/all_tests/t_u32x8.rs
@@ -8,6 +8,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u32x8, _, 8>();
+}
+
+#[test]
 fn impl_add_for_u32x8() {
   let a = u32x8::from([1, 2, u32::MAX - 1, u32::MAX - 1, 31, 72, 13, 53]);
   let b = u32x8::from([17, 18, 1, 2, 12, 12, 634, 15]);

--- a/tests/all_tests/t_u64x2.rs
+++ b/tests/all_tests/t_u64x2.rs
@@ -8,6 +8,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u64x2, _, 2>();
+}
+
+#[test]
 fn impl_add_for_u64x2() {
   let a = u64x2::from([u64::MAX - 1, u64::MAX - 1]);
   let b = u64x2::from([1, 2]);

--- a/tests/all_tests/t_u64x4.rs
+++ b/tests/all_tests/t_u64x4.rs
@@ -8,6 +8,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u64x4, _, 4>();
+}
+
+#[test]
 fn impl_add_for_u64x4() {
   let a = u64x4::from([u64::MAX - 1, u64::MAX - 1, 6, 9]);
   let b = u64x4::from([1, 2, 3, 4]);

--- a/tests/all_tests/t_u8x16.rs
+++ b/tests/all_tests/t_u8x16.rs
@@ -7,6 +7,11 @@ fn size_align() {
 }
 
 #[test]
+fn basic_traits() {
+  crate::test_basic_traits::<u8x16, _, 16>();
+}
+
+#[test]
 fn impl_add_for_u8x16() {
   let a =
     u8x16::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 250, 250]);


### PR DESCRIPTION
There's some inconsistencies and bugs between the different implementations. Add a test to ensure that not only ensure that traits are implemented across all types, but also that they work.

Discovered that Not is broken on some 256 bit types and fixed that. 