### PR TITLE
add missing `min` & `max` methods

### DIFF
--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -568,4 +568,16 @@ impl i64x2 {
   pub fn as_mut_array(&mut self) -> &mut [i64; 2] {
     cast_mut(self)
   }
+
+  #[inline]
+  #[must_use]
+  pub fn min(self, rhs: Self) -> Self {
+    self.simd_lt(rhs).blend(self, rhs)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn max(self, rhs: Self) -> Self {
+    self.simd_gt(rhs).blend(self, rhs)
+  }
 }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -482,6 +482,18 @@ impl u64x2 {
 
   #[inline]
   #[must_use]
+  pub fn min(self, rhs: Self) -> Self {
+    self.simd_lt(rhs).blend(self, rhs)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn max(self, rhs: Self) -> Self {
+    self.simd_gt(rhs).blend(self, rhs)
+  }
+
+  #[inline]
+  #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
     let arr1: [u64; 2] = cast(self);
     let arr2: [u64; 2] = cast(rhs);

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -380,6 +380,21 @@ impl u64x8 {
 
   #[inline]
   #[must_use]
+  pub fn min(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: min_u64_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {


### PR DESCRIPTION
- add `i64x2::min`, `i64x2::max`.
- add `u64x2::min`, `u64x2::max`.
- add `u64x8::min`.

fixes #239