### PR TITLE
Add support for `wasm64` with `simd128`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       env:
         CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime run --wasm-features all --dir .
       run: cargo test --target ${{ matrix.rust.target }} --all-features
-    
+
     - name: Build the crate with SSE4.1 (the "native" of CI will be above this)
       if: matrix.rust.os == 'ubuntu-latest' && matrix.rust.target == 'x86_64-unknown-linux-gnu'
       run: RUSTFLAGS="-Ctarget-feature=+sse4.1" cargo build --target ${{ matrix.rust.target }}
@@ -66,9 +66,9 @@ jobs:
     - name: Test with 'native' CPU features + No Default Cargo Features
       run: cargo test --target ${{ matrix.rust.target }} --no-default-features
 
-    - name: Test with 'native' CPU features + All Cargo Features 
+    - name: Test with 'native' CPU features + All Cargo Features
       run: cargo test --target ${{ matrix.rust.target }} --all-features
-  
+
   build_check_only:
     runs-on: ${{ matrix.rust.os }}
     strategy:
@@ -92,7 +92,9 @@ jobs:
     - name: Check the crate 3
       run: cargo check --target armv7-unknown-linux-gnueabihf
     - name: Check the crate 4
-      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target=wasm32-unknown-unknown
+      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
+    - name: Check the crate 5
+      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
 
   avx512_emulated_test:
     runs-on: ${{ matrix.rust.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,14 +91,9 @@ jobs:
       run: cargo check --target arm-unknown-linux-gnueabihf
     - name: Check the crate 3
       run: cargo check --target armv7-unknown-linux-gnueabihf
-    - name: Check the crate 4
+    - name: Check wasm32 with simd128
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
-
-    - name: Add nightly targets via Rustup
-      if: matrix.rust.toolchain == 'nightly'
-      run: rustup target add rust-src
-
-    - name: Check the crate 5
+    - name: Check wasm64 with simd128
       if: matrix.rust.toolchain == 'nightly'
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,11 @@ jobs:
       run: cargo check --target armv7-unknown-linux-gnueabihf
     - name: Check wasm32 with simd128
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
+
+    - name: Add nightly targets via Rustup
+      if: matrix.rust.toolchain == 'nightly'
+      run: rustup component add rust-src
+
     - name: Check wasm64 with simd128
       if: matrix.rust.toolchain == 'nightly'
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,7 @@ jobs:
     - name: Check the crate 4
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
     - name: Check the crate 5
+      if: ${{ matrix.rust.toolchain == "nightly" }}
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
 
   avx512_emulated_test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,8 +94,7 @@ jobs:
     - name: Check the crate 4
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
     - name: Check the crate 5
-      if: matrix.rust.toolchain == 'nightly'
-      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
+      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo +nightly check --target wasm64-unknown-unknown -Z build-std
 
   avx512_emulated_test:
     runs-on: ${{ matrix.rust.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Check the crate 4
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
     - name: Check the crate 5
-      if: ${{ matrix.rust.toolchain == "nightly" }}
+      if: matrix.rust.toolchain == 'nightly'
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
 
   avx512_emulated_test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,13 +74,13 @@ jobs:
     strategy:
       matrix:
         rust:
-        - { target: x86_64-unknown-linux-gnu, toolchain: stable, os: ubuntu-latest }
+        - { toolchain: stable, os: ubuntu-latest }
+        - { toolchain: nightly, os: ubuntu-latest }
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust.toolchain }}
-        target:  ${{ matrix.rust.target }}
 
     - name: Add targets via Rustup
       run: rustup target add riscv64gc-unknown-linux-gnu arm-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf wasm32-unknown-unknown
@@ -93,8 +93,14 @@ jobs:
       run: cargo check --target armv7-unknown-linux-gnueabihf
     - name: Check the crate 4
       run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm32-unknown-unknown
+
+    - name: Add nightly targets via Rustup
+      if: matrix.rust.toolchain == 'nightly'
+      run: rustup target add rust-src
+
     - name: Check the crate 5
-      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo +nightly check --target wasm64-unknown-unknown -Z build-std
+      if: matrix.rust.toolchain == 'nightly'
+      run: RUSTFLAGS="-Ctarget-feature=+simd128" cargo check --target wasm64-unknown-unknown -Z build-std
 
   avx512_emulated_test:
     runs-on: ${{ matrix.rust.os }}

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct f32x4 { pub(crate) sse: m128 }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct f64x2 { pub(crate) sse: m128d }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct i16x8 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
@@ -564,7 +567,10 @@ impl i16x8 {
       } else if #[cfg(target_feature="sse2")] {
         i16x8 { sse: pack_i32_to_i16_m128i( v.a.sse, v.b.sse ) }
       } else if #[cfg(target_feature="simd128")] {
+        #[cfg(target_arch = "wasm32")]
         use core::arch::wasm32::*;
+        #[cfg(target_arch = "wasm64")]
+        use core::arch::wasm64::*;
 
         i16x8 { simd: i16x8_narrow_i32x4(v.a.simd, v.b.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct i32x4 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct i64x2 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct i8x16 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]
@@ -397,7 +400,10 @@ impl i8x16 {
           i8x16 { neon: vcombine_s8(vqmovn_s16(v.a.neon), vqmovn_s16(v.b.neon)) }
         }
       } else if #[cfg(target_feature="simd128")] {
+        #[cfg(target_arch = "wasm32")]
         use core::arch::wasm32::*;
+        #[cfg(target_arch = "wasm64")]
+        use core::arch::wasm64::*;
 
         i8x16 { simd: i8x16_narrow_i16x8(v.a.simd, v.b.simd) }
       } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@
 #![allow(clippy::unusual_byte_groupings)]
 #![allow(clippy::misrefactored_assign_op)]
 #![allow(clippy::approx_constant)]
+#![cfg_attr(
+  all(target_arch = "wasm64", target_feature = "simd128"),
+  feature(simd_wasm64)
+)]
 
 //! A crate to help you go wide.
 //!

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct u16x8 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct u32x4 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct u64x2 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -6,7 +6,10 @@ pick! {
     #[repr(C, align(16))]
     pub struct u8x16 { pub(crate) sse: m128i }
   } else if #[cfg(target_feature="simd128")] {
+    #[cfg(target_arch = "wasm32")]
     use core::arch::wasm32::*;
+    #[cfg(target_arch = "wasm64")]
+    use core::arch::wasm64::*;
 
     #[derive(Clone, Copy)]
     #[repr(transparent)]


### PR DESCRIPTION
Even though the `memory64` feature has been [standardized](https://webassembly.org/features/), the `wasm64-unknown-unknown` target is currently only a [tier 3 target](https://doc.rust-lang.org/rustc/platform-support/wasm64-unknown-unknown.html), so it's perfectly understandable if you don't want to merge this PR.

I stumbled upon this while experimenting with building my project with `wasm64-unknown-unknown`.
