### PR TITLE
fix WASM CI panic message

### DIFF
--- a/tests/utils/for_simd_types.rs
+++ b/tests/utils/for_simd_types.rs
@@ -126,13 +126,20 @@ pub(crate) use for_simd_types;
 /// Improves error messages by specifying which `T` and `N` failed.
 #[doc(hidden)]
 pub fn for_simd_types_helper(f: impl FnOnce() + UnwindSafe, t: &str, n: usize) {
-  match catch_unwind(f) {
-    Ok(_) => {}
-    Err(payload) => {
-      println!();
-      println!("T: {t}");
-      println!("N: {n}");
-      resume_unwind(payload);
+  // For WASM, `catch/resume_unwind` leads to:
+  // "wasm trap: wasm `unreachable` instruction executed"
+  // which hides the actual panic message.
+  if cfg!(target_family = "wasm") {
+    f();
+  } else {
+    match catch_unwind(f) {
+      Ok(_) => {}
+      Err(payload) => {
+        println!();
+        println!("T: {t}");
+        println!("N: {n}");
+        resume_unwind(payload);
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes an issue with the new test utilities i added. The `for_simd_types` macros uses `catch/resume_unwind` to add more context to panic messages, but for WASM for some reason this leads a very wrong panic with:

"wasm trap: wasm `unreachable` instruction executed"

And the panic message doesn't show any relevant information. (this only happens for WASM CI when tests already fail)

Removing the panic handling from the WASM path should fix the issue.