### PR TITLE
fix: add aarch64+neon FMA instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,8 @@ bytemuck = "1"
 
 [dev-dependencies]
 bincode = { version = "1.3.3" }
+criterion = { version = "0.7.0" }
+
+[[bench]]
+name = "fma_benchmarks"
+harness = false

--- a/benches/fma_benchmarks.rs
+++ b/benches/fma_benchmarks.rs
@@ -1,0 +1,120 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+use wide::{f32x4, f32x8, f64x2, f64x4, f64x8};
+
+// Benchmark chains for testing FMA throughput
+fn bench_f32x4_mul_add_chain(c: &mut Criterion) {
+  c.bench_function("f32x4_mul_add_chain", |b| {
+    b.iter_batched(
+      || {
+        (
+          f32x4::from([1.0, 2.0, 3.0, 4.0]),
+          f32x4::from([1.1, 1.2, 1.3, 1.4]),
+          f32x4::from([0.1, 0.2, 0.3, 0.4]),
+        )
+      },
+      |(mut acc, mul, add)| {
+        // Chain of FMA operations to test throughput
+        for _ in 0..100 {
+          acc = acc.mul_add(mul, add);
+        }
+        black_box(acc)
+      },
+      BatchSize::SmallInput,
+    );
+  });
+}
+
+fn bench_f32x8_mul_add_chain(c: &mut Criterion) {
+  c.bench_function("f32x8_mul_add_chain", |b| {
+    b.iter_batched(
+      || {
+        (
+          f32x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+          f32x8::from([1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8]),
+          f32x8::from([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
+        )
+      },
+      |(mut acc, mul, add)| {
+        for _ in 0..100 {
+          acc = acc.mul_add(mul, add);
+        }
+        black_box(acc)
+      },
+      BatchSize::SmallInput,
+    );
+  });
+}
+
+fn bench_f64x2_mul_add_chain(c: &mut Criterion) {
+  c.bench_function("f64x2_mul_add_chain", |b| {
+    b.iter_batched(
+      || {
+        (
+          f64x2::from([1.0, 2.0]),
+          f64x2::from([1.1, 1.2]),
+          f64x2::from([0.1, 0.2]),
+        )
+      },
+      |(mut acc, mul, add)| {
+        for _ in 0..100 {
+          acc = acc.mul_add(mul, add);
+        }
+        black_box(acc)
+      },
+      BatchSize::SmallInput,
+    );
+  });
+}
+
+fn bench_f64x4_mul_add_chain(c: &mut Criterion) {
+  c.bench_function("f64x4_mul_add_chain", |b| {
+    b.iter_batched(
+      || {
+        (
+          f64x4::from([1.0, 2.0, 3.0, 4.0]),
+          f64x4::from([1.1, 1.2, 1.3, 1.4]),
+          f64x4::from([0.1, 0.2, 0.3, 0.4]),
+        )
+      },
+      |(mut acc, mul, add)| {
+        for _ in 0..100 {
+          acc = acc.mul_add(mul, add);
+        }
+        black_box(acc)
+      },
+      BatchSize::SmallInput,
+    );
+  });
+}
+
+fn bench_f64x8_mul_add_chain(c: &mut Criterion) {
+  c.bench_function("f64x8_mul_add_chain", |b| {
+    b.iter_batched(
+      || {
+        (
+          f64x8::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+          f64x8::from([1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8]),
+          f64x8::from([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),
+        )
+      },
+      |(mut acc, mul, add)| {
+        for _ in 0..100 {
+          acc = acc.mul_add(mul, add);
+        }
+        black_box(acc)
+      },
+      BatchSize::SmallInput,
+    );
+  });
+}
+
+criterion_group!(
+  benches,
+  bench_f32x4_mul_add_chain,
+  bench_f32x8_mul_add_chain,
+  bench_f64x2_mul_add_chain,
+  bench_f64x4_mul_add_chain,
+  bench_f64x8_mul_add_chain,
+);
+criterion_main!(benches);

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -846,6 +846,8 @@ impl f32x4 {
     pick! {
       if #[cfg(all(target_feature="sse2",target_feature="fma"))] {
         Self { sse: fused_mul_add_m128(self.sse, m.sse, a.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vfmaq_f32(a.neon, self.neon, m.neon) } }
       } else {
         (self * m) + a
       }
@@ -858,6 +860,8 @@ impl f32x4 {
     pick! {
       if #[cfg(all(target_feature="sse2",target_feature="fma"))] {
         Self { sse: fused_mul_sub_m128(self.sse, m.sse, s.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vfmaq_f32(vnegq_f32(s.neon), self.neon, m.neon) } }
       } else {
         (self * m) - s
       }
@@ -870,6 +874,8 @@ impl f32x4 {
     pick! {
       if #[cfg(all(target_feature="sse2",target_feature="fma"))] {
         Self { sse: fused_mul_neg_add_m128(self.sse, m.sse, a.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vfmsq_f32(a.neon, self.neon, m.neon) } }
       } else {
         a - (self * m)
       }
@@ -882,6 +888,8 @@ impl f32x4 {
     pick! {
       if #[cfg(all(target_feature="sse2",target_feature="fma"))] {
         Self { sse: fused_mul_neg_sub_m128(self.sse, m.sse, a.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vnegq_f32(vfmaq_f32(a.neon, self.neon, m.neon)) } }
       } else {
         -(self * m) - a
       }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -695,6 +695,8 @@ impl f64x2 {
     pick! {
       if #[cfg(all(target_feature="fma"))] {
         Self { sse: fused_mul_add_m128d(self.sse, m.sse, a.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vfmaq_f64(a.neon, self.neon, m.neon) } }
       } else {
         (self * m) + a
       }
@@ -707,6 +709,8 @@ impl f64x2 {
     pick! {
       if #[cfg(all(target_feature="fma"))] {
         Self { sse: fused_mul_sub_m128d(self.sse, m.sse, a.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vfmaq_f64(vnegq_f64(a.neon), self.neon, m.neon) } }
       } else {
         (self * m) - a
       }
@@ -719,6 +723,8 @@ impl f64x2 {
     pick! {
         if #[cfg(all(target_feature="fma"))] {
           Self { sse: fused_mul_neg_add_m128d(self.sse, m.sse, a.sse) }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+          unsafe { Self { neon: vfmsq_f64(a.neon, self.neon, m.neon) } }
         } else {
           a - (self * m)
         }
@@ -731,6 +737,8 @@ impl f64x2 {
     pick! {
         if #[cfg(all(target_feature="fma"))] {
           Self { sse: fused_mul_neg_sub_m128d(self.sse, m.sse, a.sse) }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+          unsafe { Self { neon: vnegq_f64(vfmaq_f64(a.neon, self.neon, m.neon)) } }
         } else {
           -(self * m) - a
         }

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -710,6 +710,23 @@ fn impl_f64x4_reduce_add() {
   assert_eq!(p.reduce_add(), 0.004);
 }
 
+// Regression test for lack of aarch64+neon FMA instructions
+// for `mul_add` that lead to subpar accuracy.
+#[test]
+fn regression_for_f64x4_fma() {
+  let a = f64::from_bits(13857435315930660864);
+  let b = f64::from_bits(4832221662680186888);
+  let c = f64::from_bits(4859139800860736384);
+  let wide_a = f64x4::splat(a);
+  let wide_b = f64x4::splat(b);
+  let wide_c = f64x4::splat(c);
+
+  let result = a.mul_add(b, c);
+  let wide_result = wide_a.mul_add(wide_b, wide_c);
+  assert_eq!(result.to_bits(), 4823328195304192032);
+  assert_eq!(wide_result.to_array()[0].to_bits(), 4823328195304192032);
+}
+
 #[test]
 fn impl_f64x4_sum() {
   let mut p = Vec::with_capacity(250_000);


### PR DESCRIPTION
Hello,

Thank you for all your hard work on `wide`. I am attempting to utilize `wide` for computing FFTs, which make heavy use of `fma` instructions. I found that the fix in this PR offers increased throughput with no tangible difference to latency.

In addition, this PR addresses the accuracy issue brought up in #200.

Thank you!!

## Summary

- This PR is a fix for issue #200.

- Add aarch64+neon specific intrinsics for: `mul_add`, `mul_sub`, `mul_neg_add`, `mul_neg_sub`

- Added criterion benchmarks that demonstrated significantly better throughput on a Apple M2 chip.

```
f32x4_mul_add_chain     time:   [34.568 ns 34.653 ns 34.755 ns]
                        change: [-70.223% -70.060% -69.917%] (p = 0.00 < 0.05)
                        Performance has improved.

f32x8_mul_add_chain     time:   [100.86 ns 101.08 ns 101.37 ns]
                        change: [-28.669% -28.237% -27.753%] (p = 0.00 < 0.05)
                        Performance has improved.

f64x2_mul_add_chain     time:   [34.728 ns 34.861 ns 34.993 ns]
                        change: [-70.142% -70.003% -69.864%] (p = 0.00 < 0.05)
                        Performance has improved.

f64x4_mul_add_chain     time:   [102.30 ns 102.77 ns 103.19 ns]
                        change: [-28.516% -27.959% -27.519%] (p = 0.00 < 0.05)
                        Performance has improved.

f64x8_mul_add_chain     time:   [99.583 ns 99.806 ns 100.04 ns]
                        change: [-46.116% -45.655% -45.113%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### Benchmarking Platform
```
CPU: Apple M2
MEM: 24 GB
OS: macOS 15.6.1
```