### PR TITLE
Rename float function `sign_bit` to `is_sign_negative` and add `is_sign_positive`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # `wide` Changelog
 
+## Unreleased
+
+* Renamed float function `sign_bit` to `is_sign_negative` and added
+  `is_sign_positive`.
+
 ## 1.3.0
 
 * Fixes the behaviour of `f32x16` functions `is_finite` and `round_int`. They

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -1273,9 +1273,12 @@ impl f32x16 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i32x16>(self);
-    let t2 = t1 >> 31;
-    cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
+    const SIGN_MASK: u32x16 = u32x16::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x16, u32x16>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(u32x16::ZERO);
+    cast::<u32x16, f32x16>(result)
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1283,9 +1286,12 @@ impl f32x16 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i32x16>(self);
-    let t2 = t1 >> 31;
-    !cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
+    const SIGN_MASK: u32x16 = u32x16::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x16, u32x16>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(SIGN_MASK);
+    cast::<u32x16, f32x16>(result)
   }
 
   /// horizontal add of all the elements of the vector

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -946,7 +946,7 @@ impl f32x16 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -999,10 +999,10 @@ impl f32x16 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1269,7 +1269,16 @@ impl f32x16 {
   }
 
   #[inline]
-  pub fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i32x16>(self);
+    let t2 = t1 >> 31;
+    cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i32x16>(self);
     let t2 = t1 >> 31;
     !cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
@@ -1427,7 +1436,7 @@ impl f32x16 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
@@ -1537,6 +1546,13 @@ impl f32x16 {
         }
       }
     }
