### PR TITLE
Add missing `f32x16` functionality and fix incorrect behaviour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # `wide` Changelog
 
+## Unreleased
+
+* Added floating-point constants to `f32x16` and made `f32x16::new` a `const fn`.
+
 ## 1.2.0
 
 * added reduce operations and dot to `i16x32`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+* Corrected the behaviour of `f32x16::is_finite` and `f32x16::round_int`.
+
+* Added `f32x16` missing functions: `abs`, `floor`, `ceil`, `fast_max`,
+  `fast_min`, `is_inf`, `fast_round_int`, `fast_trunc_int`, `trunc_int`,
+  `flip_signs`, `copysign`, `asin_acos`, `asin`, `acos`, `atan`, `atan2`,
+  `sin_cos`, `sin`, `cos`, `tan`, `to_degrees`, `to_radians`, `recip`,
+  `recip_sqrt`, `sqrt`, `to_bitmask`, `any`, `all`, `none`, `sign_bit`,
+  `reduce_add`, `exp`, `ln`, `log2`, `log10`, `pow_f32x16`, `powf`, `transpose`,
+  `from_i32x16`.
+
 * Added floating-point constants to `f32x16` and made `f32x16::new` a `const fn`.
 
 ## 1.2.0

--- a/changelog.md
+++ b/changelog.md
@@ -2,17 +2,9 @@
 
 ## Unreleased
 
-* Corrected the behaviour of `f32x16::is_finite` and `f32x16::round_int`.
+* Fixes the behaviour of `f32x16` functions `is_finite` and `round_int`.
 
-* Added `f32x16` missing functions: `abs`, `floor`, `ceil`, `fast_max`,
-  `fast_min`, `is_inf`, `fast_round_int`, `fast_trunc_int`, `trunc_int`,
-  `flip_signs`, `copysign`, `asin_acos`, `asin`, `acos`, `atan`, `atan2`,
-  `sin_cos`, `sin`, `cos`, `tan`, `to_degrees`, `to_radians`, `recip`,
-  `recip_sqrt`, `sqrt`, `to_bitmask`, `any`, `all`, `none`, `sign_bit`,
-  `reduce_add`, `exp`, `ln`, `log2`, `log10`, `pow_f32x16`, `powf`, `transpose`,
-  `from_i32x16`.
-
-* Added floating-point constants to `f32x16` and made `f32x16::new` a `const fn`.
+* Added missing `f32x16` functionality.
 
 ## 1.2.0
 

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -12,6 +12,38 @@ pick! {
   }
 }
 
+macro_rules! const_f32_as_f32x16 {
+  ($i:ident, $f:expr) => {
+    #[allow(non_upper_case_globals)]
+    pub const $i: f32x16 = f32x16::new([$f; 16]);
+  };
+}
+
+impl f32x16 {
+  const_f32_as_f32x16!(ONE, 1.0);
+  const_f32_as_f32x16!(HALF, 0.5);
+  const_f32_as_f32x16!(ZERO, 0.0);
+  const_f32_as_f32x16!(E, core::f32::consts::E);
+  const_f32_as_f32x16!(FRAC_1_PI, core::f32::consts::FRAC_1_PI);
+  const_f32_as_f32x16!(FRAC_2_PI, core::f32::consts::FRAC_2_PI);
+  const_f32_as_f32x16!(FRAC_2_SQRT_PI, core::f32::consts::FRAC_2_SQRT_PI);
+  const_f32_as_f32x16!(FRAC_1_SQRT_2, core::f32::consts::FRAC_1_SQRT_2);
+  const_f32_as_f32x16!(FRAC_PI_2, core::f32::consts::FRAC_PI_2);
+  const_f32_as_f32x16!(FRAC_PI_3, core::f32::consts::FRAC_PI_3);
+  const_f32_as_f32x16!(FRAC_PI_4, core::f32::consts::FRAC_PI_4);
+  const_f32_as_f32x16!(FRAC_PI_6, core::f32::consts::FRAC_PI_6);
+  const_f32_as_f32x16!(FRAC_PI_8, core::f32::consts::FRAC_PI_8);
+  const_f32_as_f32x16!(LN_2, core::f32::consts::LN_2);
+  const_f32_as_f32x16!(LN_10, core::f32::consts::LN_10);
+  const_f32_as_f32x16!(LOG2_E, core::f32::consts::LOG2_E);
+  const_f32_as_f32x16!(LOG10_E, core::f32::consts::LOG10_E);
+  const_f32_as_f32x16!(LOG10_2, core::f32::consts::LOG10_2);
+  const_f32_as_f32x16!(LOG2_10, core::f32::consts::LOG2_10);
+  const_f32_as_f32x16!(PI, core::f32::consts::PI);
+  const_f32_as_f32x16!(SQRT_2, core::f32::consts::SQRT_2);
+  const_f32_as_f32x16!(TAU, core::f32::consts::TAU);
+}
+
 unsafe impl Zeroable for f32x16 {}
 unsafe impl Pod for f32x16 {}
 
