### PR TITLE
feat: implement the missing SIMD version of f32x4::transpose for neon and simd128

### DIFF
--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1587,7 +1587,7 @@ impl f32x4 {
   pub fn unpack_lo(self, b: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        Self { sse: _mm_unpacklo_ps(self.sse, b.simd) }
+        Self { sse: unpack_low_m128(self.sse, b.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self {
           simd: u32x4_shuffle::<0, 4, 1, 5>(self.simd, b.simd)
@@ -1610,7 +1610,7 @@ impl f32x4 {
   pub fn unpack_hi(self, b: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        Self { sse: _mm_unpackhi_ps(self.sse, b.simd) }
+        Self { sse: unpack_high_m128(self.sse, b.sse) }
       } else if #[cfg(target_feature="simd128")] {
         Self {
           simd: u32x4_shuffle::<2, 6, 3, 7>(self.simd, b.simd)


### PR DESCRIPTION
The `f32x4::transpose` function was only accelerated for SSE. This PR adds `neon` and `simd128` versions. This also adds `f32x4::unpack_lo` and `f32x4::unpack_hi` which were needed for implementing the transpose.