+  }
+
+  #[inline]
+  #[must_use]
+  #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]
+  pub fn sign_bit(self) -> Self {
+    self.is_sign_negative()
   }
 }
 

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -1268,6 +1268,8 @@ impl f32x16 {
     cast::<_, f32x16>(i32x16::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1276,6 +1278,8 @@ impl f32x16 {
     cast::<_, f32x16>(t2).simd_eq(f32x16::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
@@ -1548,6 +1552,12 @@ impl f32x16 {
     }
   }
 
+  /// Returns true for each element if its sign bit is set.
+  ///
+  /// If the sign bit is set, the result has all bits set, not just the sign
+  /// bit. This has been renamed to [`is_sign_negative`].
+  ///
+  /// [`is_sign_negative`]: Self::is_sign_negative
   #[inline]
   #[must_use]
   #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1530,6 +1530,8 @@ impl f32x4 {
     cast::<_, f32x4>(i32x4::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1538,6 +1540,8 @@ impl f32x4 {
     cast::<_, f32x4>(t2).simd_eq(f32x4::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
@@ -1856,6 +1860,12 @@ impl f32x4 {
     }
   }
 
+  /// Returns true for each element if its sign bit is set.
+  ///
+  /// If the sign bit is set, the result has all bits set, not just the sign
+  /// bit. This has been renamed to [`is_sign_negative`].
+  ///
+  /// [`is_sign_negative`]: Self::is_sign_negative
   #[inline]
   #[must_use]
   #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1177,7 +1177,7 @@ impl f32x4 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1230,10 +1230,10 @@ impl f32x4 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1529,8 +1529,18 @@ impl f32x4 {
   fn nan_pow() -> Self {
     cast::<_, f32x4>(i32x4::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
   }
+
   #[inline]
-  pub fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i32x4>(self);
+    let t2 = t1 >> 31;
+    cast::<_, f32x4>(t2).simd_eq(f32x4::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i32x4>(self);
     let t2 = t1 >> 31;
     !cast::<_, f32x4>(t2).simd_eq(f32x4::ZERO)
@@ -1689,7 +1699,7 @@ impl f32x4 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
@@ -1844,5 +1854,12 @@ impl f32x4 {
           ] }
       }
     }
+  }
+
+  #[inline]
+  #[must_use]
+  #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]
+  pub fn sign_bit(self) -> Self {
+    self.is_sign_negative()
   }
 }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -1535,9 +1535,12 @@ impl f32x4 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i32x4>(self);
-    let t2 = t1 >> 31;
-    cast::<_, f32x4>(t2).simd_eq(f32x4::ZERO)
+    const SIGN_MASK: u32x4 = u32x4::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x4, u32x4>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(u32x4::ZERO);
+    cast::<u32x4, f32x4>(result)
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1545,9 +1548,12 @@ impl f32x4 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i32x4>(self);
-    let t2 = t1 >> 31;
-    !cast::<_, f32x4>(t2).simd_eq(f32x4::ZERO)
+    const SIGN_MASK: u32x4 = u32x4::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x4, u32x4>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(SIGN_MASK);
+    cast::<u32x4, f32x4>(result)
   }
 
   /// horizontal add of all the elements of the vector

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1246,6 +1246,8 @@ impl f32x8 {
     cast::<_, f32x8>(i32x8::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1254,6 +1256,8 @@ impl f32x8 {
     cast::<_, f32x8>(t2).simd_eq(f32x8::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
@@ -1562,6 +1566,12 @@ impl f32x8 {
     }
   }
 
+  /// Returns true for each element if its sign bit is set.
+  ///
+  /// If the sign bit is set, the result has all bits set, not just the sign
+  /// bit. This has been renamed to [`is_sign_negative`].
+  ///
+  /// [`is_sign_negative`]: Self::is_sign_negative
   #[inline]
   #[must_use]
   #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -946,7 +946,7 @@ impl f32x8 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -999,10 +999,10 @@ impl f32x8 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1245,8 +1245,18 @@ impl f32x8 {
   fn nan_pow() -> Self {
     cast::<_, f32x8>(i32x8::splat(0x7FC00000 | 0x101 & 0x003FFFFF))
   }
+
   #[inline]
-  pub fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i32x8>(self);
+    let t2 = t1 >> 31;
+    cast::<_, f32x8>(t2).simd_eq(f32x8::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i32x8>(self);
     let t2 = t1 >> 31;
     !cast::<_, f32x8>(t2).simd_eq(f32x8::ZERO)
@@ -1413,7 +1423,7 @@ impl f32x8 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
@@ -1550,6 +1560,13 @@ impl f32x8 {
           ])
       }
     }
+  }
+
+  #[inline]
+  #[must_use]
+  #[deprecated(since = "1.4.0", note = "renamed to `is_sign_negative`")]
+  pub fn sign_bit(self) -> Self {
+    self.is_sign_negative()
   }
 }
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1251,9 +1251,12 @@ impl f32x8 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i32x8>(self);
-    let t2 = t1 >> 31;
-    cast::<_, f32x8>(t2).simd_eq(f32x8::ZERO)
+    const SIGN_MASK: u32x8 = u32x8::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x8, u32x8>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(u32x8::ZERO);
+    cast::<u32x8, f32x8>(result)
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1261,9 +1264,12 @@ impl f32x8 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i32x8>(self);
-    let t2 = t1 >> 31;
-    !cast::<_, f32x8>(t2).simd_eq(f32x8::ZERO)
+    const SIGN_MASK: u32x8 = u32x8::splat((-0.0_f32).to_bits());
+
+    let bits = cast::<f32x8, u32x8>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(SIGN_MASK);
+    cast::<u32x8, f32x8>(result)
   }
 
   /// horizontal add of all the elements of the vector

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1529,6 +1529,8 @@ impl f64x2 {
     cast::<_, f64x2>(i64x2::splat(0x7FF8000000000000 | 0x101 << 29))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1537,6 +1539,8 @@ impl f64x2 {
     cast::<_, f64x2>(t2).simd_eq(f64x2::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1197,7 +1197,7 @@ impl f64x2 {
     re += s + fac;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1274,10 +1274,10 @@ impl f64x2 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1530,7 +1530,16 @@ impl f64x2 {
   }
 
   #[inline]
-  fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i64x2>(self);
+    let t2 = t1 >> 63;
+    cast::<_, f64x2>(t2).simd_eq(f64x2::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i64x2>(self);
     let t2 = t1 >> 63;
     !cast::<_, f64x2>(t2).simd_eq(f64x2::ZERO)
@@ -1709,7 +1718,7 @@ impl f64x2 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -1534,9 +1534,22 @@ impl f64x2 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i64x2>(self);
-    let t2 = t1 >> 63;
-    cast::<_, f64x2>(t2).simd_eq(f64x2::ZERO)
+    pick! {
+      // Integer equality is slow without `sse4.1`.
+      if #[cfg(any(target_feature = "sse4.1", not(target_feature = "sse2")))] {
+        const SIGN_MASK: u64x2 = u64x2::splat((-0.0_f64).to_bits());
+
+        let bits = cast::<f64x2, u64x2>(self);
+        let sign = bits & SIGN_MASK;
+        let result = sign.simd_eq(u64x2::ZERO);
+        cast::<u64x2, f64x2>(result)
+      } else {
+        let bits = cast::<f64x2, u64x2>(self);
+        let sign = bits >> 63;
+        let sign = cast::<u64x2, f64x2>(sign);
+        sign.simd_eq(f64x2::ZERO)
+      }
+    }
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1544,9 +1557,22 @@ impl f64x2 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i64x2>(self);
-    let t2 = t1 >> 63;
-    !cast::<_, f64x2>(t2).simd_eq(f64x2::ZERO)
+    pick! {
+      // Integer equality is slow without `sse4.1`.
+      if #[cfg(any(target_feature = "sse4.1", not(target_feature = "sse2")))] {
+        const SIGN_MASK: u64x2 = u64x2::splat((-0.0_f64).to_bits());
+
+        let bits = cast::<f64x2, u64x2>(self);
+        let sign = bits & SIGN_MASK;
+        let result = sign.simd_eq(SIGN_MASK);
+        cast::<u64x2, f64x2>(result)
+      } else {
+        let bits = cast::<f64x2, u64x2>(self);
+        let sign = bits >> 63;
+        let sign = cast::<u64x2, f64x2>(sign);
+        sign.simd_ne(f64x2::ZERO)
+      }
+    }
   }
 
   /// horizontal add of all the elements of the vector

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1364,6 +1364,8 @@ impl f64x4 {
     cast::<_, f64x4>(i64x4::splat(0x7FF8000000000000 | 0x101 << 29))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1372,6 +1374,8 @@ impl f64x4 {
     cast::<_, f64x4>(t2).simd_eq(f64x4::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1056,7 +1056,7 @@ impl f64x4 {
     re += s + fac;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1133,10 +1133,10 @@ impl f64x4 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1363,8 +1363,18 @@ impl f64x4 {
   fn nan_pow() -> Self {
     cast::<_, f64x4>(i64x4::splat(0x7FF8000000000000 | 0x101 << 29))
   }
+
   #[inline]
-  fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i64x4>(self);
+    let t2 = t1 >> 63;
+    cast::<_, f64x4>(t2).simd_eq(f64x4::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i64x4>(self);
     let t2 = t1 >> 63;
     !cast::<_, f64x4>(t2).simd_eq(f64x4::ZERO)
@@ -1544,7 +1554,7 @@ impl f64x4 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
 
     let z = if x_sign.any() {
       // Y into an integer

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -1369,9 +1369,12 @@ impl f64x4 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i64x4>(self);
-    let t2 = t1 >> 63;
-    cast::<_, f64x4>(t2).simd_eq(f64x4::ZERO)
+    const SIGN_MASK: u64x4 = u64x4::splat((-0.0_f64).to_bits());
+
+    let bits = cast::<f64x4, u64x4>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(u64x4::ZERO);
+    cast::<u64x4, f64x4>(result)
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1379,9 +1382,12 @@ impl f64x4 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i64x4>(self);
-    let t2 = t1 >> 63;
-    !cast::<_, f64x4>(t2).simd_eq(f64x4::ZERO)
+    const SIGN_MASK: u64x4 = u64x4::splat((-0.0_f64).to_bits());
+
+    let bits = cast::<f64x4, u64x4>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(SIGN_MASK);
+    cast::<u64x4, f64x4>(result)
   }
 
   /// horizontal add of all the elements of the vector

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -1038,7 +1038,7 @@ impl f64x8 {
     re += s + fac;
 
     // get sign bit
-    re = (self.sign_bit()).blend(-re, re);
+    re = (self.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1115,10 +1115,10 @@ impl f64x8 {
     // move back in place
     re = swapxy.blend(Self::FRAC_PI_2 - re, re);
     re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.sign_bit()).blend(Self::PI - re, re);
+    re = (x.is_sign_negative()).blend(Self::PI - re, re);
 
     // get sign bit
-    re = (y.sign_bit()).blend(-re, re);
+    re = (y.is_sign_negative()).blend(-re, re);
 
     re
   }
@@ -1346,8 +1346,18 @@ impl f64x8 {
   fn nan_pow() -> Self {
     cast::<_, f64x8>(i64x8::splat(0x7FF8000000000000 | 0x101 << 29))
   }
+
   #[inline]
-  fn sign_bit(self) -> Self {
+  #[must_use]
+  pub fn is_sign_positive(self) -> Self {
+    let t1 = cast::<_, i64x8>(self);
+    let t2 = t1 >> 63;
+    cast::<_, f64x8>(t2).simd_eq(f64x8::ZERO)
+  }
+
+  #[inline]
+  #[must_use]
+  pub fn is_sign_negative(self) -> Self {
     let t1 = cast::<_, i64x8>(self);
     let t2 = t1 >> 63;
     !cast::<_, f64x8>(t2).simd_eq(f64x8::ZERO)
@@ -1528,7 +1538,7 @@ impl f64x8 {
       z,
     );
 
-    let x_sign = self.sign_bit();
+    let x_sign = self.is_sign_negative();
 
     let z = if x_sign.any() {
       // Y into an integer

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -1347,6 +1347,8 @@ impl f64x8 {
     cast::<_, f64x8>(i64x8::splat(0x7FF8000000000000 | 0x101 << 29))
   }
 
+  /// Returns true for each element if it has a positive sign, including `+0.0`,
+  /// `NaN`s with positive sign bit and positive infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
@@ -1355,6 +1357,8 @@ impl f64x8 {
     cast::<_, f64x8>(t2).simd_eq(f64x8::ZERO)
   }
 
+  /// Returns true for each element if it has a negative sign, including `-0.0`,
+  /// `NaN`s with negative sign bit and negative infinity.
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -1352,9 +1352,12 @@ impl f64x8 {
   #[inline]
   #[must_use]
   pub fn is_sign_positive(self) -> Self {
-    let t1 = cast::<_, i64x8>(self);
-    let t2 = t1 >> 63;
-    cast::<_, f64x8>(t2).simd_eq(f64x8::ZERO)
+    const SIGN_MASK: u64x8 = u64x8::splat((-0.0_f64).to_bits());
+
+    let bits = cast::<f64x8, u64x8>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(u64x8::ZERO);
+    cast::<u64x8, f64x8>(result)
   }
 
   /// Returns true for each element if it has a negative sign, including `-0.0`,
@@ -1362,9 +1365,12 @@ impl f64x8 {
   #[inline]
   #[must_use]
   pub fn is_sign_negative(self) -> Self {
-    let t1 = cast::<_, i64x8>(self);
-    let t2 = t1 >> 63;
-    !cast::<_, f64x8>(t2).simd_eq(f64x8::ZERO)
+    const SIGN_MASK: u64x8 = u64x8::splat((-0.0_f64).to_bits());
+
+    let bits = cast::<f64x8, u64x8>(self);
+    let sign = bits & SIGN_MASK;
+    let result = sign.simd_eq(SIGN_MASK);
+    cast::<u64x8, f64x8>(result)
   }
 
   #[inline]

--- a/tests/all_tests/t_f32x16.rs
+++ b/tests/all_tests/t_f32x16.rs
@@ -1745,6 +1745,92 @@ fn impl_f32x16_powf() {
 }
 
 #[test]
+fn impl_f32x16_is_sign_positive() {
+  let a = f32x16::new([
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+  ]);
+  let expected = f32x16::new([
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+  ]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x16::ZERO);
+}
+
+#[test]
+fn impl_f32x16_is_sign_negative() {
+  let a = f32x16::new([
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+  ]);
+  let expected = f32x16::new([
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+  ]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x16::ZERO);
+}
+
+#[test]
 fn impl_f32x16_reduce_add() {
   let p = f32x16::from([
     0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.009, 0.008, -0.01,

--- a/tests/all_tests/t_f32x4.rs
+++ b/tests/all_tests/t_f32x4.rs
@@ -832,6 +832,24 @@ fn impl_f32x4_pow_n() {
 }
 
 #[test]
+fn impl_f32x4_is_sign_positive() {
+  let a = f32x4::new([2401.0, -123.0, f32::INFINITY, f32::NEG_INFINITY]);
+  let expected = f32x4::new([f32::from_bits(!0), 0.0, f32::from_bits(!0), 0.0]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x4::ZERO);
+}
+
+#[test]
+fn impl_f32x4_is_sign_negative() {
+  let a = f32x4::new([2401.0, -123.0, f32::INFINITY, f32::NEG_INFINITY]);
+  let expected = f32x4::new([0.0, f32::from_bits(!0), 0.0, f32::from_bits(!0)]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x4::ZERO);
+}
+
+#[test]
 fn impl_f32x4_reduce_add() {
   let p = f32x4::splat(0.001);
   assert_eq!(p.reduce_add(), 0.004);

--- a/tests/all_tests/t_f32x8.rs
+++ b/tests/all_tests/t_f32x8.rs
@@ -915,6 +915,60 @@ fn impl_f32x8_pow_n() {
 }
 
 #[test]
+fn impl_f32x8_is_sign_positive() {
+  let a = f32x8::new([
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+  ]);
+  let expected = f32x8::new([
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+  ]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x8::ZERO);
+}
+
+#[test]
+fn impl_f32x8_is_sign_negative() {
+  let a = f32x8::new([
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f32::INFINITY,
+    f32::NEG_INFINITY,
+  ]);
+  let expected = f32x8::new([
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+    0.0,
+    f32::from_bits(!0),
+  ]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f32x8::ZERO);
+}
+
+#[test]
 fn impl_f32x8_reduce_add() {
   let p = f32x8::from([0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.009]);
   assert!((p.reduce_add() - 0.037) < 0.000000001);

--- a/tests/all_tests/t_f64x2.rs
+++ b/tests/all_tests/t_f64x2.rs
@@ -839,6 +839,24 @@ fn impl_f64x2_pow_multiple() {
 }
 
 #[test]
+fn impl_f64x2_is_sign_positive() {
+  let a = f64x2::new([2401.0, -123.0]);
+  let expected = f64x2::new([f64::from_bits(!0), 0.0]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x2::ZERO);
+}
+
+#[test]
+fn impl_f64x2_is_sign_negative() {
+  let a = f64x2::new([2401.0, -123.0]);
+  let expected = f64x2::new([0.0, f64::from_bits(!0)]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x2::ZERO);
+}
+
+#[test]
 fn impl_f64x2_reduce_add() {
   let p = f64x2::splat(0.001);
   assert_eq!(p.reduce_add(), 0.002);

--- a/tests/all_tests/t_f64x4.rs
+++ b/tests/all_tests/t_f64x4.rs
@@ -725,6 +725,24 @@ fn impl_f64x4_pow_multiple() {
 }
 
 #[test]
+fn impl_f64x4_is_sign_positive() {
+  let a = f64x4::new([2401.0, -123.0, f64::INFINITY, f64::NEG_INFINITY]);
+  let expected = f64x4::new([f64::from_bits(!0), 0.0, f64::from_bits(!0), 0.0]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x4::ZERO);
+}
+
+#[test]
+fn impl_f64x4_is_sign_negative() {
+  let a = f64x4::new([2401.0, -123.0, f64::INFINITY, f64::NEG_INFINITY]);
+  let expected = f64x4::new([0.0, f64::from_bits(!0), 0.0, f64::from_bits(!0)]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x4::ZERO);
+}
+
+#[test]
 fn impl_f64x4_reduce_add() {
   let p = f64x4::splat(0.001);
   assert_eq!(p.reduce_add(), 0.004);

--- a/tests/all_tests/t_f64x8.rs
+++ b/tests/all_tests/t_f64x8.rs
@@ -820,6 +820,60 @@ fn impl_f64x8_powf_multiple() {
 }
 
 #[test]
+fn impl_f64x8_is_sign_positive() {
+  let a = f64x8::new([
+    2401.0,
+    -123.0,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+  ]);
+  let expected = f64x8::new([
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+  ]);
+  let actual = a.is_sign_positive();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x8::ZERO);
+}
+
+#[test]
+fn impl_f64x8_is_sign_negative() {
+  let a = f64x8::new([
+    2401.0,
+    -123.0,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+    2401.0,
+    -123.0,
+    f64::INFINITY,
+    f64::NEG_INFINITY,
+  ]);
+  let expected = f64x8::new([
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+    0.0,
+    f64::from_bits(!0),
+  ]);
+  let actual = a.is_sign_negative();
+  // Use bitwise equality to accept NaNs as equal.
+  assert_eq!(expected ^ actual, f64x8::ZERO);
+}
+
+#[test]
 fn impl_f64x8_reduce_add() {
   let p = f64x8::splat(0.001);
   assert_eq!(p.reduce_add(), 0.008);


### PR DESCRIPTION
The name `sign_bit` makes the behavior of the function unclear. `is_sign_*` are also used in `std::simd`.

For `f32` types i deprecated the original function. `f64` types did not expose the original function in the first place.

I put this in a separate PR because this involves deprecating functions and so you may not want it.

Note: if this is not merged for `v1.4.0` the `deprecated` attributes would need to be updated.