@@ -318,8 +350,8 @@ impl CmpNe for f32x16 {
 impl f32x16 {
   #[inline]
   #[must_use]
-  pub fn new(array: [f32; 16]) -> Self {
-    Self::from(array)
+  pub const fn new(array: [f32; 16]) -> Self {
+    unsafe { core::mem::transmute(array) }
   }
 
   #[inline]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -371,6 +371,70 @@ impl f32x16 {
 
   #[inline]
   #[must_use]
+  pub fn abs(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        let non_sign_bits = f32x16::from(f32::from_bits(i32::MAX as u32));
+        self & non_sign_bits
+      } else {
+        Self {
+          a : self.a.abs(),
+          b : self.b.abs(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn floor(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: round_m512::<{round_op!(NegInf)}>(self.avx512) }
+      } else {
+        Self {
+          a : self.a.floor(),
+          b : self.b.floor(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn ceil(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: round_m512::<{round_op!(PosInf)}>(self.avx512) }
+      } else {
+        Self {
+          a : self.a.ceil(),
+          b : self.b.ceil(),
+        }
+      }
+    }
+  }
+
+  /// Calculates the lanewise maximum of both vectors. This is a faster
+  /// implementation than `max`, but it doesn't specify any behavior if NaNs are
+  /// involved.
+  #[inline]
+  #[must_use]
+  pub fn fast_max(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: max_m512(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.fast_max(rhs.a),
+          b: self.b.fast_max(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
@@ -382,6 +446,24 @@ impl f32x16 {
         Self {
           a: self.a.max(rhs.a),
           b: self.b.max(rhs.b),
+        }
+      }
+    }
+  }
+
+  /// Calculates the lanewise minimum of both vectors. This is a faster
+  /// implementation than `min`, but it doesn't specify any behavior if NaNs are
+  /// involved.
+  #[inline]
+  #[must_use]
+  pub fn fast_min(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: min_m512(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.fast_min(rhs.a),
+          b: self.b.fast_min(rhs.b),
         }
       }
     }
@@ -423,10 +505,20 @@ impl f32x16 {
   #[inline]
   #[must_use]
   pub fn is_finite(self) -> Self {
-    let shifted_exp_mask = u32x16::splat(0x7F800000);
+    let shifted_exp_mask = u32x16::splat(0xFF000000);
     let u: u32x16 = cast(self);
     let shift_u = u << 1_u32;
     let out = !(shift_u & shifted_exp_mask).simd_eq(shifted_exp_mask);
+    cast(out)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_inf(self) -> Self {
+    let shifted_inf = u32x16::from(0xFF000000);
+    let u: u32x16 = cast(self);
+    let shift_u = u << 1_u64;
+    let out = (shift_u).simd_eq(shifted_inf);
     cast(out)
   }
 
@@ -445,12 +537,38 @@ impl f32x16 {
     }
   }
 
+  /// Rounds each lane into an integer. This is a faster implementation than
+  /// `round_int`, but it doesn't handle out of range values or NaNs. For those
+  /// values you get implementation defined behavior.
+  #[inline]
+  #[must_use]
+  pub fn fast_round_int(self) -> i32x16 {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        cast(convert_to_i32_m512i_from_m512(self.avx512))
+      } else {
+        i32x16 {
+          a: self.a.fast_round_int(),
+          b: self.b.fast_round_int(),
+        }
+      }
+    }
+  }
+
+  /// Rounds each lane into an integer. This saturates out of range values and
+  /// turns NaNs into 0. Use `fast_round_int` for a faster implementation that
+  /// doesn't handle out of range values or NaNs.
   #[inline]
   #[must_use]
   pub fn round_int(self) -> i32x16 {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        cast(convert_to_i32_m512i_from_m512(self.avx512))
+        // Based on: https://github.com/v8/v8/blob/210987a552a2bf2a854b0baa9588a5959ff3979d/src/codegen/shared-ia32-x64/macro-assembler-shared-ia32-x64.h#L489-L504
+        let non_nan_mask = self.simd_eq(self);
+        let non_nan = self & non_nan_mask;
+        let flip_to_max: i32x16 = cast(self.simd_ge(Self::splat(2147483648.0)));
+        let cast: i32x16 = cast(convert_to_i32_m512i_from_m512(non_nan.avx512));
+        flip_to_max ^ cast
       } else {
         i32x16 {
           a: self.a.round_int(),
@@ -458,6 +576,763 @@ impl f32x16 {
         }
       }
     }
+  }
+
+  /// Truncates each lane into an integer. This is a faster implementation than
+  /// `trunc_int`, but it doesn't handle out of range values or NaNs. For those
+  /// values you get implementation defined behavior.
+  #[inline]
+  #[must_use]
+  pub fn fast_trunc_int(self) -> i32x16 {
+    pick! {
+      if #[cfg(all(target_feature="avx512f"))] {
+        cast(convert_truncate_m512_i32_m512i(self.avx512))
+      } else {
+        cast([
+          self.a.fast_trunc_int(),
+          self.b.fast_trunc_int(),
+        ])
+      }
+    }
+  }
+
+  /// Truncates each lane into an integer. This saturates out of range values
+  /// and turns NaNs into 0. Use `fast_trunc_int` for a faster implementation
+  /// that doesn't handle out of range values or NaNs.
+  #[inline]
+  #[must_use]
+  pub fn trunc_int(self) -> i32x16 {
+    pick! {
+        if #[cfg(target_feature="avx512f")] {
+        // Based on: https://github.com/v8/v8/blob/210987a552a2bf2a854b0baa9588a5959ff3979d/src/codegen/shared-ia32-x64/macro-assembler-shared-ia32-x64.h#L489-L504
+        let non_nan_mask = self.simd_eq(self);
+        let non_nan = self & non_nan_mask;
+        let flip_to_max: i32x16 = cast(self.simd_ge(Self::splat(2147483648.0)));
+        let cast: i32x16 = cast(convert_truncate_m512_i32_m512i(non_nan.avx512));
+        flip_to_max ^ cast
+      } else {
+        cast([
+          self.a.trunc_int(),
+          self.b.trunc_int(),
+        ])
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn flip_signs(self, signs: Self) -> Self {
+    self ^ (signs & Self::from(-0.0))
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn copysign(self, sign: Self) -> Self {
+    let magnitude_mask = Self::from(f32::from_bits(u32::MAX >> 1));
+    (self & magnitude_mask) | (sign & Self::from(-0.0))
+  }
+
+  #[inline]
+  pub fn asin_acos(self) -> (Self, Self) {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x16!(P4asinf, 4.2163199048E-2);
+    const_f32_as_f32x16!(P3asinf, 2.4181311049E-2);
+    const_f32_as_f32x16!(P2asinf, 4.5470025998E-2);
+    const_f32_as_f32x16!(P1asinf, 7.4953002686E-2);
+    const_f32_as_f32x16!(P0asinf, 1.6666752422E-1);
+
+    let xa = self.abs();
+    let big = xa.simd_ge(f32x16::splat(0.5));
+
+    let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
+    let x2 = xa * xa;
+    let x3 = big.blend(x1, x2);
+
+    let xb = x1.sqrt();
+
+    let x4 = big.blend(xb, xa);
+
+    let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
+    let z = z.mul_add(x3 * x4, x4);
+
+    let z1 = z + z;
+
+    // acos
+    let z3 = self.simd_lt(f32x16::ZERO).blend(f32x16::PI - z1, z1);
+    let z4 = f32x16::FRAC_PI_2 - z.flip_signs(self);
+    let acos = big.blend(z3, z4);
+
+    // asin
+    let z3 = f32x16::FRAC_PI_2 - z1;
+    let asin = big.blend(z3, z);
+    let asin = asin.flip_signs(self);
+
+    (asin, acos)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn asin(self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x16!(P4asinf, 4.2163199048E-2);
+    const_f32_as_f32x16!(P3asinf, 2.4181311049E-2);
+    const_f32_as_f32x16!(P2asinf, 4.5470025998E-2);
+    const_f32_as_f32x16!(P1asinf, 7.4953002686E-2);
+    const_f32_as_f32x16!(P0asinf, 1.6666752422E-1);
+
+    let xa = self.abs();
+    let big = xa.simd_ge(f32x16::splat(0.5));
+
+    let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
+    let x2 = xa * xa;
+    let x3 = big.blend(x1, x2);
+
+    let xb = x1.sqrt();
+
+    let x4 = big.blend(xb, xa);
+
+    let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
+    let z = z.mul_add(x3 * x4, x4);
+
+    let z1 = z + z;
+
+    // asin
+    let z3 = f32x16::FRAC_PI_2 - z1;
+    let asin = big.blend(z3, z);
+    let asin = asin.flip_signs(self);
+
+    asin
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn acos(self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x16!(P4asinf, 4.2163199048E-2);
+    const_f32_as_f32x16!(P3asinf, 2.4181311049E-2);
+    const_f32_as_f32x16!(P2asinf, 4.5470025998E-2);
+    const_f32_as_f32x16!(P1asinf, 7.4953002686E-2);
+    const_f32_as_f32x16!(P0asinf, 1.6666752422E-1);
+
+    let xa = self.abs();
+    let big = xa.simd_ge(f32x16::splat(0.5));
+
+    let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
+    let x2 = xa * xa;
+    let x3 = big.blend(x1, x2);
+
+    let xb = x1.sqrt();
+
+    let x4 = big.blend(xb, xa);
+
+    let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
+    let z = z.mul_add(x3 * x4, x4);
+
+    let z1 = z + z;
+
+    // acos
+    let z3 = self.simd_lt(f32x16::ZERO).blend(f32x16::PI - z1, z1);
+    let z4 = f32x16::FRAC_PI_2 - z.flip_signs(self);
+    let acos = big.blend(z3, z4);
+
+    acos
+  }
+
+  #[inline]
+  pub fn atan(self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x16!(P3atanf, 8.05374449538E-2);
+    const_f32_as_f32x16!(P2atanf, -1.38776856032E-1);
+    const_f32_as_f32x16!(P1atanf, 1.99777106478E-1);
+    const_f32_as_f32x16!(P0atanf, -3.33329491539E-1);
+
+    let t = self.abs();
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    // big:    z = -1.0 / t;
+    let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
+    let notbig = t.simd_le(Self::SQRT_2 + Self::ONE);
+
+    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    s = notsmal & s;
+
+    let mut a = notbig & t;
+    a = notsmal.blend(a - Self::ONE, a);
+    let mut b = notbig & Self::ONE;
+    b = notsmal.blend(b + t, b);
+    let z = a / b;
+
+    let zz = z * z;
+
+    // Taylor expansion
+    let mut re = polynomial_3!(zz, P0atanf, P1atanf, P2atanf, P3atanf);
+    re = re.mul_add(zz * z, z) + s;
+
+    // get sign bit
+    re = (self.sign_bit()).blend(-re, re);
+
+    re
+  }
+
+  #[inline]
+  pub fn atan2(self, x: Self) -> Self {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+    const_f32_as_f32x16!(P3atanf, 8.05374449538E-2);
+    const_f32_as_f32x16!(P2atanf, -1.38776856032E-1);
+    const_f32_as_f32x16!(P1atanf, 1.99777106478E-1);
+    const_f32_as_f32x16!(P0atanf, -3.33329491539E-1);
+
+    let y = self;
+
+    // move in first octant
+    let x1 = x.abs();
+    let y1 = y.abs();
+    let swapxy = y1.simd_gt(x1);
+    // swap x and y if y1 > x1
+    let mut x2 = swapxy.blend(y1, x1);
+    let mut y2 = swapxy.blend(x1, y1);
+
+    // check for special case: x and y are both +/- INF
+    let both_infinite = x.is_inf() & y.is_inf();
+    if both_infinite.any() {
+      let minus_one = -Self::ONE;
+      x2 = both_infinite.blend(x2 & minus_one, x2);
+      y2 = both_infinite.blend(y2 & minus_one, y2);
+    }
+
+    // x = y = 0 will produce NAN. No problem, fixed below
+    let t = y2 / x2;
+
+    // small:  z = t / 1.0;
+    // medium: z = (t-1.0) / (t+1.0);
+    let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
+
+    let a = notsmal.blend(t - Self::ONE, t);
+    let b = notsmal.blend(t + Self::ONE, Self::ONE);
+    let s = notsmal & Self::FRAC_PI_4;
+    let z = a / b;
+
+    let zz = z * z;
+
+    // Taylor expansion
+    let mut re = polynomial_3!(zz, P0atanf, P1atanf, P2atanf, P3atanf);
+    re = re.mul_add(zz * z, z) + s;
+
+    // move back in place
+    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
+    re = (x.sign_bit()).blend(Self::PI - re, re);
+
+    // get sign bit
+    re = (y.sign_bit()).blend(-re, re);
+
+    re
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn sin_cos(self) -> (Self, Self) {
+    // Based on the Agner Fog "vector class library":
+    // https://github.com/vectorclass/version2/blob/master/vectormath_trig.h
+
+    const_f32_as_f32x16!(DP1F, 0.78515625_f32 * 2.0);
+    const_f32_as_f32x16!(DP2F, 2.4187564849853515625E-4_f32 * 2.0);
+    const_f32_as_f32x16!(DP3F, 3.77489497744594108E-8_f32 * 2.0);
+
+    const_f32_as_f32x16!(P0sinf, -1.6666654611E-1);
+    const_f32_as_f32x16!(P1sinf, 8.3321608736E-3);
+    const_f32_as_f32x16!(P2sinf, -1.9515295891E-4);
+
+    const_f32_as_f32x16!(P0cosf, 4.166664568298827E-2);
+    const_f32_as_f32x16!(P1cosf, -1.388731625493765E-3);
+    const_f32_as_f32x16!(P2cosf, 2.443315711809948E-5);
+
+    const_f32_as_f32x16!(TWO_OVER_PI, 2.0 / core::f32::consts::PI);
+
+    let xa = self.abs();
+
+    // Find quadrant
+    let y = (xa * TWO_OVER_PI).round();
+    let q: i32x16 = y.round_int();
+
+    let x = y.mul_neg_add(DP3F, y.mul_neg_add(DP2F, y.mul_neg_add(DP1F, xa)));
+
+    let x2 = x * x;
+    let mut s = polynomial_2!(x2, P0sinf, P1sinf, P2sinf) * (x * x2) + x;
+    let mut c = polynomial_2!(x2, P0cosf, P1cosf, P2cosf) * (x2 * x2)
+      + f32x16::from(0.5).mul_neg_add(x2, f32x16::from(1.0));
+
+    let swap = !(q & i32x16::from(1)).simd_eq(i32x16::from(0));
+
+    let mut overflow: f32x16 = cast(q.simd_gt(i32x16::from(0x2000000)));
+    overflow &= xa.is_finite();
+    s = overflow.blend(f32x16::from(0.0), s);
+    c = overflow.blend(f32x16::from(1.0), c);
+
+    // calc sin
+    let mut sin1 = cast::<_, f32x16>(swap).blend(c, s);
+    let sign_sin: i32x16 = (q << 30) ^ cast::<_, i32x16>(self);
+    sin1 = sin1.flip_signs(cast(sign_sin));
+
+    // calc cos
+    let mut cos1 = cast::<_, f32x16>(swap).blend(s, c);
+    let sign_cos: i32x16 = ((q + i32x16::from(1)) & i32x16::from(2)) << 30;
+    cos1 ^= cast::<_, f32x16>(sign_cos);
+
+    (sin1, cos1)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn sin(self) -> Self {
+    let (s, _) = self.sin_cos();
+    s
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn cos(self) -> Self {
+    let (_, c) = self.sin_cos();
+    c
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn tan(self) -> Self {
+    let (s, c) = self.sin_cos();
+    s / c
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn to_degrees(self) -> Self {
+    const_f32_as_f32x16!(RAD_TO_DEG_RATIO, 180.0_f32 / core::f32::consts::PI);
+    self * RAD_TO_DEG_RATIO
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn to_radians(self) -> Self {
+    const_f32_as_f32x16!(DEG_TO_RAD_RATIO, core::f32::consts::PI / 180.0_f32);
+    self * DEG_TO_RAD_RATIO
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn recip(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        // TODO: Add `_mm512_rcp14_ps` to `safe_arch`, looks like it is missing,
+        // then consider updating this implementation if the relative error is
+        // acceptable.
+        1.0 / self
+      } else {
+        Self {
+          a : self.a.recip(),
+          b : self.b.recip(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn recip_sqrt(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        // TODO: Add `_mm512_rsqrt14_ps` to `safe_arch`, looks like it is
+        // missing, then consider updating this implementation if the relative
+        // error is acceptable.
+        self.recip().sqrt()
+      } else {
+        Self {
+          a : self.a.recip_sqrt(),
+          b : self.b.recip_sqrt(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn sqrt(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: sqrt_m512(self.avx512) }
+      } else {
+        Self {
+          a : self.a.sqrt(),
+          b : self.b.sqrt(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  #[doc(alias("movemask", "move_mask"))]
+  pub fn to_bitmask(self) -> u32 {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        movepi32_mask_m512(self.avx512) as u32
+      } else {
+        (self.b.to_bitmask() << 8) | self.a.to_bitmask()
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn any(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        movepi32_mask_m512(self.avx512) != 0
+      } else {
+        self.a.any() || self.b.any()
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn all(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        movepi32_mask_m512(self.avx512) == !0_u16
+      } else {
+        self.a.all() && self.b.all()
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn none(self) -> bool {
+    !self.any()
+  }
+
+  #[inline]
+  fn vm_pow2n(self) -> Self {
+    const_f32_as_f32x16!(pow2_23, 8388608.0);
+    const_f32_as_f32x16!(bias, 127.0);
+    let a = self + (bias + pow2_23);
+    let c = cast::<_, i32x16>(a) << 23;
+    cast::<_, f32x16>(c)
+  }
+
+  /// Calculate the exponent of a packed `f32x16`
+  #[inline]
+  #[must_use]
+  pub fn exp(self) -> Self {
+    const_f32_as_f32x16!(P0, 1.0 / 2.0);
+    const_f32_as_f32x16!(P1, 1.0 / 6.0);
+    const_f32_as_f32x16!(P2, 1. / 24.);
+    const_f32_as_f32x16!(P3, 1. / 120.);
+    const_f32_as_f32x16!(P4, 1. / 720.);
+    const_f32_as_f32x16!(P5, 1. / 5040.);
+    const_f32_as_f32x16!(LN2D_HI, 0.693359375);
+    const_f32_as_f32x16!(LN2D_LO, -2.12194440e-4);
+    let max_x = f32x16::from(87.3);
+    let r = (self * Self::LOG2_E).round();
+    let x = r.mul_neg_add(LN2D_HI, self);
+    let x = r.mul_neg_add(LN2D_LO, x);
+    let z = polynomial_5!(x, P0, P1, P2, P3, P4, P5);
+    let x2 = x * x;
+    let z = z.mul_add(x2, x);
+    let n2 = Self::vm_pow2n(r);
+    let z = (z + Self::ONE) * n2;
+    // check for overflow
+    let in_range = self.abs().simd_lt(max_x);
+    let in_range = in_range & self.is_finite();
+    in_range.blend(z, Self::ZERO)
+  }
+
+  #[inline]
+  fn exponent(self) -> Self {
+    const_f32_as_f32x16!(pow2_23, 8388608.0);
+    const_f32_as_f32x16!(bias, 127.0);
+    let a = cast::<_, u32x16>(self);
+    let b = a >> 23;
+    let c = b | cast::<_, u32x16>(pow2_23);
+    let d = cast::<_, f32x16>(c);
+    let e = d - (pow2_23 + bias);
+    e
+  }
+
+  #[inline]
+  fn fraction_2(self) -> Self {
+    let t1 = cast::<_, u32x16>(self);
+    let t2 = cast::<_, u32x16>(
+      (t1 & u32x16::from(0x007FFFFF)) | u32x16::from(0x3F000000),
+    );
+    cast::<_, f32x16>(t2)
+  }
+
+  #[inline]
+  fn is_zero_or_subnormal(self) -> Self {
+    let t = cast::<_, i32x16>(self);
+    let t = t & i32x16::splat(0x7F800000);
+    i32x16::round_float(t.simd_eq(i32x16::splat(0)))
+  }
+
+  #[inline]
+  fn infinity() -> Self {
+    cast::<_, f32x16>(i32x16::splat(0x7F800000))
+  }
+
+  #[inline]
+  fn nan_log() -> Self {
+    cast::<_, f32x16>(i32x16::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
+  }
+
+  #[inline]
+  fn nan_pow() -> Self {
+    cast::<_, f32x16>(i32x16::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
+  }
+
+  #[inline]
+  pub fn sign_bit(self) -> Self {
+    let t1 = cast::<_, i32x16>(self);
+    let t2 = t1 >> 31;
+    !cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
+  }
+
+  /// horizontal add of all the elements of the vector
+  #[inline]
+  #[must_use]
+  pub fn reduce_add(self) -> f32 {
+    pick! {
+      if #[cfg(target_feature="avx512f")]{
+        reduce_add_m512(self.avx512)
+      } else {
+        self.a.reduce_add() + self.b.reduce_add()
+      }
+    }
+  }
+
+  /// Natural log (ln(x))
+  #[inline]
+  #[must_use]
+  pub fn ln(self) -> Self {
+    const_f32_as_f32x16!(HALF, 0.5);
+    const_f32_as_f32x16!(P0, 3.3333331174E-1);
+    const_f32_as_f32x16!(P1, -2.4999993993E-1);
+    const_f32_as_f32x16!(P2, 2.0000714765E-1);
+    const_f32_as_f32x16!(P3, -1.6668057665E-1);
+    const_f32_as_f32x16!(P4, 1.4249322787E-1);
+    const_f32_as_f32x16!(P5, -1.2420140846E-1);
+    const_f32_as_f32x16!(P6, 1.1676998740E-1);
+    const_f32_as_f32x16!(P7, -1.1514610310E-1);
+    const_f32_as_f32x16!(P8, 7.0376836292E-2);
+    const_f32_as_f32x16!(LN2F_HI, 0.693359375);
+    const_f32_as_f32x16!(LN2F_LO, -2.12194440e-4);
+    const_f32_as_f32x16!(VM_SMALLEST_NORMAL, 1.17549435E-38);
+
+    let x1 = self;
+    let x = Self::fraction_2(x1);
+    let e = Self::exponent(x1);
+    let mask = x.simd_gt(Self::SQRT_2 * HALF);
+    let x = (!mask).blend(x + x, x);
+    let fe = mask.blend(e + Self::ONE, e);
+    let x = x - Self::ONE;
+    let res = polynomial_8!(x, P0, P1, P2, P3, P4, P5, P6, P7, P8);
+    let x2 = x * x;
+    let res = x2 * x * res;
+    let res = fe.mul_add(LN2F_LO, res);
+    let res = res + x2.mul_neg_add(HALF, x);
+    let res = fe.mul_add(LN2F_HI, res);
+    let overflow = !self.is_finite();
+    let underflow = x1.simd_lt(VM_SMALLEST_NORMAL);
+    let mask = overflow | underflow;
+    if !mask.any() {
+      res
+    } else {
+      let is_zero = self.is_zero_or_subnormal();
+      let res = underflow.blend(Self::nan_log(), res);
+      let res = is_zero.blend(Self::infinity(), res);
+      let res = overflow.blend(self, res);
+      res
+    }
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn log2(self) -> Self {
+    Self::ln(self) * Self::LOG2_E
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn log10(self) -> Self {
+    Self::ln(self) * Self::LOG10_E
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn pow_f32x16(self, y: Self) -> Self {
+    const_f32_as_f32x16!(ln2f_hi, 0.693359375);
+    const_f32_as_f32x16!(ln2f_lo, -2.12194440e-4);
+    const_f32_as_f32x16!(P0logf, 3.3333331174E-1);
+    const_f32_as_f32x16!(P1logf, -2.4999993993E-1);
+    const_f32_as_f32x16!(P2logf, 2.0000714765E-1);
+    const_f32_as_f32x16!(P3logf, -1.6668057665E-1);
+    const_f32_as_f32x16!(P4logf, 1.4249322787E-1);
+    const_f32_as_f32x16!(P5logf, -1.2420140846E-1);
+    const_f32_as_f32x16!(P6logf, 1.1676998740E-1);
+    const_f32_as_f32x16!(P7logf, -1.1514610310E-1);
+    const_f32_as_f32x16!(P8logf, 7.0376836292E-2);
+
+    const_f32_as_f32x16!(p2expf, 1.0 / 2.0); // coefficients for Taylor expansion of exp
+    const_f32_as_f32x16!(p3expf, 1.0 / 6.0);
+    const_f32_as_f32x16!(p4expf, 1.0 / 24.0);
+    const_f32_as_f32x16!(p5expf, 1.0 / 120.0);
+    const_f32_as_f32x16!(p6expf, 1.0 / 720.0);
+    const_f32_as_f32x16!(p7expf, 1.0 / 5040.0);
+
+    let x1 = self.abs();
+    let x = x1.fraction_2();
+    let mask = x.simd_gt(f32x16::SQRT_2 * f32x16::HALF);
+    let x = (!mask).blend(x + x, x);
+
+    let x = x - f32x16::ONE;
+    let x2 = x * x;
+    let lg1 = polynomial_8!(
+      x, P0logf, P1logf, P2logf, P3logf, P4logf, P5logf, P6logf, P7logf, P8logf
+    );
+    let lg1 = lg1 * x2 * x;
+
+    let ef = x1.exponent();
+    let ef = mask.blend(ef + f32x16::ONE, ef);
+    let e1 = (ef * y).round();
+    let yr = ef.mul_sub(y, e1);
+
+    let lg = f32x16::HALF.mul_neg_add(x2, x) + lg1;
+    let x2_err = (f32x16::HALF * x).mul_sub(x, f32x16::HALF * x2);
+    let lg_err = f32x16::HALF.mul_add(x2, lg - x) - lg1;
+
+    let e2 = (lg * y * f32x16::LOG2_E).round();
+    let v = lg.mul_sub(y, e2 * ln2f_hi);
+    let v = e2.mul_neg_add(ln2f_lo, v);
+    let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x16::LN_2);
+
+    let x = v;
+    let e3 = (x * f32x16::LOG2_E).round();
+    let x = e3.mul_neg_add(f32x16::LN_2, x);
+    let x2 = x * x;
+    let z = x2.mul_add(
+      polynomial_5!(x, p2expf, p3expf, p4expf, p5expf, p6expf, p7expf),
+      x + f32x16::ONE,
+    );
+
+    let ee = e1 + e2 + e3;
+    let ei = cast::<_, i32x16>(ee.round_int());
+    let ej = cast::<_, i32x16>(ei + (cast::<_, i32x16>(z) >> 23));
+
+    let overflow = cast::<_, f32x16>(ej.simd_gt(i32x16::splat(0x0FF)))
+      | (ee.simd_gt(f32x16::splat(300.0)));
+    let underflow = cast::<_, f32x16>(ej.simd_lt(i32x16::splat(0x000)))
+      | (ee.simd_lt(f32x16::splat(-300.0)));
+
+    // Add exponent by integer addition
+    let z = cast::<_, f32x16>(cast::<_, i32x16>(z) + (ei << 23));
+    // Check for overflow/underflow
+    let z = underflow.blend(f32x16::ZERO, z);
+    let z = overflow.blend(Self::infinity(), z);
+
+    // Check for self == 0
+    let x_zero = self.is_zero_or_subnormal();
+    let z = x_zero.blend(
+      y.simd_lt(f32x16::ZERO).blend(
+        Self::infinity(),
+        y.simd_eq(f32x16::ZERO).blend(f32x16::ONE, f32x16::ZERO),
+      ),
+      z,
+    );
+
+    let x_sign = self.sign_bit();
+    let z = if x_sign.any() {
+      // Y into an integer
+      let yi = y.simd_eq(y.round());
+
+      // Is y odd?
+      let y_odd = cast::<_, i32x16>(y.round_int() << 31).round_float();
+
+      let z1 =
+        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
+
+      x_sign.blend(z1, z)
+    } else {
+      z
+    };
+
+    let x_finite = self.is_finite();
+    let y_finite = y.is_finite();
+    let e_finite = ee.is_finite();
+    if (x_finite & y_finite & (e_finite | x_zero)).all() {
+      return z;
+    }
+
+    (self.is_nan() | y.is_nan()).blend(self + y, z)
+  }
+
+  #[inline]
+  pub fn powf(self, y: f32) -> Self {
+    Self::pow_f32x16(self, f32x16::splat(y))
+  }
+
+  /// Transpose matrix of 16x16 `f32` matrix. Currently not accelerated.
+  #[must_use]
+  #[inline]
+  pub fn transpose(data: [f32x16; 16]) -> [f32x16; 16] {
+    // TODO: Add `_mm512_unpackhi_ps` to `safe_arch`, looks like it is missing,
+    // then try adding an optimized `avx512f` implementation.
+
+    #[inline(always)]
+    fn transpose_column(data: &[f32x16; 16], index: usize) -> f32x16 {
+      f32x16::new([
+        data[0].as_array()[index],
+        data[1].as_array()[index],
+        data[2].as_array()[index],
+        data[3].as_array()[index],
+        data[4].as_array()[index],
+        data[5].as_array()[index],
+        data[6].as_array()[index],
+        data[7].as_array()[index],
+        data[8].as_array()[index],
+        data[9].as_array()[index],
+        data[10].as_array()[index],
+        data[11].as_array()[index],
+        data[12].as_array()[index],
+        data[13].as_array()[index],
+        data[14].as_array()[index],
+        data[15].as_array()[index],
+      ])
+    }
+
+    [
+      transpose_column(&data, 0),
+      transpose_column(&data, 1),
+      transpose_column(&data, 2),
+      transpose_column(&data, 3),
+      transpose_column(&data, 4),
+      transpose_column(&data, 5),
+      transpose_column(&data, 6),
+      transpose_column(&data, 7),
+      transpose_column(&data, 8),
+      transpose_column(&data, 9),
+      transpose_column(&data, 10),
+      transpose_column(&data, 11),
+      transpose_column(&data, 12),
+      transpose_column(&data, 13),
+      transpose_column(&data, 14),
+      transpose_column(&data, 15),
+    ]
   }
 
   #[inline]
@@ -645,6 +1520,20 @@ impl f32x16 {
         Self {
           a: self.a.mul_neg_sub(m.a, s.a),
           b: self.b.mul_neg_sub(m.b, s.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn from_i32x16(v: i32x16) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: convert_to_m512_from_i32_m512i(v.avx512) }
+      } else {
+        Self {
+          a: f32x8::from_i32x8(v.a),
+          b: f32x8::from_i32x8(v.b),
         }
       }
     }

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -619,6 +619,178 @@ impl f32x16 {
     }
   }
 
+  /// Performs a multiply-add operation: `self * m + a`
+  ///
+  /// When hardware FMA support is available, this computes the result with a
+  /// single rounding operation. Without FMA support, it falls back to separate
+  /// multiply and add operations with two roundings.
+  ///
+  /// # Platform-specific behavior
+  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfmadd` (single
+  ///   rounding, best accuracy)
+  /// - On `x86`/`x86_64` with AVX-512F only: Uses `(self * m) + a` (two
+  ///   roundings)
+  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
+  ///
+  /// # Examples
+  /// ```
+  /// # use wide::f32x16;
+  /// let a = f32x16::from([1.0; 16]);
+  /// let b = f32x16::from([2.0; 16]);
+  /// let c = f32x16::from([10.0; 16]);
+  ///
+  /// let result = a.mul_add(b, c);
+  ///
+  /// let expected = f32x16::from([12.0; 16]);
+  /// assert_eq!(result, expected);
+  /// ```
+  #[inline]
+  #[must_use]
+  pub fn mul_add(self, m: Self, a: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
+        Self { avx512: fused_mul_add_m512(self.avx512, m.avx512, a.avx512) }
+      } else if #[cfg(target_feature="avx512f")] {
+        // still want to use 512 bit ops
+        (self * m) + a
+      } else {
+        Self {
+          a: self.a.mul_add(m.a, a.a),
+          b: self.b.mul_add(m.b, a.b),
+        }
+      }
+    }
+  }
+
+  /// Performs a multiply-subtract operation: `self * m - s`
+  ///
+  /// When hardware FMA support is available, this computes the result with a
+  /// single rounding operation. Without FMA support, it falls back to separate
+  /// multiply and subtract operations with two roundings.
+  ///
+  /// # Platform-specific behavior
+  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfmsub` (single
+  ///   rounding, best accuracy)
+  /// - On `x86`/`x86_64` with AVX-512F only: Uses `(self * m) - s` (two
+  ///   roundings)
+  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
+  ///
+  /// # Examples
+  /// ```
+  /// # use wide::f32x16;
+  /// let a = f32x16::from([10.0; 16]);
+  /// let b = f32x16::from([3.0; 16]);
+  /// let c = f32x16::from([5.0; 16]);
+  ///
+  /// let result = a.mul_sub(b, c);
+  ///
+  /// let expected = f32x16::from([25.0; 16]);
+  /// assert_eq!(result, expected);
+  /// ```
+  #[inline]
+  #[must_use]
+  pub fn mul_sub(self, m: Self, s: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
+        Self { avx512: fused_mul_sub_m512(self.avx512, m.avx512, s.avx512) }
+      } else if #[cfg(target_feature="avx512f")] {
+        // still want to use 512 bit ops
+        (self * m) - s
+      } else {
+        Self {
+          a: self.a.mul_sub(m.a, s.a),
+          b: self.b.mul_sub(m.b, s.b),
+        }
+      }
+    }
+  }
+
+  /// Performs a negative multiply-add operation: `a - (self * m)`
+  ///
+  /// When hardware FMA support is available, this computes the result with a
+  /// single rounding operation. Without FMA support, it falls back to separate
+  /// operations with two roundings.
+  ///
+  /// # Platform-specific behavior
+  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfnmadd` (single
+  ///   rounding, best accuracy)
+  /// - On `x86`/`x86_64` with AVX-512F only: Uses `a - (self * m)` (two
+  ///   roundings)
+  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
+  ///
+  /// # Examples
+  /// ```
+  /// # use wide::f32x16;
+  /// let a = f32x16::from([4.0; 16]);
+  /// let b = f32x16::from([2.0; 16]);
+  /// let c = f32x16::from([10.0; 16]);
+  ///
+  /// let result = a.mul_neg_add(b, c);
+  ///
+  /// let expected = f32x16::from([2.0; 16]);
+  /// assert_eq!(result, expected);
+  /// ```
+  #[inline]
+  #[must_use]
+  pub fn mul_neg_add(self, m: Self, a: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
+        Self { avx512: fused_mul_neg_add_m512(self.avx512, m.avx512, a.avx512) }
+      } else if #[cfg(target_feature="avx512f")] {
+        // still want to use 512 bit ops
+        a - (self * m)
+      } else {
+        Self {
+          a: self.a.mul_neg_add(m.a, a.a),
+          b: self.b.mul_neg_add(m.b, a.b),
+        }
+      }
+    }
+  }
+
+  /// Performs a negative multiply-subtract operation: `-(self * m) - s`
+  ///
+  /// When hardware FMA support is available, this computes the result with a
+  /// single rounding operation. Without FMA support, it falls back to separate
+  /// operations with two roundings.
+  ///
+  /// # Platform-specific behavior
+  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfnmsub` (single
+  ///   rounding, best accuracy)
+  /// - On `x86`/`x86_64` with AVX-512F only: Uses `-(self * m) - s` (two
+  ///   roundings)
+  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
+  ///
+  /// # Examples
+  /// ```
+  /// # use wide::f32x16;
+  /// let a = f32x16::from([4.0; 16]);
+  /// let b = f32x16::from([2.0; 16]);
+  /// let c = f32x16::from([1.0; 16]);
+  ///
+  /// let result = a.mul_neg_sub(b, c);
+  ///
+  /// let expected = f32x16::from([-9.0; 16]);
+  /// assert_eq!(result, expected);
+  /// ```
+  #[inline]
+  #[must_use]
+  pub fn mul_neg_sub(self, m: Self, s: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
+        Self { avx512: fused_mul_neg_sub_m512(self.avx512, m.avx512, s.avx512) }
+      } else if #[cfg(target_feature="avx512f")] {
+        // still want to use 512 bit ops
+        -(self * m) - s
+      } else {
+        Self {
+          a: self.a.mul_neg_sub(m.a, s.a),
+          b: self.b.mul_neg_sub(m.b, s.b),
+        }
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn flip_signs(self, signs: Self) -> Self {
@@ -1351,178 +1523,6 @@ impl f32x16 {
   #[must_use]
   pub fn as_mut_array(&mut self) -> &mut [f32; 16] {
     cast_mut(self)
-  }
-
-  /// Performs a multiply-add operation: `self * m + a`
-  ///
-  /// When hardware FMA support is available, this computes the result with a
-  /// single rounding operation. Without FMA support, it falls back to separate
-  /// multiply and add operations with two roundings.
-  ///
-  /// # Platform-specific behavior
-  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfmadd` (single
-  ///   rounding, best accuracy)
-  /// - On `x86`/`x86_64` with AVX-512F only: Uses `(self * m) + a` (two
-  ///   roundings)
-  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
-  ///
-  /// # Examples
-  /// ```
-  /// # use wide::f32x16;
-  /// let a = f32x16::from([1.0; 16]);
-  /// let b = f32x16::from([2.0; 16]);
-  /// let c = f32x16::from([10.0; 16]);
-  ///
-  /// let result = a.mul_add(b, c);
-  ///
-  /// let expected = f32x16::from([12.0; 16]);
-  /// assert_eq!(result, expected);
-  /// ```
-  #[inline]
-  #[must_use]
-  pub fn mul_add(self, m: Self, a: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
-        Self { avx512: fused_mul_add_m512(self.avx512, m.avx512, a.avx512) }
-      } else if #[cfg(target_feature="avx512f")] {
-        // still want to use 512 bit ops
-        (self * m) + a
-      } else {
-        Self {
-          a: self.a.mul_add(m.a, a.a),
-          b: self.b.mul_add(m.b, a.b),
-        }
-      }
-    }
-  }
-
-  /// Performs a multiply-subtract operation: `self * m - s`
-  ///
-  /// When hardware FMA support is available, this computes the result with a
-  /// single rounding operation. Without FMA support, it falls back to separate
-  /// multiply and subtract operations with two roundings.
-  ///
-  /// # Platform-specific behavior
-  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfmsub` (single
-  ///   rounding, best accuracy)
-  /// - On `x86`/`x86_64` with AVX-512F only: Uses `(self * m) - s` (two
-  ///   roundings)
-  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
-  ///
-  /// # Examples
-  /// ```
-  /// # use wide::f32x16;
-  /// let a = f32x16::from([10.0; 16]);
-  /// let b = f32x16::from([3.0; 16]);
-  /// let c = f32x16::from([5.0; 16]);
-  ///
-  /// let result = a.mul_sub(b, c);
-  ///
-  /// let expected = f32x16::from([25.0; 16]);
-  /// assert_eq!(result, expected);
-  /// ```
-  #[inline]
-  #[must_use]
-  pub fn mul_sub(self, m: Self, s: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
-        Self { avx512: fused_mul_sub_m512(self.avx512, m.avx512, s.avx512) }
-      } else if #[cfg(target_feature="avx512f")] {
-        // still want to use 512 bit ops
-        (self * m) - s
-      } else {
-        Self {
-          a: self.a.mul_sub(m.a, s.a),
-          b: self.b.mul_sub(m.b, s.b),
-        }
-      }
-    }
-  }
-
-  /// Performs a negative multiply-add operation: `a - (self * m)`
-  ///
-  /// When hardware FMA support is available, this computes the result with a
-  /// single rounding operation. Without FMA support, it falls back to separate
-  /// operations with two roundings.
-  ///
-  /// # Platform-specific behavior
-  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfnmadd` (single
-  ///   rounding, best accuracy)
-  /// - On `x86`/`x86_64` with AVX-512F only: Uses `a - (self * m)` (two
-  ///   roundings)
-  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
-  ///
-  /// # Examples
-  /// ```
-  /// # use wide::f32x16;
-  /// let a = f32x16::from([4.0; 16]);
-  /// let b = f32x16::from([2.0; 16]);
-  /// let c = f32x16::from([10.0; 16]);
-  ///
-  /// let result = a.mul_neg_add(b, c);
-  ///
-  /// let expected = f32x16::from([2.0; 16]);
-  /// assert_eq!(result, expected);
-  /// ```
-  #[inline]
-  #[must_use]
-  pub fn mul_neg_add(self, m: Self, a: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
-        Self { avx512: fused_mul_neg_add_m512(self.avx512, m.avx512, a.avx512) }
-      } else if #[cfg(target_feature="avx512f")] {
-        // still want to use 512 bit ops
-        a - (self * m)
-      } else {
-        Self {
-          a: self.a.mul_neg_add(m.a, a.a),
-          b: self.b.mul_neg_add(m.b, a.b),
-        }
-      }
-    }
-  }
-
-  /// Performs a negative multiply-subtract operation: `-(self * m) - s`
-  ///
-  /// When hardware FMA support is available, this computes the result with a
-  /// single rounding operation. Without FMA support, it falls back to separate
-  /// operations with two roundings.
-  ///
-  /// # Platform-specific behavior
-  /// - On `x86`/`x86_64` with AVX-512F+FMA: Uses 512-bit `vfnmsub` (single
-  ///   rounding, best accuracy)
-  /// - On `x86`/`x86_64` with AVX-512F only: Uses `-(self * m) - s` (two
-  ///   roundings)
-  /// - Other platforms: Delegates to [`f32x8`] (inherits its FMA behavior)
-  ///
-  /// # Examples
-  /// ```
-  /// # use wide::f32x16;
-  /// let a = f32x16::from([4.0; 16]);
-  /// let b = f32x16::from([2.0; 16]);
-  /// let c = f32x16::from([1.0; 16]);
-  ///
-  /// let result = a.mul_neg_sub(b, c);
-  ///
-  /// let expected = f32x16::from([-9.0; 16]);
-  /// assert_eq!(result, expected);
-  /// ```
-  #[inline]
-  #[must_use]
-  pub fn mul_neg_sub(self, m: Self, s: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f",target_feature="fma"))] {
-        Self { avx512: fused_mul_neg_sub_m512(self.avx512, m.avx512, s.avx512) }
-      } else if #[cfg(target_feature="avx512f")] {
-        // still want to use 512 bit ops
-        -(self * m) - s
-      } else {
-        Self {
-          a: self.a.mul_neg_sub(m.a, s.a),
-          b: self.b.mul_neg_sub(m.b, s.b),
-        }
-      }
-    }
   }
 
   #[inline]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -1117,11 +1117,11 @@ impl f32x16 {
   #[must_use]
   pub fn recip_sqrt(self) -> Self {
     pick! {
-      if #[cfg(target_feature="avx")] {
+      if #[cfg(target_feature="avx512f")] {
         // TODO: Add `_mm512_rsqrt14_ps` to `safe_arch`, looks like it is
         // missing, then consider updating this implementation if the relative
         // error is acceptable.
-        self.recip().sqrt()
+        self.sqrt().recip()
       } else {
         Self {
           a : self.a.recip_sqrt(),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -4,11 +4,11 @@ pick! {
   if #[cfg(target_feature="avx")] {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f32x8 { avx: m256 }
+    pub struct f32x8 { pub(crate) avx: m256 }
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f32x8 { a : f32x4, b : f32x4 }
+    pub struct f32x8 { pub(crate) a : f32x4, pub(crate) b : f32x4 }
   }
 }
 

--- a/tests/all_tests/t_f32x16.rs
+++ b/tests/all_tests/t_f32x16.rs
@@ -128,12 +128,40 @@ fn impl_sub_for_f32x16() {
 #[test]
 fn impl_neg_for_f32x16() {
   let a = f32x16::from([
-    1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 0.0, -0.0, f32::INFINITY,
-    f32::NEG_INFINITY, 9.0, -10.0, 11.0, -12.0,
+    1.0,
+    -2.0,
+    3.0,
+    -4.0,
+    5.0,
+    -6.0,
+    7.0,
+    -8.0,
+    0.0,
+    -0.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    9.0,
+    -10.0,
+    11.0,
+    -12.0,
   ]);
   let expected = f32x16::from([
-    -1.0, 2.0, -3.0, 4.0, -5.0, 6.0, -7.0, 8.0, -0.0, 0.0, f32::NEG_INFINITY,
-    f32::INFINITY, -9.0, 10.0, -11.0, 12.0,
+    -1.0,
+    2.0,
+    -3.0,
+    4.0,
+    -5.0,
+    6.0,
+    -7.0,
+    8.0,
+    -0.0,
+    0.0,
+    f32::NEG_INFINITY,
+    f32::INFINITY,
+    -9.0,
+    10.0,
+    -11.0,
+    12.0,
   ]);
   assert_eq!(-a, expected);
 
@@ -344,44 +372,191 @@ fn impl_f32x16_blend() {
   assert_eq!(expected, actual);
 }
 
-// #[test]
-// fn impl_f32x16_abs() {
-//   let a =
-//     f32x16::from([-1.0, 2.0, -3.5, f32::NEG_INFINITY, 6.0, 15.0, -19.0,
-// -9.0]);   let expected =
-//     f32x16::from([1.0, 2.0, 3.5, f32::INFINITY, 6.0, 15.0, 19.0, 9.0]);
-//   let actual = a.abs();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_abs() {
+  let a = f32x16::from([
+    -1.0,
+    2.0,
+    -3.5,
+    f32::NEG_INFINITY,
+    6.0,
+    15.0,
+    -19.0,
+    -9.0,
+    4.5,
+    -20.0,
+    f32::INFINITY,
+    5.0,
+    -4.0,
+    13.0,
+    9.5,
+    -3.0,
+  ]);
+  let expected = f32x16::from([
+    1.0,
+    2.0,
+    3.5,
+    f32::INFINITY,
+    6.0,
+    15.0,
+    19.0,
+    9.0,
+    4.5,
+    20.0,
+    f32::INFINITY,
+    5.0,
+    4.0,
+    13.0,
+    9.5,
+    3.0,
+  ]);
+  let actual = a.abs();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_floor() {
-//   let a = f32x16::from([-1.1, 60.9, 1.1, f32::INFINITY, 96.6, -53.2, 0.1,
-// 9.2]);   let expected =
-//     f32x16::from([-2.0, 60.0, 1.0, f32::INFINITY, 96.0, -54.0, 0.0, 9.0]);
-//   let actual = a.floor();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_floor() {
+  let a = f32x16::from([
+    -1.1,
+    60.9,
+    1.1,
+    f32::INFINITY,
+    96.6,
+    -53.2,
+    0.1,
+    9.2,
+    6.9,
+    -3.4,
+    85.3,
+    -79.8,
+    4.2,
+    -6.4,
+    7.3,
+    -9.1,
+  ]);
+  let expected = f32x16::from([
+    -2.0,
+    60.0,
+    1.0,
+    f32::INFINITY,
+    96.0,
+    -54.0,
+    0.0,
+    9.0,
+    6.0,
+    -4.0,
+    85.0,
+    -80.0,
+    4.0,
+    -7.0,
+    7.0,
+    -10.0,
+  ]);
+  let actual = a.floor();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f64x4_ceil() {
-//   let a =
-//     f32x16::from([-1.1, 60.9, 1.1, f32::NEG_INFINITY, 96.6, -53.2, 0.1,
-// 9.2]);   let expected =
-//     f32x16::from([-1.0, 61.0, 2.0, f32::NEG_INFINITY, 97.0, -53.0, 1.0,
-// 10.0]);   let actual = a.ceil();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_ceil() {
+  let a = f32x16::from([
+    -1.1,
+    60.9,
+    1.1,
+    f32::NEG_INFINITY,
+    96.6,
+    -53.2,
+    0.1,
+    9.2,
+    6.9,
+    -3.4,
+    85.3,
+    -79.8,
+    4.2,
+    -6.4,
+    7.3,
+    -9.1,
+  ]);
+  let expected = f32x16::from([
+    -1.0,
+    61.0,
+    2.0,
+    f32::NEG_INFINITY,
+    97.0,
+    -53.0,
+    1.0,
+    10.0,
+    7.0,
+    -3.0,
+    86.0,
+    -79.0,
+    5.0,
+    -6.0,
+    8.0,
+    -9.0,
+  ]);
+  let actual = a.ceil();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_fast_max() {
-//   let a = f32x16::from([1.0, 5.0, 3.0, 0.0, 6.0, -8.0, 12.0, 9.0]);
-//   let b = f32x16::from([2.0, -3.0, f32::INFINITY, 10.0, 19.0, -5.0, -1.0,
-// -9.0]);   let expected =
-//     f32x16::from([2.0, 5.0, f32::INFINITY, 10.0, 19.0, -5.0, 12.0, 9.0]);
-//   let actual = a.fast_max(b);
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_fast_max() {
+  let a = f32x16::from([
+    1.0,
+    5.0,
+    3.0,
+    0.0,
+    6.0,
+    -8.0,
+    12.0,
+    9.0,
+    2.0,
+    -3.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    -1.0,
+    -9.0,
+  ]);
+  let b = f32x16::from([
+    2.0,
+    -3.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    -1.0,
+    -9.0,
+    1.0,
+    5.0,
+    3.0,
+    0.0,
+    6.0,
+    -8.0,
+    12.0,
+    9.0,
+  ]);
+  let expected = f32x16::from([
+    2.0,
+    5.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    12.0,
+    9.0,
+    2.0,
+    5.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    12.0,
+    9.0,
+  ]);
+  let actual = a.fast_max(b);
+  assert_eq!(expected, actual);
+}
 
 #[test]
 fn impl_f32x16_max() {
@@ -443,15 +618,65 @@ fn impl_f32x16_max() {
   assert_eq!(expected, actual);
 }
 
-// #[test]
-// fn impl_f32x16_fast_min() {
-//   let a = f32x16::from([1.0, 5.0, 3.0, f32::NEG_INFINITY, 6.0, -8.0, 12.0,
-// 9.0]);   let b = f32x16::from([2.0, -3.0, f32::INFINITY, 10.0, 19.0, -5.0,
-// -1.0, -9.0]);   let expected =
-//     f32x16::from([1.0, -3.0, 3.0, f32::NEG_INFINITY, 6.0, -8.0, -1.0, -9.0]);
-//   let actual = a.fast_min(b);
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_fast_min() {
+  let a = f32x16::from([
+    1.0,
+    5.0,
+    3.0,
+    f32::NEG_INFINITY,
+    6.0,
+    -8.0,
+    12.0,
+    9.0,
+    2.0,
+    -3.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    -1.0,
+    -9.0,
+  ]);
+  let b = f32x16::from([
+    2.0,
+    -3.0,
+    f32::INFINITY,
+    10.0,
+    19.0,
+    -5.0,
+    -1.0,
+    -9.0,
+    1.0,
+    5.0,
+    3.0,
+    f32::NEG_INFINITY,
+    6.0,
+    -8.0,
+    12.0,
+    9.0,
+  ]);
+  let expected = f32x16::from([
+    1.0,
+    -3.0,
+    3.0,
+    f32::NEG_INFINITY,
+    6.0,
+    -8.0,
+    -1.0,
+    -9.0,
+    1.0,
+    -3.0,
+    3.0,
+    f32::NEG_INFINITY,
+    6.0,
+    -8.0,
+    -1.0,
+    -9.0,
+  ]);
+  let actual = a.fast_min(b);
+  assert_eq!(expected, actual);
+}
 
 #[test]
 fn impl_f32x16_min() {
@@ -513,30 +738,131 @@ fn impl_f32x16_min() {
   assert_eq!(expected, actual);
 }
 
-// #[test]
-// fn impl_f32x16_is_nan() {
-//   let a = f32x16::from([0.0, f32::NAN, f32::NAN, 0.0, 0.0, 0.0, f32::NAN,
-// 0.0]);   let expected: [u32; 8] = [0, u32::MAX, u32::MAX, 0, 0, 0, u32::MAX,
-// 0];   let actual: [u32; 8] = cast(a.is_nan());
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_is_nan() {
+  let a = f32x16::from([
+    0.0,
+    f32::NAN,
+    f32::NAN,
+    0.0,
+    0.0,
+    0.0,
+    f32::NAN,
+    0.0,
+    1.0,
+    2.0,
+    1000.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    -0.0,
+    f32::NAN,
+    -1.0,
+  ]);
+  let expected: [u32; 16] = [
+    0,
+    u32::MAX,
+    u32::MAX,
+    0,
+    0,
+    0,
+    u32::MAX,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    u32::MAX,
+    0,
+  ];
+  let actual: [u32; 16] = cast(a.is_nan());
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_is_finite() {
-//   let a = f32x16::from([
-//     f32::NAN,
-//     1.0,
-//     f32::INFINITY,
-//     f32::NEG_INFINITY,
-//     2.0,
-//     5.0,
-//     f32::INFINITY,
-//     9.0,
-//   ]);
-//   let expected: [u32; 8] = [0, u32::MAX, 0, 0, u32::MAX, u32::MAX, 0,
-// u32::MAX];   let actual: [u32; 8] = cast(a.is_finite());
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_is_finite() {
+  let a = f32x16::from([
+    f32::NAN,
+    1.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2.0,
+    5.0,
+    f32::INFINITY,
+    9.0,
+    -0.0,
+    8.0,
+    100.0,
+    -50.0,
+    f32::NEG_INFINITY,
+    f32::NAN,
+    4.0,
+    5.0,
+  ]);
+  let expected: [u32; 16] = [
+    0,
+    u32::MAX,
+    0,
+    0,
+    u32::MAX,
+    u32::MAX,
+    0,
+    u32::MAX,
+    u32::MAX,
+    u32::MAX,
+    u32::MAX,
+    u32::MAX,
+    0,
+    0,
+    u32::MAX,
+    u32::MAX,
+  ];
+  let actual: [u32; 16] = cast(a.is_finite());
+  assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_f32x16_is_inf() {
+  let a = f32x16::from([
+    f32::NAN,
+    1.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2.0,
+    5.0,
+    f32::INFINITY,
+    9.0,
+    -0.0,
+    8.0,
+    100.0,
+    -50.0,
+    f32::NEG_INFINITY,
+    f32::NAN,
+    4.0,
+    5.0,
+  ]);
+  let expected: [u32; 16] = [
+    0,
+    0,
+    u32::MAX,
+    u32::MAX,
+    0,
+    0,
+    u32::MAX,
+    0,
+    0,
+    0,
+    0,
+    0,
+    u32::MAX,
+    0,
+    0,
+    0,
+  ];
+  let actual: [u32; 16] = cast(a.is_inf());
+  assert_eq!(expected, actual);
+}
 
 #[test]
 fn impl_f32x16_round() {
@@ -594,84 +920,84 @@ fn impl_f32x16_round() {
   let expected: [u32; 16] = [u32::MAX; 16];
   let actual: [u32; 16] = cast(a.round().is_nan());
   assert_eq!(expected, actual);
+  //
+  let a = f32x16::from(-0.0);
+  let expected = a;
+  let actual = a.round();
+  assert_eq!(expected, actual);
 }
-//   let a = f32x16::from(-0.0);
-//   let expected = a;
-//   let actual = a.round();
-//   assert_eq!(expected, actual);
-// }
 
-// #[test]
-// fn impl_f32x16_fast_round_int() {
-//   for (f, i) in [(1.0, 1), (1.1, 1), (-2.1, -2), (2.5, 2), (0.0, 0), (-0.0,
-// 0)]     .iter()
-//     .copied()
-//   {
-//     let a = f32x16::from(f);
-//     let expected = i32x8::from(i);
-//     let actual = a.fast_round_int();
-//     assert_eq!(expected, actual);
-//   }
-// }
+#[test]
+fn impl_f32x16_fast_round_int() {
+  for (f, i) in [(1.0, 1), (1.1, 1), (-2.1, -2), (2.5, 2), (0.0, 0), (-0.0, 0)]
+    .iter()
+    .copied()
+  {
+    let a = f32x16::from(f);
+    let expected = i32x16::from(i);
+    let actual = a.fast_round_int();
+    assert_eq!(expected, actual);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_round_int() {
-//   for (f, i) in [
-//     (1.0, 1),
-//     (1.1, 1),
-//     (-2.1, -2),
-//     (2.5, 2),
-//     (0.0, 0),
-//     (-0.0, 0),
-//     (f32::NAN, 0),
-//     (f32::INFINITY, i32::MAX),
-//     (f32::NEG_INFINITY, i32::MIN),
-//   ]
-//   .iter()
-//   .copied()
-//   {
-//     let a = f32x16::from(f);
-//     let expected = i32x8::from(i);
-//     let actual = a.round_int();
-//     assert_eq!(expected, actual);
-//   }
-// }
+#[test]
+fn impl_f32x16_round_int() {
+  for (f, i) in [
+    (1.0, 1),
+    (1.1, 1),
+    (-2.1, -2),
+    (2.5, 2),
+    (0.0, 0),
+    (-0.0, 0),
+    (f32::NAN, 0),
+    (f32::INFINITY, i32::MAX),
+    (f32::NEG_INFINITY, i32::MIN),
+  ]
+  .iter()
+  .copied()
+  {
+    let a = f32x16::from(f);
+    let expected = i32x16::from(i);
+    let actual = a.round_int();
+    assert_eq!(expected, actual);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_fast_trunc_int() {
-//   for (f, i) in [(1.0, 1), (1.1, 1), (-2.1, -2), (2.5, 2), (3.7, 3), (-0.0,
-// 0)]     .iter()
-//     .copied()
-//   {
-//     let a = f32x16::from(f);
-//     let expected = i32x8::from(i);
-//     let actual = a.fast_trunc_int();
-//     assert_eq!(expected, actual);
-//   }
-// }
+#[test]
+fn impl_f32x16_fast_trunc_int() {
+  for (f, i) in [(1.0, 1), (1.1, 1), (-2.1, -2), (2.5, 2), (3.7, 3), (-0.0, 0)]
+    .iter()
+    .copied()
+  {
+    let a = f32x16::from(f);
+    let expected = i32x16::from(i);
+    let actual = a.fast_trunc_int();
+    assert_eq!(expected, actual);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_trunc_int() {
-//   for (f, i) in [
-//     (1.0, 1),
-//     (1.1, 1),
-//     (-2.1, -2),
-//     (2.5, 2),
-//     (3.7, 3),
-//     (-0.0, 0),
-//     (f32::NAN, 0),
-//     (f32::INFINITY, i32::MAX),
-//     (f32::NEG_INFINITY, i32::MIN),
-//   ]
-//   .iter()
-//   .copied()
-//   {
-//     let a = f32x16::from(f);
-//     let expected = i32x8::from(i);
-//     let actual = a.trunc_int();
-//     assert_eq!(expected, actual);
-//   }
-// }
+#[test]
+fn impl_f32x16_trunc_int() {
+  for (f, i) in [
+    (1.0, 1),
+    (1.1, 1),
+    (-2.1, -2),
+    (2.5, 2),
+    (3.7, 3),
+    (-0.0, 0),
+    (f32::NAN, 0),
+    (f32::INFINITY, i32::MAX),
+    (f32::NEG_INFINITY, i32::MIN),
+  ]
+  .iter()
+  .copied()
+  {
+    let a = f32x16::from(f);
+    let expected = i32x16::from(i);
+    let actual = a.trunc_int();
+    assert_eq!(expected, actual);
+  }
+}
 
 #[test]
 fn impl_f32x16_mul_add() {
@@ -757,542 +1083,851 @@ fn impl_f32x16_mul_neg_sub() {
   }
 }
 
-// #[test]
-// fn impl_f32x16_flip_signs() {
-//   let a = f32x16::from([1.0, 1.0, -1.0, -1.0, 5.2, 6.7, -8.2, -12.5]);
-//   let b = f32x16::from([2.0, -3.0, 4.0, -5.0, 5.2, 6.7, -8.2, -12.5]);
-//   let expected = f32x16::from([1.0, -1.0, -1.0, 1.0, 5.2, 6.7, 8.2, 12.5]);
-//   let actual = a.flip_signs(b);
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_flip_signs() {
+  let a = f32x16::from([
+    1.0, 1.0, -1.0, -1.0, 5.2, 6.7, -8.2, -12.5, 3.0, -6.4, 7.2, -24.01, 3.2,
+    1.6, -0.8, 0.4,
+  ]);
+  let b = f32x16::from([
+    2.0, -3.0, 4.0, -5.0, 5.2, 6.7, -8.2, -12.5, 3.3, -4.0, -5.5, 6.6, -6.9,
+    5.4, 3.1, -6.0,
+  ]);
+  let expected = f32x16::from([
+    1.0, -1.0, -1.0, 1.0, 5.2, 6.7, 8.2, 12.5, 3.0, 6.4, -7.2, -24.01, -3.2,
+    1.6, -0.8, -0.4,
+  ]);
+  let actual = a.flip_signs(b);
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_copysign() {
-//   let a = f32x16::from([1.0, 1.0, -1.0, -1.0, 5.2, 6.7, -8.2, -12.5]);
-//   let b = f32x16::from([2.0, -3.0, 4.0, -5.0, 5.2, 6.7, -8.2, -12.5]);
-//   let expected = f32x16::from([1.0, -1.0, 1.0, -1.0, 5.2, 6.7, -8.2, -12.5]);
-//   let actual = a.copysign(b);
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_copysign() {
+  let a = f32x16::from([
+    1.0, 1.0, -1.0, -1.0, 5.2, 6.7, -8.2, -12.5, 3.0, -6.4, 7.2, -24.01, 3.2,
+    1.6, -0.8, 0.4,
+  ]);
+  let b = f32x16::from([
+    2.0, -3.0, 4.0, -5.0, 5.2, 6.7, -8.2, -12.5, 3.3, -4.0, -5.5, 6.6, -6.9,
+    5.4, 3.1, -6.0,
+  ]);
+  let expected = f32x16::from([
+    1.0, -1.0, 1.0, -1.0, 5.2, 6.7, -8.2, -12.5, 3.0, -6.4, -7.2, 24.01, -3.2,
+    1.6, 0.8, -0.4,
+  ]);
+  let actual = a.copysign(b);
+  assert_eq!(expected, actual);
+}
 
-// // NOTE: Disabled
-// #[cfg(target_feature = "sse")]
-// #[test]
-// fn impl_f32x16_asin_acos() {
-//   let inc = 1.0 / 2501.0 / 8.0;
-//   for x in -2500..=2500 {
-//     let base = (x * 8) as f32 * inc;
-//     let origs = [
-//       base,
-//       base + inc,
-//       base + 2.0 * inc,
-//       base + 3.0 * inc,
-//       base + 4.0 * inc,
-//       base + 5.0 * inc,
-//       base + 6.0 * inc,
-//       base + 7.0 * inc,
-//     ];
-//     let (actual_asins, actual_acoses) = f32x16::from(origs).asin_acos();
-//     for i in 0..8 {
-//       let orig = origs[i];
-//       let check = |name: &str, vals: f32x16, expected: f32| {
-//         let actual_arr: [f32; 8] = cast(vals);
-//         let actual = actual_arr[i];
-//         assert!(
-//           (actual - expected).abs() < 0.0000006,
-//           "Wanted {name}({orig}) to be {expected} but got {actual}",
-//           name = name,
-//           orig = orig,
-//           expected = expected,
-//           actual = actual
-//         );
-//       };
-//       check("asin", actual_asins, orig.asin());
-//       check("acos", actual_acoses, orig.acos());
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_asin_acos() {
+  let inc = 1.0 / 2501.0 / 8.0;
+  for x in -2500..=2500 {
+    let base = (x * 8) as f32 * inc;
+    let origs = [
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+    ];
+    let (actual_asins, actual_acoses) = f32x16::from(origs).asin_acos();
+    for i in 0..8 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f32x16, expected: f32| {
+        let actual_arr: [f32; 16] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("asin", actual_asins, orig.asin());
+      check("acos", actual_acoses, orig.acos());
+    }
+  }
+}
 
-// // FIXME: remove cfg requirement once masks as their own types are
-// implemented #[cfg(target_feature = "avx")]
-// #[test]
-// fn impl_f32x16_asin() {
-//   let inc = 1.0 / 2501.0 / 8.0;
-//   for x in -2500..=2500 {
-//     let base = (x * 4) as f32 * inc;
-//     let origs = [
-//       base,
-//       base + inc,
-//       base + 2.0 * inc,
-//       base + 3.0 * inc,
-//       base + 4.0 * inc,
-//       base + 5.0 * inc,
-//       base + 6.0 * inc,
-//       base + 7.0 * inc,
-//     ];
-//     let actual_asins = f32x16::from(origs).asin();
-//     for i in 0..8 {
-//       let orig = origs[i];
-//       let check = |name: &str, vals: f32x16, expected: f32| {
-//         let actual_arr: [f32; 8] = cast(vals);
-//         let actual = actual_arr[i];
-//         assert!(
-//           (actual - expected).abs() < 0.0000006,
-//           "Wanted {name}({orig}) to be {expected} but got {actual}",
-//           name = name,
-//           orig = orig,
-//           expected = expected,
-//           actual = actual
-//         );
-//       };
-//       check("asin", actual_asins, orig.asin());
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_asin() {
+  let inc = 1.0 / 2501.0 / 8.0;
+  for x in -2500..=2500 {
+    let base = (x * 4) as f32 * inc;
+    let origs = [
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+    ];
+    let actual_asins = f32x16::from(origs).asin();
+    for i in 0..8 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f32x16, expected: f32| {
+        let actual_arr: [f32; 16] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("asin", actual_asins, orig.asin());
+    }
+  }
+}
 
-// // FIXME: remove cfg requirement once masks as their own types are
-// implemented #[cfg(target_feature = "avx")]
-// #[test]
-// fn impl_f32x16_acos() {
-//   let inc = 1.0 / 2501.0 / 8.0;
-//   for x in -2500..=2500 {
-//     let base = (x * 8) as f32 * inc;
-//     let origs = [
-//       base,
-//       base + inc,
-//       base + 2.0 * inc,
-//       base + 3.0 * inc,
-//       base + 4.0 * inc,
-//       base + 5.0 * inc,
-//       base + 6.0 * inc,
-//       base + 7.0 * inc,
-//     ];
-//     let actual_acoses = f32x16::from(origs).acos();
-//     for i in 0..8 {
-//       let orig = origs[i];
-//       let check = |name: &str, vals: f32x16, expected: f32| {
-//         let actual_arr: [f32; 8] = cast(vals);
-//         let actual = actual_arr[i];
-//         assert!(
-//           (actual - expected).abs() < 0.0000006,
-//           "Wanted {name}({orig}) to be {expected} but got {actual}",
-//           name = name,
-//           orig = orig,
-//           expected = expected,
-//           actual = actual
-//         );
-//       };
-//       check("acos", actual_acoses, orig.acos());
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_acos() {
+  let inc = 1.0 / 2501.0 / 8.0;
+  for x in -2500..=2500 {
+    let base = (x * 8) as f32 * inc;
+    let origs = [
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+    ];
+    let actual_acoses = f32x16::from(origs).acos();
+    for i in 0..8 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f32x16, expected: f32| {
+        let actual_arr: [f32; 16] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("acos", actual_acoses, orig.acos());
+    }
+  }
+}
 
-// // FIXME: remove cfg requirement once masks as their own types are
-// implemented #[cfg(target_feature = "avx")]
-// #[test]
-// fn impl_f32x16_atan() {
-//   let inc = 1.0 / 2501.0 / 8.0;
-//   for x in -2500..=2500 {
-//     let base = (x * 8) as f32 * inc;
-//     let origs = [
-//       base,
-//       base + inc,
-//       base + 2.0 * inc,
-//       base + 3.0 * inc,
-//       base + 4.0 * inc,
-//       base + 5.0 * inc,
-//       base + 6.0 * inc,
-//       base + 7.0 * inc,
-//     ];
-//     let actual_atans = f32x16::from(origs).atan();
-//     for i in 0..8 {
-//       let orig = origs[i];
-//       let check = |name: &str, vals: f32x16, expected: f32| {
-//         let actual_arr: [f32; 8] = cast(vals);
-//         let actual = actual_arr[i];
-//         assert!(
-//           (actual - expected).abs() < 0.0000006,
-//           "Wanted {name}({orig}) to be {expected} but got {actual}",
-//           name = name,
-//           orig = orig,
-//           expected = expected,
-//           actual = actual
-//         );
-//       };
-//       check("atan", actual_atans, orig.atan());
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_atan() {
+  let inc = 1.0 / 2501.0 / 8.0;
+  for x in -2500..=2500 {
+    let base = (x * 8) as f32 * inc;
+    let origs = [
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+      base,
+      base + inc,
+      base + 2.0 * inc,
+      base + 3.0 * inc,
+      base + 4.0 * inc,
+      base + 5.0 * inc,
+      base + 6.0 * inc,
+      base + 7.0 * inc,
+    ];
+    let actual_atans = f32x16::from(origs).atan();
+    for i in 0..8 {
+      let orig = origs[i];
+      let check = |name: &str, vals: f32x16, expected: f32| {
+        let actual_arr: [f32; 16] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000006,
+          "Wanted {name}({orig}) to be {expected} but got {actual}",
+          name = name,
+          orig = orig,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("atan", actual_atans, orig.atan());
+    }
+  }
+}
 
-// // FIXME: remove cfg requirement once masks as their own types are
-// implemented #[cfg(target_feature = "avx")]
-// #[test]
-// fn impl_f32x16_atan2() {
-//   let inc_y = 1.0 / 51.0 / 8.0;
-//   let inc_x = 1.0 / 2501.0 / 8.0;
-//   for y in -50..=50 {
-//     let base_y = (y * 8) as f32 * inc_y;
-//     let origs_y = [
-//       base_y,
-//       base_y + inc_y,
-//       base_y + 2.0 * inc_y,
-//       base_y + 3.0 * inc_y,
-//       base_y + 4.0 * inc_y,
-//       base_y + 5.0 * inc_y,
-//       base_y + 6.0 * inc_y,
-//       base_y + 7.0 * inc_y,
-//     ];
-//     let actual_y = f32x16::from(origs_y);
-//     for x in -2500..=2500 {
-//       let base_x = (x * 8) as f32 * inc_x;
-//       let origs_x = [
-//         base_x,
-//         base_x + inc_x,
-//         base_x + 2.0 * inc_x,
-//         base_x + 3.0 * inc_x,
-//         base_x + 4.0 * inc_x,
-//         base_x + 5.0 * inc_x,
-//         base_x + 6.0 * inc_x,
-//         base_x + 7.0 * inc_x,
-//       ];
-//       let actual_x = f32x16::from(origs_x);
-//       let actual_atan2s = actual_y.atan2(actual_x);
-//       for i in 0..8 {
-//         let orig_y = origs_y[i];
-//         let orig_x = origs_x[i];
-//         let check = |name: &str, vals: f32x16, expected: f32| {
-//           let actual_arr: [f32; 8] = cast(vals);
-//           let actual = actual_arr[i];
-//           assert!(
-//           (actual - expected).abs() < 0.0000006,
-//           "Wanted {name}({orig_y}, {orig_x}) to be {expected} but got
-// {actual}",           name = name,
-//           orig_y = orig_y,
-//           orig_x = orig_x,
-//           expected = expected,
-//           actual = actual
-//         );
-//         };
-//         check("atan2", actual_atan2s, orig_y.atan2(orig_x));
-//       }
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_atan2() {
+  let inc_y = 1.0 / 51.0 / 8.0;
+  let inc_x = 1.0 / 2501.0 / 8.0;
+  for y in -50..=50 {
+    let base_y = (y * 8) as f32 * inc_y;
+    let origs_y = [
+      base_y,
+      base_y + inc_y,
+      base_y + 2.0 * inc_y,
+      base_y + 3.0 * inc_y,
+      base_y + 4.0 * inc_y,
+      base_y + 5.0 * inc_y,
+      base_y + 6.0 * inc_y,
+      base_y + 7.0 * inc_y,
+      base_y,
+      base_y + inc_y,
+      base_y + 2.0 * inc_y,
+      base_y + 3.0 * inc_y,
+      base_y + 4.0 * inc_y,
+      base_y + 5.0 * inc_y,
+      base_y + 6.0 * inc_y,
+      base_y + 7.0 * inc_y,
+    ];
+    let actual_y = f32x16::from(origs_y);
+    for x in -2500..=2500 {
+      let base_x = (x * 8) as f32 * inc_x;
+      let origs_x = [
+        base_x,
+        base_x + inc_x,
+        base_x + 2.0 * inc_x,
+        base_x + 3.0 * inc_x,
+        base_x + 4.0 * inc_x,
+        base_x + 5.0 * inc_x,
+        base_x + 6.0 * inc_x,
+        base_x + 7.0 * inc_x,
+        base_x,
+        base_x + inc_x,
+        base_x + 2.0 * inc_x,
+        base_x + 3.0 * inc_x,
+        base_x + 4.0 * inc_x,
+        base_x + 5.0 * inc_x,
+        base_x + 6.0 * inc_x,
+        base_x + 7.0 * inc_x,
+      ];
+      let actual_x = f32x16::from(origs_x);
+      let actual_atan2s = actual_y.atan2(actual_x);
+      for i in 0..8 {
+        let orig_y = origs_y[i];
+        let orig_x = origs_x[i];
+        let check = |name: &str, vals: f32x16, expected: f32| {
+          let actual_arr: [f32; 16] = cast(vals);
+          let actual = actual_arr[i];
+          assert!(
+            (actual - expected).abs() < 0.0000006,
+            "Wanted {name}({orig_y}, {orig_x}) to be {expected} but got {actual}",
+            name = name,
+            orig_y = orig_y,
+            orig_x = orig_x,
+            expected = expected,
+            actual = actual
+          );
+        };
+        check("atan2", actual_atan2s, orig_y.atan2(orig_x));
+      }
+    }
+  }
+}
 
-// #[test]
-// fn impl_f32x16_sin_cos() {
-//   for x in -2500..=2500 {
-//     let base = (x * 4) as f32;
-//     let angles = [
-//       base,
-//       base + 1.0,
-//       base + 2.0,
-//       base + 3.0,
-//       base + 4.0,
-//       base + 5.0,
-//       base + 6.0,
-//       base + 7.0,
-//     ];
-//     let (actual_sins, actual_coses) = f32x16::from(angles).sin_cos();
-//     for i in 0..4 {
-//       let angle = angles[i];
-//       let check = |name: &str, vals: f32x16, expected: f32| {
-//         let actual_arr: [f32; 8] = cast(vals);
-//         let actual = actual_arr[i];
-//         assert!(
-//           (actual - expected).abs() < 0.0000002,
-//           "Wanted {name}({angle}) to be {expected} but got {actual}",
-//           name = name,
-//           angle = angle,
-//           expected = expected,
-//           actual = actual
-//         );
-//       };
-//       check("sin", actual_sins, angle.sin());
-//       check("cos", actual_coses, angle.cos());
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_sin_cos() {
+  for x in -2500..=2500 {
+    let base = (x * 4) as f32;
+    let angles = [
+      base,
+      base + 1.0,
+      base + 2.0,
+      base + 3.0,
+      base + 4.0,
+      base + 5.0,
+      base + 6.0,
+      base + 7.0,
+      base,
+      base + 1.0,
+      base + 2.0,
+      base + 3.0,
+      base + 4.0,
+      base + 5.0,
+      base + 6.0,
+      base + 7.0,
+    ];
+    let (actual_sins, actual_coses) = f32x16::from(angles).sin_cos();
+    for i in 0..4 {
+      let angle = angles[i];
+      let check = |name: &str, vals: f32x16, expected: f32| {
+        let actual_arr: [f32; 16] = cast(vals);
+        let actual = actual_arr[i];
+        assert!(
+          (actual - expected).abs() < 0.0000002,
+          "Wanted {name}({angle}) to be {expected} but got {actual}",
+          name = name,
+          angle = angle,
+          expected = expected,
+          actual = actual
+        );
+      };
+      check("sin", actual_sins, angle.sin());
+      check("cos", actual_coses, angle.cos());
+    }
+  }
+}
 
-// #[test]
-// fn impl_f32x16_to_degrees() {
-//   let pi = core::f32::consts::PI;
-//   let a =
-//     f32x16::from([0.0, pi / 2.0, pi, 2.0 * pi, 0.0, pi / 2.0, pi, 2.0 * pi]);
-//   let expected =
-//     f32x16::from([0.0, 90.0, 180.0, 360.0, 0.0, 90.0, 180.0, 360.0]);
-//   let actual = a.to_degrees();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_to_degrees() {
+  let pi = core::f32::consts::PI;
+  let a = f32x16::from([
+    0.0,
+    pi / 2.0,
+    pi,
+    2.0 * pi,
+    0.0,
+    pi / 2.0,
+    pi,
+    2.0 * pi,
+    pi / 2.0,
+    0.0,
+    pi,
+    2.0 * pi,
+    pi / 2.0,
+    pi / 2.0,
+    pi,
+    -pi,
+  ]);
+  let expected = f32x16::from([
+    0.0, 90.0, 180.0, 360.0, 0.0, 90.0, 180.0, 360.0, 90.0, 0.0, 180.0, 360.0,
+    90.0, 90.0, 180.0, -180.0,
+  ]);
+  let actual = a.to_degrees();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_to_radians() {
-//   let pi = core::f32::consts::PI;
-//   let a = f32x16::from([0.0, 90.0, 180.0, 360.0, 0.0, 90.0, 180.0, 360.0]);
-//   let expected =
-//     f32x16::from([0.0, pi / 2.0, pi, 2.0 * pi, 0.0, pi / 2.0, pi, 2.0 * pi]);
-//   let actual = a.to_radians();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn impl_f32x16_to_radians() {
+  let pi = core::f32::consts::PI;
+  let a = f32x16::from([
+    0.0, 90.0, 180.0, 360.0, 0.0, 90.0, 180.0, 360.0, 90.0, 0.0, 180.0, 360.0,
+    90.0, 90.0, 180.0, -180.0,
+  ]);
+  let expected = f32x16::from([
+    0.0,
+    pi / 2.0,
+    pi,
+    2.0 * pi,
+    0.0,
+    pi / 2.0,
+    pi,
+    2.0 * pi,
+    pi / 2.0,
+    0.0,
+    pi,
+    2.0 * pi,
+    pi / 2.0,
+    pi / 2.0,
+    pi,
+    -pi,
+  ]);
+  let actual = a.to_radians();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn impl_f32x16_recip() {
-//   {
-//     let expected = f32x16::from(0.0);
-//     let actual = f32x16::from(f32::INFINITY).recip();
-//     assert_eq!(expected, actual);
-//   }
-//   {
-//     let expected = f32x16::from(0.0);
-//     let actual = f32x16::from(-f32::INFINITY).recip();
-//     assert_eq!(expected, actual);
-//   }
-//   {
-//     let actual = f32x16::from(f32::NAN).recip();
-//     assert!(actual.is_nan().any());
-//   }
-//   {
-//     let expected = f32x16::from(f32::INFINITY);
-//     let actual = f32x16::from(0.0).recip();
-//     assert_eq!(expected, actual);
-//   }
-//   {
-//     let expected = f32x16::from(0.49987793);
-//     let actual = f32x16::from(2.0).recip();
-//     let diff: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff[0] < 0.001);
-//   }
-//   {
-//     let expected = f32x16::from(-0.08102417);
-//     let actual = f32x16::from(-12.34).recip();
-//     let diff: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff[0] < 0.001);
-//   }
-// }
+#[test]
+fn impl_f32x16_recip() {
+  {
+    let expected = f32x16::from(0.0);
+    let actual = f32x16::from(f32::INFINITY).recip();
+    assert_eq!(expected, actual);
+  }
+  {
+    let expected = f32x16::from(0.0);
+    let actual = f32x16::from(-f32::INFINITY).recip();
+    assert_eq!(expected, actual);
+  }
+  {
+    let actual = f32x16::from(f32::NAN).recip();
+    assert!(actual.is_nan().any());
+  }
+  {
+    let expected = f32x16::from(f32::INFINITY);
+    let actual = f32x16::from(0.0).recip();
+    assert_eq!(expected, actual);
+  }
+  {
+    let expected = f32x16::from(0.49987793);
+    let actual = f32x16::from(2.0).recip();
+    let diff: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff[0] < 0.001);
+  }
+  {
+    let expected = f32x16::from(-0.08102417);
+    let actual = f32x16::from(-12.34).recip();
+    let diff: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff[0] < 0.001);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_recip_sqrt() {
-//   {
-//     let expected = f32x16::from(0.0);
-//     let actual = f32x16::from(f32::INFINITY).recip_sqrt();
-//     assert_eq!(expected, actual);
-//   }
-//   {
-//     let actual = f32x16::from(-f32::INFINITY).recip_sqrt();
-//     assert!(actual.is_nan().any());
-//   }
-//   {
-//     let actual = f32x16::from(f32::NAN).recip_sqrt();
-//     assert!(actual.is_nan().any());
-//   }
-//   {
-//     let expected = f32x16::from(f32::INFINITY);
-//     let actual = f32x16::from(0.0).recip_sqrt();
-//     assert_eq!(expected, actual);
-//   }
-//   {
-//     let expected = f32x16::from(0.70703125);
-//     let actual = f32x16::from(2.0).recip_sqrt();
-//     let diff: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff[0] < 0.001);
-//   }
-//   {
-//     let actual = f32x16::from(-12.34).recip_sqrt();
-//     assert!(actual.is_nan().any());
-//   }
-// }
+#[test]
+fn impl_f32x16_recip_sqrt() {
+  {
+    let expected = f32x16::from(0.0);
+    let actual = f32x16::from(f32::INFINITY).recip_sqrt();
+    assert_eq!(expected, actual);
+  }
+  {
+    let actual = f32x16::from(-f32::INFINITY).recip_sqrt();
+    assert!(actual.is_nan().any());
+  }
+  {
+    let actual = f32x16::from(f32::NAN).recip_sqrt();
+    assert!(actual.is_nan().any());
+  }
+  {
+    let expected = f32x16::from(f32::INFINITY);
+    let actual = f32x16::from(0.0).recip_sqrt();
+    assert_eq!(expected, actual);
+  }
+  {
+    let expected = f32x16::from(0.70703125);
+    let actual = f32x16::from(2.0).recip_sqrt();
+    let diff: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff[0] < 0.001);
+  }
+  {
+    let actual = f32x16::from(-12.34).recip_sqrt();
+    assert!(actual.is_nan().any());
+  }
+}
 
-// #[test]
-// fn impl_f32x16_sqrt() {
-//   for (f, e) in [
-//     (f32::INFINITY, f32::INFINITY),
-//     (0.0, 0.0),
-//     (-0.0, -0.0),
-//     (4.0, 2.0),
-//     (9.0, 3.0),
-//     (16.0, 4.0),
-//     (25.0, 5.0),
-//     (5000.0 * 5000.0, 5000.0),
-//   ]
-//   .iter()
-//   .copied()
-//   {
-//     let expected = f32x16::from(e);
-//     let actual = f32x16::from(f).sqrt();
-//     assert_eq!(expected, actual);
-//   }
-//   assert_eq!(
-//     cast::<_, i32x8>(f32x16::from(f32::NAN).sqrt().is_nan()),
-//     i32x8::from(-1)
-//   );
-//   assert_eq!(
-//     cast::<_, i32x8>(f32x16::from(f32::NEG_INFINITY).sqrt().is_nan()),
-//     i32x8::from(-1)
-//   );
-//   assert_eq!(
-//     cast::<_, i32x8>(f32x16::from(-1.0).sqrt().is_nan()),
-//     i32x8::from(-1)
-//   );
-// }
+#[test]
+fn impl_f32x16_sqrt() {
+  for (f, e) in [
+    (f32::INFINITY, f32::INFINITY),
+    (0.0, 0.0),
+    (-0.0, -0.0),
+    (4.0, 2.0),
+    (9.0, 3.0),
+    (16.0, 4.0),
+    (25.0, 5.0),
+    (5000.0 * 5000.0, 5000.0),
+  ]
+  .iter()
+  .copied()
+  {
+    let expected = f32x16::from(e);
+    let actual = f32x16::from(f).sqrt();
+    assert_eq!(expected, actual);
+  }
+  assert_eq!(
+    cast::<_, i32x16>(f32x16::from(f32::NAN).sqrt().is_nan()),
+    i32x16::from(-1)
+  );
+  assert_eq!(
+    cast::<_, i32x16>(f32x16::from(f32::NEG_INFINITY).sqrt().is_nan()),
+    i32x16::from(-1)
+  );
+  assert_eq!(
+    cast::<_, i32x16>(f32x16::from(-1.0).sqrt().is_nan()),
+    i32x16::from(-1)
+  );
+}
 
-// #[test]
-// fn impl_f32x16_exp() {
-//   for f in [(-2.0), (-1.0), (0.0), (1.0), (1.5), (2.0),
-// (10.0)].iter().copied()   {
-//     let expected = f32x16::from((f as f32).exp());
-//     let actual = f32x16::from(f).exp();
-//     let diff_from_std: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff_from_std[0] < 0.000000000000001);
-//   }
-// }
+#[test]
+fn impl_f32x16_exp() {
+  for f in [(-2.0), (-1.0), (0.0), (1.0), (1.5), (2.0), (10.0)].iter().copied()
+  {
+    let expected = f32x16::from((f as f32).exp());
+    let actual = f32x16::from(f).exp();
+    let diff_from_std: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff_from_std[0] < 0.000000000000001);
+  }
+}
 
-// #[test]
-// fn test_f32x16_move_mask() {
-//   let a = f32x16::from([-1.0, 0.0, -2.0, -3.0, -1.0, 0.0, -2.0, -3.0]);
-//   let expected = 0b11011101;
-//   let actual = a.to_bitmask();
-//   assert_eq!(expected, actual);
-//   //
-//   let a = f32x16::from([1.0, 0.0, 2.0, -3.0, 1.0, 0.0, 2.0, -3.0]);
-//   let expected = 0b10001000;
-//   let actual = a.to_bitmask();
-//   assert_eq!(expected, actual);
-// }
+#[test]
+fn test_f32x16_to_bitmask() {
+  let a = f32x16::from([
+    -1.0, 0.0, -2.0, -3.0, -1.0, 0.0, -2.0, -3.0, 5.0, -6.0, 7.0, -8.0, 9.0,
+    10.0, -10.0, -1.0,
+  ]);
+  let expected = 0b1100101011011101;
+  let actual = a.to_bitmask();
+  assert_eq!(expected, actual);
+  //
+  let a = f32x16::from([
+    1.0, 0.0, 2.0, -3.0, 1.0, 0.0, 2.0, -3.0, 0.0, -0.0, 1.0, 2.0, -3.0, 3.0,
+    -2.0, -1.0,
+  ]);
+  let expected = 0b1101001010001000;
+  let actual = a.to_bitmask();
+  assert_eq!(expected, actual);
+}
 
-// #[test]
-// fn test_f32x16_any() {
-//   let a =
-//     f32x16::from([-1.0, 0.0, -2.0, -3.0, 2.0, -1.0, -2.0,
-// f32::NAN]).is_nan();   assert!(a.any());
-//   //
-//   let a = f32x16::from([1.0, 0.0, 2.0, 3.0, 2.0, 5.0, 6.7, 7.1]).is_nan();
-//   assert!(!a.any());
-// }
+#[test]
+fn test_f32x16_any() {
+  let a = f32x16::from([
+    -1.0,
+    0.0,
+    -2.0,
+    -3.0,
+    2.0,
+    -1.0,
+    -2.0,
+    f32::NAN,
+    -1.0,
+    0.0,
+    -2.0,
+    -3.0,
+    2.0,
+    -1.0,
+    -2.0,
+    -0.0,
+  ])
+  .is_nan();
+  assert!(a.any());
+  //
+  let a = f32x16::from([
+    1.0, 0.0, 2.0, 3.0, 2.0, 5.0, 6.7, 7.1, -1.0, 0.0, -2.0, -3.0, 2.0, -1.0,
+    -2.0, 0.0,
+  ])
+  .is_nan();
+  assert!(!a.any());
+}
 
-// #[test]
-// fn test_f32x16_all() {
-//   let a = f32x16::from([f32::NAN; 8]).is_nan();
-//   assert!(a.all());
-//   //
-//   let a = f32x16::from([1.0, -0.0, 2.0, 3.0, 4.0, 9.0, 7.2,
-// f32::NAN]).is_nan();   assert!(!a.all());
-// }
+#[test]
+fn test_f32x16_all() {
+  let a = f32x16::from([f32::NAN; 16]).is_nan();
+  assert!(a.all());
+  //
+  let a = f32x16::from([
+    1.0,
+    -0.0,
+    2.0,
+    3.0,
+    4.0,
+    9.0,
+    7.2,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+    f32::NAN,
+  ])
+  .is_nan();
+  assert!(!a.all());
+}
 
-// #[test]
-// fn test_f32x16_none() {
-//   let a = f32x16::from([1.0, 0.0, 2.0, 3.0, 1.0, 0.0, 2.0, 3.0]).is_nan();
-//   assert!(a.none());
-//   //
-//   let a = f32x16::from([1.0, -0.0, 2.0, 3.0, 1.0, -0.0, 2.0,
-// f32::NAN]).is_nan();   assert!(!a.none());
-// }
+#[test]
+fn test_f32x16_none() {
+  let a = f32x16::from([
+    1.0, 0.0, 2.0, 3.0, 1.0, 0.0, 2.0, 3.0, 1.0, 0.0, 2.0, 3.0, 1.0, 0.0, 2.0,
+    3.0,
+  ])
+  .is_nan();
+  assert!(a.none());
+  //
+  let a = f32x16::from([
+    1.0,
+    -0.0,
+    2.0,
+    3.0,
+    1.0,
+    -0.0,
+    2.0,
+    f32::NAN,
+    1.0,
+    0.0,
+    2.0,
+    3.0,
+    1.0,
+    0.0,
+    2.0,
+    3.0,
+  ])
+  .is_nan();
+  assert!(!a.none());
+}
 
-// #[test]
-// fn impl_f32x16_ln() {
-//   for f in [0.1, 0.5, 1.0, 2.718282, 10.0, 35.0, 1250.0].iter().copied() {
-//     let expected = f32x16::from((f as f32).ln());
-//     let actual = f32x16::from(f).ln();
-//     let diff_from_std: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff_from_std[0] < 0.0000001);
-//   }
-// }
+#[test]
+fn impl_f32x16_ln() {
+  for f in [0.1, 0.5, 1.0, 2.718282, 10.0, 35.0, 1250.0].iter().copied() {
+    let expected = f32x16::from((f as f32).ln());
+    let actual = f32x16::from(f).ln();
+    let diff_from_std: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff_from_std[0] < 0.0000001);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_pow() {
-//   for f in [0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0].iter().copied() {
-//     let expected = f32x16::splat(2.0 as f32).powf(f);
-//     let actual = f32x16::from(2.0_f32.powf(f));
-//     let diff_from_std: [f32; 8] = cast((actual - expected).abs());
-//     assert!(diff_from_std[0] < 0.000001);
-//   }
-// }
+#[test]
+fn impl_f32x16_log2() {
+  for f in [0.1, 0.5, 1.0, 2.718282, 10.0, 35.0, 1250.0].iter().copied() {
+    let expected = f32x16::from((f as f32).log2());
+    let actual = f32x16::from(f).log2();
+    let diff_from_std: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff_from_std[0] < 0.000001);
+  }
+}
 
-// #[test]
-// fn impl_f32x16_pow_n() {
-//   let p = f32x16::from([29.0, 0.1, 0.5, 1.0, 2.718282, -0.2, -1.5, 3.4]);
-//   let f = f32x16::from([1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, -4.5]);
-//   let res = f.pow_f32x16(p);
+#[test]
+fn impl_f32x16_log10() {
+  for f in [0.1, 0.5, 1.0, 2.718282, 10.0, 35.0, 1250.0].iter().copied() {
+    let expected = f32x16::from((f as f32).log10());
+    let actual = f32x16::from(f).log10();
+    let diff_from_std: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff_from_std[0] < 0.000001);
+  }
+}
 
-//   let p: [f32; 8] = cast(p);
-//   let f: [f32; 8] = cast(f);
-//   let res: [f32; 8] = cast(res);
-//   for i in 0..p.len() {
-//     let expected = f[i].powf(p[i]);
-//     if !(expected.is_nan() && res[i].is_nan()) {
-//       assert!((expected - res[i]).abs() < 0.0001);
-//     }
-//   }
-// }
+#[test]
+fn impl_f32x16_pow_f32x16() {
+  let p = f32x16::from([
+    29.0, 0.1, 0.5, 1.0, 2.718282, -0.2, -1.5, 3.4, 29.0, 0.1, 0.5, 1.0,
+    2.718282, -0.2, -1.5, 3.4,
+  ]);
+  let f = f32x16::from([
+    1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, -4.5, 1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5,
+    -4.5,
+  ]);
+  let res = f.pow_f32x16(p);
 
-// #[test]
-// fn impl_f32x16_reduce_add() {
-//   let p = f32x16::from([0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007,
-// 0.009]);   assert!((p.reduce_add() - 0.037) < 0.000000001);
-// }
+  let p: [f32; 16] = cast(p);
+  let f: [f32; 16] = cast(f);
+  let res: [f32; 16] = cast(res);
+  for i in 0..p.len() {
+    let expected = f[i].powf(p[i]);
+    if !(expected.is_nan() && res[i].is_nan()) {
+      assert!((expected - res[i]).abs() < 0.0001);
+    }
+  }
+}
 
-// #[test]
-// fn impl_f32x16_sum() {
-//   let mut p = Vec::with_capacity(250_000);
-//   for _ in 0..125_000 {
-//     p.push(f32x16::splat(0.001));
-//   }
-//   let now = std::time::Instant::now();
-//   let sum: f32 = p.iter().map(|x| x.reduce_add()).sum();
-//   let duration = now.elapsed().as_micros();
-//   println!("Time take {} {}us", sum, duration);
+#[test]
+fn impl_f32x16_powf() {
+  for f in [0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0].iter().copied() {
+    let expected = f32x16::splat(2.0 as f32).powf(f);
+    let actual = f32x16::from(2.0_f32.powf(f));
+    let diff_from_std: [f32; 16] = cast((actual - expected).abs());
+    assert!(diff_from_std[0] < 0.000001);
+  }
+}
 
-//   let p = vec![0.001; 1_000_000];
-//   let now = std::time::Instant::now();
-//   let sum2: f32 = p.iter().sum();
-//   let duration = now.elapsed().as_micros();
-//   println!("Time take {} {}us", sum2, duration);
-// }
+#[test]
+fn impl_f32x16_reduce_add() {
+  let p = f32x16::from([
+    0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.009, 0.008, -0.01,
+    0.005, -0.001, 0.006, 0.004, -0.009, 0.007,
+  ]);
+  assert!((p.reduce_add() - 0.056) < 0.000000001);
+}
 
-// #[test]
-// fn impl_transpose_for_f32x16() {
-//   let a = [
-//     f32x16::new([0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1]),
-//     f32x16::new([8.1, 9.1, 10.1, 11.1, 12.1, 13.1, 14.1, 15.1]),
-//     f32x16::new([16.1, 17.1, 18.1, 19.1, 20.1, 21.1, 22.1, 23.1]),
-//     f32x16::new([24.1, 25.1, 26.1, 27.1, 28.1, 29.1, 30.1, 31.1]),
-//     f32x16::new([32.1, 33.1, 34.1, 35.1, 36.1, 37.1, 38.1, 39.1]),
-//     f32x16::new([40.1, 41.1, 42.1, 43.1, 44.1, 45.1, 46.1, 47.1]),
-//     f32x16::new([48.1, 49.1, 50.1, 51.1, 52.1, 53.1, 54.1, 55.1]),
-//     f32x16::new([
-//       5600000.1, 5700000.1, 5800000.1, 5900000.1, 6000000.1, 6100000.1,
-//       6200000.1, 6300000.1,
-//     ]),
-//   ];
+#[test]
+fn impl_f32x16_sum() {
+  let mut p = Vec::with_capacity(250_000);
+  for _ in 0..125_000 {
+    p.push(f32x16::splat(0.001));
+  }
+  let now = std::time::Instant::now();
+  let sum: f32 = p.iter().map(|x| x.reduce_add()).sum();
+  let duration = now.elapsed().as_micros();
+  println!("Time take {} {}us", sum, duration);
 
-//   let result = f32x16::transpose(a);
+  let p = vec![0.001; 1_000_000];
+  let now = std::time::Instant::now();
+  let sum2: f32 = p.iter().sum();
+  let duration = now.elapsed().as_micros();
+  println!("Time take {} {}us", sum2, duration);
+}
 
-//   let expected = [
-//     f32x16::new([0.1, 8.1, 16.1, 24.1, 32.1, 40.1, 48.1, 5600000.1]),
-//     f32x16::new([1.1, 9.1, 17.1, 25.1, 33.1, 41.1, 49.1, 5700000.1]),
-//     f32x16::new([2.1, 10.1, 18.1, 26.1, 34.1, 42.1, 50.1, 5800000.1]),
-//     f32x16::new([3.1, 11.1, 19.1, 27.1, 35.1, 43.1, 51.1, 5900000.1]),
-//     f32x16::new([4.1, 12.1, 20.1, 28.1, 36.1, 44.1, 52.1, 6000000.1]),
-//     f32x16::new([5.1, 13.1, 21.1, 29.1, 37.1, 45.1, 53.1, 6100000.1]),
-//     f32x16::new([6.1, 14.1, 22.1, 30.1, 38.1, 46.1, 54.1, 6200000.1]),
-//     f32x16::new([7.1, 15.1, 23.1, 31.1, 39.1, 47.1, 55.1, 6300000.1]),
-//   ];
+#[test]
+fn impl_transpose_for_f32x16() {
+  let a = [
+    f32x16::new([
+      1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09, 1.10, 1.11, 1.12,
+      1.13, 1.14, 1.15, 1.16,
+    ]),
+    f32x16::new([
+      2.01, 2.02, 2.03, 2.04, 2.05, 2.06, 2.07, 2.08, 2.09, 2.10, 2.11, 2.12,
+      2.13, 2.14, 2.15, 2.16,
+    ]),
+    f32x16::new([
+      3.01, 3.02, 3.03, 3.04, 3.05, 3.06, 3.07, 3.08, 3.09, 3.10, 3.11, 3.12,
+      3.13, 3.14, 3.15, 3.16,
+    ]),
+    f32x16::new([
+      4.01, 4.02, 4.03, 4.04, 4.05, 4.06, 4.07, 4.08, 4.09, 4.10, 4.11, 4.12,
+      4.13, 4.14, 4.15, 4.16,
+    ]),
+    f32x16::new([
+      5.01, 5.02, 5.03, 5.04, 5.05, 5.06, 5.07, 5.08, 5.09, 5.10, 5.11, 5.12,
+      5.13, 5.14, 5.15, 5.16,
+    ]),
+    f32x16::new([
+      6.01, 6.02, 6.03, 6.04, 6.05, 6.06, 6.07, 6.08, 6.09, 6.10, 6.11, 6.12,
+      6.13, 6.14, 6.15, 6.16,
+    ]),
+    f32x16::new([
+      7.01, 7.02, 7.03, 7.04, 7.05, 7.06, 7.07, 7.08, 7.09, 7.10, 7.11, 7.12,
+      7.13, 7.14, 7.15, 7.16,
+    ]),
+    f32x16::new([
+      8.01, 8.02, 8.03, 8.04, 8.05, 8.06, 8.07, 8.08, 8.09, 8.10, 8.11, 8.12,
+      8.13, 8.14, 8.15, 8.16,
+    ]),
+    f32x16::new([
+      9.01, 9.02, 9.03, 9.04, 9.05, 9.06, 9.07, 9.08, 9.09, 9.10, 9.11, 9.12,
+      9.13, 9.14, 9.15, 9.16,
+    ]),
+    f32x16::new([
+      10.01, 10.02, 10.03, 10.04, 10.05, 10.06, 10.07, 10.08, 10.09, 10.10,
+      10.11, 10.12, 10.13, 10.14, 10.15, 10.16,
+    ]),
+    f32x16::new([
+      11.01, 11.02, 11.03, 11.04, 11.05, 11.06, 11.07, 11.08, 11.09, 11.10,
+      11.11, 11.12, 11.13, 11.14, 11.15, 11.16,
+    ]),
+    f32x16::new([
+      12.01, 12.02, 12.03, 12.04, 12.05, 12.06, 12.07, 12.08, 12.09, 12.10,
+      12.11, 12.12, 12.13, 12.14, 12.15, 12.16,
+    ]),
+    f32x16::new([
+      13.01, 13.02, 13.03, 13.04, 13.05, 13.06, 13.07, 13.08, 13.09, 13.10,
+      13.11, 13.12, 13.13, 13.14, 13.15, 13.16,
+    ]),
+    f32x16::new([
+      14.01, 14.02, 14.03, 14.04, 14.05, 14.06, 14.07, 14.08, 14.09, 14.10,
+      14.11, 14.12, 14.13, 14.14, 14.15, 14.16,
+    ]),
+    f32x16::new([
+      15.01, 15.02, 15.03, 15.04, 15.05, 15.06, 15.07, 15.08, 15.09, 15.10,
+      15.11, 15.12, 15.13, 15.14, 15.15, 15.16,
+    ]),
+    f32x16::new([
+      16.01, 16.02, 16.03, 16.04, 16.05, 16.06, 16.07, 16.08, 16.09, 16.10,
+      16.11, 16.12, 16.13, 16.14, 16.15, 16.16,
+    ]),
+  ];
 
-//   assert_eq!(result, expected);
-// }
+  let result = f32x16::transpose(a);
 
-// #[test]
-// fn impl_f32x16_from_i32x8() {
-//   let i = i32x8::from([1, 2, 3, 4, 5, 6, 7, 8]);
-//   let f = f32x16::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
-//   assert_eq!(f32x16::from_i32x8(i), f)
-// }
+  let expected = [
+    f32x16::new([
+      1.01, 2.01, 3.01, 4.01, 5.01, 6.01, 7.01, 8.01, 9.01, 10.01, 11.01,
+      12.01, 13.01, 14.01, 15.01, 16.01,
+    ]),
+    f32x16::new([
+      1.02, 2.02, 3.02, 4.02, 5.02, 6.02, 7.02, 8.02, 9.02, 10.02, 11.02,
+      12.02, 13.02, 14.02, 15.02, 16.02,
+    ]),
+    f32x16::new([
+      1.03, 2.03, 3.03, 4.03, 5.03, 6.03, 7.03, 8.03, 9.03, 10.03, 11.03,
+      12.03, 13.03, 14.03, 15.03, 16.03,
+    ]),
+    f32x16::new([
+      1.04, 2.04, 3.04, 4.04, 5.04, 6.04, 7.04, 8.04, 9.04, 10.04, 11.04,
+      12.04, 13.04, 14.04, 15.04, 16.04,
+    ]),
+    f32x16::new([
+      1.05, 2.05, 3.05, 4.05, 5.05, 6.05, 7.05, 8.05, 9.05, 10.05, 11.05,
+      12.05, 13.05, 14.05, 15.05, 16.05,
+    ]),
+    f32x16::new([
+      1.06, 2.06, 3.06, 4.06, 5.06, 6.06, 7.06, 8.06, 9.06, 10.06, 11.06,
+      12.06, 13.06, 14.06, 15.06, 16.06,
+    ]),
+    f32x16::new([
+      1.07, 2.07, 3.07, 4.07, 5.07, 6.07, 7.07, 8.07, 9.07, 10.07, 11.07,
+      12.07, 13.07, 14.07, 15.07, 16.07,
+    ]),
+    f32x16::new([
+      1.08, 2.08, 3.08, 4.08, 5.08, 6.08, 7.08, 8.08, 9.08, 10.08, 11.08,
+      12.08, 13.08, 14.08, 15.08, 16.08,
+    ]),
+    f32x16::new([
+      1.09, 2.09, 3.09, 4.09, 5.09, 6.09, 7.09, 8.09, 9.09, 10.09, 11.09,
+      12.09, 13.09, 14.09, 15.09, 16.09,
+    ]),
+    f32x16::new([
+      1.10, 2.10, 3.10, 4.10, 5.10, 6.10, 7.10, 8.10, 9.10, 10.10, 11.10,
+      12.10, 13.10, 14.10, 15.10, 16.10,
+    ]),
+    f32x16::new([
+      1.11, 2.11, 3.11, 4.11, 5.11, 6.11, 7.11, 8.11, 9.11, 10.11, 11.11,
+      12.11, 13.11, 14.11, 15.11, 16.11,
+    ]),
+    f32x16::new([
+      1.12, 2.12, 3.12, 4.12, 5.12, 6.12, 7.12, 8.12, 9.12, 10.12, 11.12,
+      12.12, 13.12, 14.12, 15.12, 16.12,
+    ]),
+    f32x16::new([
+      1.13, 2.13, 3.13, 4.13, 5.13, 6.13, 7.13, 8.13, 9.13, 10.13, 11.13,
+      12.13, 13.13, 14.13, 15.13, 16.13,
+    ]),
+    f32x16::new([
+      1.14, 2.14, 3.14, 4.14, 5.14, 6.14, 7.14, 8.14, 9.14, 10.14, 11.14,
+      12.14, 13.14, 14.14, 15.14, 16.14,
+    ]),
+    f32x16::new([
+      1.15, 2.15, 3.15, 4.15, 5.15, 6.15, 7.15, 8.15, 9.15, 10.15, 11.15,
+      12.15, 13.15, 14.15, 15.15, 16.15,
+    ]),
+    f32x16::new([
+      1.16, 2.16, 3.16, 4.16, 5.16, 6.16, 7.16, 8.16, 9.16, 10.16, 11.16,
+      12.16, 13.16, 14.16, 15.16, 16.16,
+    ]),
+  ];
 
-// #[cfg(feature = "serde")]
-// #[test]
-// fn impl_f32x16_ser_de_roundtrip() {
-//   let serialized =
-//     bincode::serialize(&f32x16::ZERO).expect("serialization failed");
-//   let deserialized =
-//     bincode::deserialize(&serialized).expect("deserializaion failed");
-//   assert_eq!(f32x16::ZERO, deserialized);
-// }
+  assert_eq!(result, expected);
+}
+
+#[test]
+fn impl_f32x16_from_i32x16() {
+  let i = i32x16::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  let f = f32x16::from([
+    1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
+    15.0, 16.0,
+  ]);
+  assert_eq!(f32x16::from_i32x16(i), f);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn impl_f32x16_ser_de_roundtrip() {
+  let serialized =
+    bincode::serialize(&f32x16::ZERO).expect("serialization failed");
+  let deserialized =
+    bincode::deserialize(&serialized).expect("deserializaion failed");
+  assert_eq!(f32x16::ZERO, deserialized);
+}


### PR DESCRIPTION
Notes:

My CPU does not support `avx512f` so i did not run tests with the feature enabled. Tests should probably be ran before merging.

Three functions are missing optimizations that require missing `safe_arch` intrinsics (see commit log).

While adding the missing functionality i found two `f32x16` bugs that i fixed, though this does mean behaviour is changed and a minor SemVer update may be needed:

The mask used in `is_finite` was incorrect and was causing infinite values to be seen as finite.

`round_int`, unlike its counterparts from other wide float types, did not handle NaNs or other edge cases (that is the job of `fast_round_int`).