### PR TITLE
Implement `Neg` using native operations if possible

### DIFF
--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -81,6 +81,23 @@ impl Div for f32x16 {
   }
 }
 
+impl Neg for f32x16 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: bitxor_m512(self.avx512, Self::splat(-0.0).avx512) }
+      } else {
+        Self {
+          a : self.a.neg(),
+          b : self.b.neg(),
+        }
+      }
+    }
+  }
+}
+
 impl Add<f32> for f32x16 {
   type Output = Self;
   #[inline]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -181,6 +181,29 @@ impl Div for f32x4 {
   }
 }
 
+impl Neg for f32x4 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="sse")] {
+        Self { sse: bitxor_m128(self.sse, Self::splat(-0.0).sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_neg(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vnegq_f32(self.neon) }}
+      } else {
+        Self { arr: [
+          -self.arr[0],
+          -self.arr[1],
+          -self.arr[2],
+          -self.arr[3],
+        ]}
+      }
+    }
+  }
+}
+
 impl Add<f32> for f32x4 {
   type Output = Self;
   #[inline]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -119,6 +119,23 @@ impl Div for f32x8 {
   }
 }
 
+impl Neg for f32x8 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: bitxor_m256(self.avx, Self::splat(-0.0).avx) }
+      } else {
+        Self {
+          a : self.a.neg(),
+          b : self.b.neg(),
+        }
+      }
+    }
+  }
+}
+
 impl Add<f32> for f32x8 {
   type Output = Self;
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -176,6 +176,27 @@ impl Div for f64x2 {
   }
 }
 
+impl Neg for f64x2 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="sse")] {
+        Self { sse: bitxor_m128d(self.sse, Self::splat(-0.0).sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f64x2_neg(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vnegq_f64(self.neon) }}
+      } else {
+        Self { arr: [
+          -self.arr[0],
+          -self.arr[1],
+        ]}
+      }
+    }
+  }
+}
+
 impl Add<f64> for f64x2 {
   type Output = Self;
   #[inline]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -119,6 +119,23 @@ impl Div for f64x4 {
   }
 }
 
+impl Neg for f64x4 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: bitxor_m256d(self.avx, Self::splat(-0.0).avx) }
+      } else {
+        Self {
+          a : self.a.neg(),
+          b : self.b.neg(),
+        }
+      }
+    }
+  }
+}
+
 impl Add<f64> for f64x4 {
   type Output = Self;
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -88,6 +88,23 @@ impl Div for f64x8 {
   }
 }
 
+impl Neg for f64x8 {
+  type Output = Self;
+  #[inline]
+  fn neg(self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: bitxor_m512d(self.avx512, Self::splat(-0.0).avx512) }
+      } else {
+        Self {
+          a : self.a.neg(),
+          b : self.b.neg(),
+        }
+      }
+    }
+  }
+}
+
 impl Add<f64> for f64x8 {
   type Output = Self;
   #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,33 +394,6 @@ impl_integer_neg! {
   i8x32, i8x16, i16x8, i16x16, i16x32, i32x8, i32x4, i32x16, i64x4, i64x2, i64x8, u8x32, u8x16, u16x8, u16x16, u16x32, u32x8, u32x4, u32x16, u64x2, u64x4, u64x8
 }
 
-// Floats need special handling for sign inversion:
-// https://github.com/Lokathor/wide/issues/241
-macro_rules! impl_float_neg {
-  ($($t:ty),+ $(,)?) => {
-    $(
-      impl Neg for $t {
-        type Output = Self;
-        #[inline(always)]
-        fn neg(self) -> Self::Output {
-          Self::splat(-0.0) ^ self
-        }
-      }
-      impl Neg for &'_ $t {
-        type Output = $t;
-        #[inline(always)]
-        fn neg(self) -> Self::Output {
-          <$t>::splat(-0.0) ^ *self
-        }
-      }
-    )+
-  };
-}
-
-impl_float_neg! {
-  f32x16, f32x8, f32x4, f64x8, f64x4, f64x2
-}
-
 // only works for 128 bit values
 macro_rules! impl_simple_not {
   ($($t:ty),+ $(,)?) => {


### PR DESCRIPTION
Previously, https://github.com/Lokathor/wide/issues/242 fixed the implementation of `Neg` for floating-point types to return correct results. Instead of subtracting the operand from 0, we need to flip the sign bit, and #242 implemented that across all platforms by XOR'ing the sign bit.

This *should* allow a multiply-add + negate to be fused into a single negate-multiply-add if the backend supports it. However, it seems that LLVM only recognizes `x ^ -0.0` as being equivalent to a negation on x86. This is probably because the other architectures (ARM, WebAssembly) have *native* negate operations that LLVM expects us to use if available.

Because of this, PhastFT apparently [ended up reverting back to using `mul_neg_add`](https://github.com/QuState/PhastFT/pull/59), since the current negate implementation here is not optimized properly on ARM.

This PR changes the `Neg` implementation for floating-point types to only use the XOR-based implementation on x86. On other platforms, it now calls the native "negate" intrinsics, which LLVM can recognize and fuse in the backend. I have confirmed that with this change, `mul_add` with a negation produces identical ARM assembly to `mul_neg_add` in PhastFT.