### PR TITLE
fix, feat: Fix `round` and rename the old implementation to `round_ties_even`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,11 @@
 
 * Added `reduce_mul` for integers.
 
+* Added float function `round_ties_even`.
+
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
+
+* Fixed `round` which previously behaved like `round_ties_even`.
 
 ## 1.5.0
 

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -649,8 +649,10 @@ impl f32x16 {
           cast(BOUNDS_LIMIT),
         ));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else {
         Self {
           a: self.a.round(),

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -629,14 +629,14 @@ impl f32x16 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: round_m512::<{round_op!(Nearest)}>(self.avx512) }
       } else {
         Self {
-          a: self.a.round(),
-          b: self.b.round(),
+          a: self.a.round_ties_even(),
+          b: self.b.round_ties_even(),
         }
       }
     }
@@ -1172,7 +1172,7 @@ impl f32x16 {
     let xa = self.abs();
 
     // Find quadrant
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q: i32x16 = y.round_int();
 
     let x = y.mul_neg_add(DP3F, y.mul_neg_add(DP2F, y.mul_neg_add(DP1F, xa)));
@@ -1515,7 +1515,7 @@ impl f32x16 {
       return Self::ZERO;
     }
     let max_r = f32x16::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1570,7 +1570,7 @@ impl f32x16 {
     let max_x = f32x16::from(88.723);
     let min_x = f32x16::from(-103.63);
     let max_r = f32x16::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1622,7 +1622,7 @@ impl f32x16 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f32x16::from(127.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -1874,20 +1874,20 @@ impl f32x16 {
 
     let ef = x1.exponent();
     let ef = mask.blend(ef + f32x16::ONE, ef);
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f32x16::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x16::HALF * x).mul_sub(x, f32x16::HALF * x2);
     let lg_err = f32x16::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x16::LOG2_E).round();
+    let e2 = (lg * y * f32x16::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
     let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x16::LN_2);
 
     let x = v;
-    let e3 = (x * f32x16::LOG2_E).round();
+    let e3 = (x * f32x16::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f32x16::LN_2, x);
     let x2 = x * x;
     let z = x2.mul_add(
@@ -1923,7 +1923,7 @@ impl f32x16 {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
 
       // Is y odd?
       let y_odd = cast::<_, i32x16>(y.round_int() << 31).round_float();

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -627,6 +627,16 @@ impl f32x16 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -629,6 +629,21 @@ impl f32x16 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: round_m512::<{round_op!(Nearest)}>(self.avx512) }
+      } else {
+        Self {
+          a: self.a.round(),
+          b: self.b.round(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -632,7 +632,25 @@ impl f32x16 {
   pub fn round(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: round_m512::<{round_op!(Nearest)}>(self.avx512) }
+        const_f32_as_f32x16!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x16!(BOUNDS_LIMIT, 8388608.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { avx512: round_m512::<{round_op!(Zero)}>(adjusted_self.avx512) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_op_mask_i32_m512i::<{cmp_int_op!(Lt)}>(
+          cast(self_abs),
+          cast(BOUNDS_LIMIT),
+        ));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else {
         Self {
           a: self.a.round(),

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -672,6 +672,10 @@ impl f32x16 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -876,32 +876,27 @@ impl f32x4 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vrndnq_f32(self.neon) }}
       } else {
-        // Note(Lokathor): This software fallback is probably very slow compared
-        // to having a hardware option available, even just the sse2 version is
-        // better than this. Oh well.
-        let to_int = f32x4::from(1.0 / f32::EPSILON);
-        let u: u32x4 = cast(self);
-        let e: i32x4 = cast((u >> 23) & u32x4::from(0xff));
-        let mut y: f32x4;
+        const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
 
-        let no_op_magic = i32x4::from(0x7f + 23);
-        let no_op_mask: f32x4 = cast(e.simd_gt(no_op_magic) | e.simd_eq(no_op_magic));
-        let no_op_val: f32x4 = self;
+        let self_abs = self.abs();
 
-        let zero_magic = i32x4::from(0x7f - 1);
-        let zero_mask: f32x4 = cast(e.simd_lt(zero_magic));
-        let zero_val: f32x4 = self * f32x4::from(0.0);
+        let adjusted_self = (self_abs + Self::HALF).to_array();
+        let result_abs = Self::new([
+          adjusted_self[0] as u32 as f32,
+          adjusted_self[1] as u32 as f32,
+          adjusted_self[2] as u32 as f32,
+          adjusted_self[3] as u32 as f32,
+        ]);
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
 
-        let neg_bit: f32x4 = cast(cast::<u32x4, i32x4>(u).simd_lt(i32x4::default()));
-        let x: f32x4 = neg_bit.blend(-self, self);
-        y = x + to_int - to_int - x;
-        y = y.simd_gt(f32x4::from(0.5)).blend(
-          y + x - f32x4::from(-1.0),
-          y.simd_lt(f32x4::from(-0.5)).blend(y + x + f32x4::from(1.0), y + x),
-        );
-        y = neg_bit.blend(-y, y);
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cast::<_, i32x4>(self_abs).simd_lt(cast::<_, i32x4>(BOUNDS_LIMIT)));
 
-        no_op_mask.blend(no_op_val, zero_mask.blend(zero_val, y))
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       }
     }
   }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -874,7 +874,7 @@ impl f32x4 {
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f32x4_nearest(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vrndnq_f32(self.neon) }}
+        unsafe {Self { neon: vrndaq_f32(self.neon) }}
       } else {
         const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
         const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -833,6 +833,53 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: round_m128::<{round_op!(Nearest)}>(self.sse) }
+      } else if #[cfg(target_feature="sse2")] {
+        let mi: m128i = convert_to_i32_m128i_from_m128(self.sse);
+        let f: f32x4 = f32x4 { sse: convert_to_m128_from_i32_m128i(mi) };
+        let i: i32x4 = cast(mi);
+        let mask: f32x4 = cast(i.simd_eq(i32x4::from(0x80000000_u32 as i32)));
+        mask.blend(self, f)
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f32x4_nearest(self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vrndnq_f32(self.neon) }}
+      } else {
+        // Note(Lokathor): This software fallback is probably very slow compared
+        // to having a hardware option available, even just the sse2 version is
+        // better than this. Oh well.
+        let to_int = f32x4::from(1.0 / f32::EPSILON);
+        let u: u32x4 = cast(self);
+        let e: i32x4 = cast((u >> 23) & u32x4::from(0xff));
+        let mut y: f32x4;
+
+        let no_op_magic = i32x4::from(0x7f + 23);
+        let no_op_mask: f32x4 = cast(e.simd_gt(no_op_magic) | e.simd_eq(no_op_magic));
+        let no_op_val: f32x4 = self;
+
+        let zero_magic = i32x4::from(0x7f - 1);
+        let zero_mask: f32x4 = cast(e.simd_lt(zero_magic));
+        let zero_val: f32x4 = self * f32x4::from(0.0);
+
+        let neg_bit: f32x4 = cast(cast::<u32x4, i32x4>(u).simd_lt(i32x4::default()));
+        let x: f32x4 = neg_bit.blend(-self, self);
+        y = x + to_int - to_int - x;
+        y = y.simd_gt(f32x4::from(0.5)).blend(
+          y + x - f32x4::from(-1.0),
+          y.simd_lt(f32x4::from(-0.5)).blend(y + x + f32x4::from(1.0), y + x),
+        );
+        y = neg_bit.blend(-y, y);
+
+        no_op_mask.blend(no_op_val, zero_mask.blend(zero_val, y))
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -836,13 +836,41 @@ impl f32x4 {
   pub fn round(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: round_m128::<{round_op!(Nearest)}>(self.sse) }
+        const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { sse: round_m128::<{round_op!(Zero)}>(adjusted_self.sse) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(target_feature="sse2")] {
-        let mi: m128i = convert_to_i32_m128i_from_m128(self.sse);
-        let f: f32x4 = f32x4 { sse: convert_to_m128_from_i32_m128i(mi) };
-        let i: i32x4 = cast(mi);
-        let mask: f32x4 = cast(i.simd_eq(i32x4::from(0x80000000_u32 as i32)));
-        mask.blend(self, f)
+        const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self {
+          sse: convert_to_m128_from_i32_m128i(truncate_m128_to_m128i(adjusted_self.sse)),
+        };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f32x4_nearest(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -872,7 +872,22 @@ impl f32x4 {
         // `abs` keeps the original sign.
         bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: f32x4_nearest(self.simd) }
+        const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { simd: f32x4_trunc(adjusted_self.simd) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask = Self { simd: i32x4_lt(self_abs.simd, BOUNDS_LIMIT.simd) };
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vrndaq_f32(self.neon) }}
       } else {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -850,8 +850,10 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else if #[cfg(target_feature="sse2")] {
         const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
         const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
@@ -869,8 +871,10 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else if #[cfg(target_feature="simd128")] {
         const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
         const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
@@ -910,8 +914,10 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cast::<_, i32x4>(self_abs).simd_lt(cast::<_, i32x4>(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       }
     }
   }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -932,6 +932,10 @@ impl f32x4 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -831,6 +831,16 @@ impl f32x4 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -833,7 +833,7 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: round_m128::<{round_op!(Nearest)}>(self.sse) }
@@ -1424,7 +1424,7 @@ impl f32x4 {
     let xa = self.abs();
 
     // Find quadrant
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q: i32x4 = y.round_int();
 
     let x = y.mul_neg_add(DP3F, y.mul_neg_add(DP2F, y.mul_neg_add(DP1F, xa)));
@@ -1803,7 +1803,7 @@ impl f32x4 {
       return Self::ZERO;
     }
     let max_r = f32x4::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1858,7 +1858,7 @@ impl f32x4 {
     let max_x = f32x4::from(88.723);
     let min_x = f32x4::from(-103.63);
     let max_r = f32x4::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1910,7 +1910,7 @@ impl f32x4 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f32x4::from(127.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -2142,20 +2142,20 @@ impl f32x4 {
     let ef = x1.exponent();
     let ef = mask.blend(ef + f32x4::ONE, ef);
 
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f32x4::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x4::HALF * x).mul_sub(x, f32x4::HALF * x2);
     let lg_err = f32x4::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x4::LOG2_E).round();
+    let e2 = (lg * y * f32x4::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
     let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x4::LN_2);
 
     let x = v;
-    let e3 = (x * f32x4::LOG2_E).round();
+    let e3 = (x * f32x4::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f32x4::LN_2, x);
     let x2 = x * x;
     let z = x2.mul_add(
@@ -2196,7 +2196,7 @@ impl f32x4 {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
       // Is y odd?
       let y_odd = cast::<_, i32x4>(y.round_int() << 31).round_float();
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -629,6 +629,22 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out
+      if #[cfg(target_feature="avx")] {
+        Self { avx: round_m256::<{round_op!(Nearest)}>(self.avx) }
+      } else {
+        Self {
+          a : self.a.round(),
+          b : self.b.round(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -667,6 +667,10 @@ impl f32x8 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -646,8 +646,10 @@ impl f32x8 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i32_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else {
         let [a, b] = cast::<f32x8, [f32x4; 2]>(self);
         cast([a.round(), b.round()])

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -629,15 +629,15 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out
       if #[cfg(target_feature="avx")] {
         Self { avx: round_m256::<{round_op!(Nearest)}>(self.avx) }
       } else {
         Self {
-          a : self.a.round(),
-          b : self.b.round(),
+          a : self.a.round_ties_even(),
+          b : self.b.round_ties_even(),
         }
       }
     }
@@ -1168,7 +1168,7 @@ impl f32x8 {
     let xa = self.abs();
 
     // Find quadrant
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q: i32x8 = y.round_int();
 
     let x = y.mul_neg_add(DP3F, y.mul_neg_add(DP2F, y.mul_neg_add(DP1F, xa)));
@@ -1494,7 +1494,7 @@ impl f32x8 {
       return Self::ZERO;
     }
     let max_r = f32x8::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1549,7 +1549,7 @@ impl f32x8 {
     let max_x = f32x8::from(88.723);
     let min_x = f32x8::from(-103.63);
     let max_r = f32x8::from(127.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1601,7 +1601,7 @@ impl f32x8 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f32x8::from(127.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -1861,20 +1861,20 @@ impl f32x8 {
 
     let ef = x1.exponent();
     let ef = mask.blend(ef + f32x8::ONE, ef);
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f32x8::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x8::HALF * x).mul_sub(x, f32x8::HALF * x2);
     let lg_err = f32x8::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x8::LOG2_E).round();
+    let e2 = (lg * y * f32x8::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
     let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x8::LN_2);
 
     let x = v;
-    let e3 = (x * f32x8::LOG2_E).round();
+    let e3 = (x * f32x8::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f32x8::LN_2, x);
     let x2 = x * x;
     let z = x2.mul_add(
@@ -1910,7 +1910,7 @@ impl f32x8 {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
 
       // Is y odd?
       let y_odd = cast::<_, i32x8>(y.round_int() << 31).round_float();

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -631,9 +631,23 @@ impl f32x8 {
   #[must_use]
   pub fn round(self) -> Self {
     pick! {
-      // NOTE: Is there an SSE2 version of this? f32x4 version probably translates but I've not had time to figure it out
-      if #[cfg(target_feature="avx")] {
-        Self { avx: round_m256::<{round_op!(Nearest)}>(self.avx) }
+      if #[cfg(target_feature="avx2")] {
+        const_f32_as_f32x8!(HALF_NEXT_DOWN, 0.5_f32.next_down());
+        const_f32_as_f32x8!(BOUNDS_LIMIT, 8388608.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { avx: round_m256::<{round_op!(Zero)}>(adjusted_self.avx) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_gt_mask_i32_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else {
         Self {
           a : self.a.round(),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -627,6 +627,16 @@ impl f32x8 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -649,10 +649,8 @@ impl f32x8 {
         // `abs` keeps the original sign.
         bounds_mask.abs().blend(result_abs, self)
       } else {
-        Self {
-          a : self.a.round(),
-          b : self.b.round(),
-        }
+        let [a, b] = cast::<f32x8, [f32x4; 2]>(self);
+        cast([a.round(), b.round()])
       }
     }
   }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -796,8 +796,23 @@ impl f64x2 {
   #[must_use]
   pub fn round(self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: round_m128d::<{round_op!(Nearest)}>(self.sse) }
+      if #[cfg(target_feature="sse4.2")] {
+        const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
+        const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { sse: round_m128d::<{round_op!(Zero)}>(adjusted_self.sse) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_gt_mask_i64_m128i(cast(BOUNDS_LIMIT), cast(self_abs)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f64x2_nearest(self.simd) }
       } else {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -794,7 +794,7 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: round_m128d::<{round_op!(Nearest)}>(self.sse) }
@@ -853,7 +853,7 @@ impl f64x2 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         cast(Self { neon: unsafe { vreinterpretq_f64_s64(vcvtnq_s64_f64(self.neon)) } })
       } else {
-        let rounded: [f64; 2] = cast(self.round());
+        let rounded: [f64; 2] = cast(self.round_ties_even());
         cast([rounded[0] as i64, rounded[1] as i64])
       }
     }
@@ -1557,7 +1557,7 @@ impl f64x2 {
 
     let xa = self.abs();
 
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q = y.round_int();
 
     let x = y.mul_neg_add(DP3, y.mul_neg_add(DP2, y.mul_neg_add(DP1, xa)));
@@ -1904,7 +1904,7 @@ impl f64x2 {
       return Self::ZERO;
     }
     let max_r = f64x2::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1961,7 +1961,7 @@ impl f64x2 {
     let max_x = Self::from(709.783);
     let min_x = Self::from(-744.79);
     let max_r = Self::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -2018,7 +2018,7 @@ impl f64x2 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f64x2::from(1023.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -2303,20 +2303,20 @@ impl f64x2 {
 
     let ef = x1.exponent();
     let ef = mask.blend(ef + f64x2::ONE, ef);
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f64x2::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x2::HALF * x).mul_sub(x, f64x2::HALF * x2);
     let lg_err = f64x2::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x2::LOG2_E).round();
+    let e2 = (lg * y * f64x2::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
     let v = v - (lg_err + x2err).mul_sub(y, yr * f64x2::LN_2);
 
     let x = v;
-    let e3 = (x * f64x2::LOG2_E).round();
+    let e3 = (x * f64x2::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f64x2::LN_2, x);
     let z =
       polynomial_13!(x, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
@@ -2354,7 +2354,7 @@ impl f64x2 {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
       // Is y odd?
       let y_odd = cast::<_, i64x2>(y.round_int() << 63).round_float();
 

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -811,8 +811,10 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i64_m128i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else if #[cfg(target_feature="simd128")] {
         const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
         const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
@@ -828,8 +830,10 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask = Self { simd: i64x2_lt(self_abs.simd, BOUNDS_LIMIT.simd) };
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else {
         const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
         const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
@@ -848,8 +852,10 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cast::<_, i64x2>(self_abs).simd_lt(cast::<_, i64x2>(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       }
     }
   }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -814,7 +814,22 @@ impl f64x2 {
         // `abs` keeps the original sign.
         bounds_mask.abs().blend(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: f64x2_nearest(self.simd) }
+        const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
+        const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { simd: f64x2_trunc(adjusted_self.simd) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask = Self { simd: i64x2_lt(self_abs.simd, BOUNDS_LIMIT.simd) };
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else {
         const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
         const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -794,6 +794,28 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: round_m128d::<{round_op!(Nearest)}>(self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: f64x2_nearest(self.simd) }
+      } else {
+        const SIGN_MASK: f64x2 = f64x2::splat(-0.0);
+        const MAGIC_VALUE: f64x2 = f64x2::splat(f64::from_bits(0x43300000_00000000));
+
+        let self_sign = self & SIGN_MASK;
+        let magic_value = MAGIC_VALUE | self_sign;
+        let result = self + magic_value - magic_value;
+
+        let bounds_mask = self.abs().simd_le(MAGIC_VALUE);
+        bounds_mask.abs().blend(result, self)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -870,6 +870,10 @@ impl f64x2 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -792,6 +792,16 @@ impl f64x2 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -816,15 +816,25 @@ impl f64x2 {
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f64x2_nearest(self.simd) }
       } else {
-        const SIGN_MASK: f64x2 = f64x2::splat(-0.0);
-        const MAGIC_VALUE: f64x2 = f64x2::splat(f64::from_bits(0x43300000_00000000));
+        const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
+        const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
 
-        let self_sign = self & SIGN_MASK;
-        let magic_value = MAGIC_VALUE | self_sign;
-        let result = self + magic_value - magic_value;
+        let self_abs = self.abs();
 
-        let bounds_mask = self.abs().simd_le(MAGIC_VALUE);
-        bounds_mask.abs().blend(result, self)
+        let adjusted_self = (self_abs + Self::HALF).to_array();
+        let result_abs = Self::new([
+          adjusted_self[0] as u64 as f64,
+          adjusted_self[1] as u64 as f64,
+        ]);
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cast::<_, i64x2>(self_abs).simd_lt(cast::<_, i64x2>(BOUNDS_LIMIT)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       }
     }
   }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -628,6 +628,21 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: round_m256d::<{round_op!(Nearest)}>(self.avx) }
+      } else {
+        Self {
+          a : self.a.round(),
+          b : self.b.round(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -645,8 +645,10 @@ impl f64x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i64_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else {
         let [a, b] = cast::<f64x4, [f64x2; 2]>(self);
         cast([a.round(), b.round()])

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -666,6 +666,10 @@ impl f64x4 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -628,14 +628,14 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: round_m256d::<{round_op!(Nearest)}>(self.avx) }
       } else {
         Self {
-          a : self.a.round(),
-          b : self.b.round(),
+          a : self.a.round_ties_even(),
+          b : self.b.round_ties_even(),
         }
       }
     }
@@ -1381,7 +1381,7 @@ impl f64x4 {
 
     let xa = self.abs();
 
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q = y.round_int();
 
     let x = y.mul_neg_add(DP3, y.mul_neg_add(DP2, y.mul_neg_add(DP1, xa)));
@@ -1708,7 +1708,7 @@ impl f64x4 {
       return Self::ZERO;
     }
     let max_r = f64x4::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1765,7 +1765,7 @@ impl f64x4 {
     let max_x = f64x4::from(709.783);
     let min_x = f64x4::from(-744.79);
     let max_r = f64x4::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1822,7 +1822,7 @@ impl f64x4 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f64x4::from(1023.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -2095,20 +2095,20 @@ impl f64x4 {
 
     let ef = x1.exponent();
     let ef = mask.blend(ef + f64x4::ONE, ef);
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f64x4::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x4::HALF * x).mul_sub(x, f64x4::HALF * x2);
     let lg_err = f64x4::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x4::LOG2_E).round();
+    let e2 = (lg * y * f64x4::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
     let v = v - (lg_err + x2err).mul_sub(y, yr * f64x4::LN_2);
 
     let x = v;
-    let e3 = (x * f64x4::LOG2_E).round();
+    let e3 = (x * f64x4::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f64x4::LN_2, x);
     let z =
       polynomial_13!(x, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
@@ -2147,7 +2147,7 @@ impl f64x4 {
 
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
       // Is y odd?
       let y_odd = cast::<_, i64x4>(y.round_int() << 63).round_float();
       let z1 =

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -648,10 +648,8 @@ impl f64x4 {
         // `abs` keeps the original sign.
         bounds_mask.abs().blend(result_abs, self)
       } else {
-        Self {
-          a : self.a.round(),
-          b : self.b.round(),
-        }
+        let [a, b] = cast::<f64x4, [f64x2; 2]>(self);
+        cast([a.round(), b.round()])
       }
     }
   }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -630,8 +630,23 @@ impl f64x4 {
   #[must_use]
   pub fn round(self) -> Self {
     pick! {
-      if #[cfg(target_feature="avx")] {
-        Self { avx: round_m256d::<{round_op!(Nearest)}>(self.avx) }
+      if #[cfg(target_feature="avx2")] {
+        const_f64_as_f64x4!(HALF_NEXT_DOWN, 0.5_f64.next_down());
+        const_f64_as_f64x4!(BOUNDS_LIMIT, 4503599627370496.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { avx: round_m256d::<{round_op!(Zero)}>(adjusted_self.avx) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_gt_mask_i64_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else {
         Self {
           a : self.a.round(),

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -626,6 +626,16 @@ impl f64x4 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -649,6 +649,10 @@ impl f64x8 {
     }
   }
 
+  /// Returns the nearest integers to `self`. Rounds half-way cases to the
+  /// number with an even least significant digit.
+  ///
+  /// This function always returns the precise result.
   #[inline]
   #[must_use]
   pub fn round_ties_even(self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -604,6 +604,16 @@ impl f64x8 {
     cast(out)
   }
 
+  /// Returns the nearest integers to `self`. If a value is half-way between two
+  /// integers, round away from `0.0`.
+  ///
+  /// This function always returns the precise result.
+  ///
+  /// For most targets [`round`] is slower than [`round_ties_even`]. If you
+  /// do not care about the difference, consider using that instead.
+  ///
+  /// [`round`]: Self::round
+  /// [`round_ties_even`]: Self::round_ties_even
   #[inline]
   #[must_use]
   pub fn round(self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -632,8 +632,8 @@ impl f64x8 {
 
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_op_mask_i64_m512i::<{cmp_int_op!(Lt)}>(
-          cast(BOUNDS_LIMIT),
           cast(self_abs),
+          cast(BOUNDS_LIMIT),
         ));
 
         // `abs` keeps the original sign. `blend` cannot be used here because it

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -609,7 +609,25 @@ impl f64x8 {
   pub fn round(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: round_m512d::<{round_op!(Nearest)}>(self.avx512) }
+        const_f64_as_f64x8!(HALF_NEXT_DOWN, 0.5_f64.next_down());
+        const_f64_as_f64x8!(BOUNDS_LIMIT, 4503599627370496.0);
+
+        let self_abs = self.abs();
+
+        let adjusted_self = self_abs + Self::HALF;
+        let result_abs = Self { avx512: round_m512d::<{round_op!(Zero)}>(adjusted_self.avx512) };
+        // The addition breaks for `0.5.next_down()` which incorrectly rounds to
+        // `1.0`. This resets the result back to `0.0`.
+        let result_abs = result_abs & self_abs.simd_ne(HALF_NEXT_DOWN);
+
+        // Large value, infinity and NaN need special handling.
+        let bounds_mask: Self = cast(cmp_op_mask_i64_m512i::<{cmp_int_op!(Lt)}>(
+          cast(BOUNDS_LIMIT),
+          cast(self_abs),
+        ));
+
+        // `abs` keeps the original sign.
+        bounds_mask.abs().blend(result_abs, self)
       } else {
         Self {
           a: self.a.round(),

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -606,14 +606,14 @@ impl f64x8 {
 
   #[inline]
   #[must_use]
-  pub fn round(self) -> Self {
+  pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: round_m512d::<{round_op!(Nearest)}>(self.avx512) }
       } else {
         Self {
-          a: self.a.round(),
-          b: self.b.round(),
+          a: self.a.round_ties_even(),
+          b: self.b.round_ties_even(),
         }
       }
     }
@@ -1371,7 +1371,7 @@ impl f64x8 {
 
     let xa = self.abs();
 
-    let y = (xa * TWO_OVER_PI).round();
+    let y = (xa * TWO_OVER_PI).round_ties_even();
     let q = y.round_int();
 
     let x = y.mul_neg_add(DP3, y.mul_neg_add(DP2, y.mul_neg_add(DP1, xa)));
@@ -1699,7 +1699,7 @@ impl f64x8 {
       return Self::ZERO;
     }
     let max_r = f64x8::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1756,7 +1756,7 @@ impl f64x8 {
     let max_x = f64x8::from(709.783);
     let min_x = f64x8::from(-744.79);
     let max_r = f64x8::from(1023.0);
-    let r = (self * Self::LOG2_E).round();
+    let r = (self * Self::LOG2_E).round_ties_even();
     let big = r.simd_gt(max_r);
     let r_safe = big.blend(max_r, r);
     let excess = r - max_r;
@@ -1813,7 +1813,7 @@ impl f64x8 {
       return Self::ZERO;
     }
 
-    let round = self.round();
+    let round = self.round_ties_even();
     let max_r = f64x8::from(1023.0);
     let big = round.simd_gt(max_r);
     let r_safe = big.blend(max_r, round);
@@ -2089,20 +2089,20 @@ impl f64x8 {
 
     let ef = x1.exponent();
     let ef = mask.blend(ef + f64x8::ONE, ef);
-    let e1 = (ef * y).round();
+    let e1 = (ef * y).round_ties_even();
     let yr = ef.mul_sub(y, e1);
 
     let lg = f64x8::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x8::HALF * x).mul_sub(x, f64x8::HALF * x2);
     let lg_err = f64x8::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x8::LOG2_E).round();
+    let e2 = (lg * y * f64x8::LOG2_E).round_ties_even();
     let v = lg.mul_sub(y, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
     let v = v - (lg_err + x2err).mul_sub(y, yr * f64x8::LN_2);
 
     let x = v;
-    let e3 = (x * f64x8::LOG2_E).round();
+    let e3 = (x * f64x8::LOG2_E).round_ties_even();
     let x = e3.mul_neg_add(f64x8::LN_2, x);
     let z =
       polynomial_13!(x, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
@@ -2141,7 +2141,7 @@ impl f64x8 {
 
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round());
+      let yi = y.simd_eq(y.round_ties_even());
       // Is y odd?
       let y_odd = cast::<_, i64x8>(y.round_int() << 63).round_float();
       let z1 =

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -626,8 +626,10 @@ impl f64x8 {
           cast(self_abs),
         ));
 
-        // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        // `abs` keeps the original sign. `blend` cannot be used here because it
+        // doesn't work as an arbitrary bit-blend.
+        let bounds_mask = bounds_mask.abs();
+        result_abs & bounds_mask | self & !bounds_mask
       } else {
         Self {
           a: self.a.round(),

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -606,6 +606,21 @@ impl f64x8 {
 
   #[inline]
   #[must_use]
+  pub fn round(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: round_m512d::<{round_op!(Nearest)}>(self.avx512) }
+      } else {
+        Self {
+          a: self.a.round(),
+          b: self.b.round(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn round_ties_even(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -474,6 +474,53 @@ fn test_is_inf() {
 }
 
 #[test]
+fn test_round() {
+  for_simd_types!(|T: Float, N| {
+    for value in simd_chunks!([
+      0.0,
+      0.1,
+      0.5,
+      0.7,
+      -0.0,
+      -0.1,
+      -0.5,
+      -0.7,
+      2.0,
+      2.1,
+      2.5,
+      2.7,
+      -2.0,
+      -2.1,
+      -2.5,
+      -2.7,
+      5.0,
+      5.1,
+      5.5,
+      5.7,
+      -5.0,
+      -5.1,
+      -5.5,
+      -5.7,
+      T::MAX,
+      T::MIN,
+      T::NAN,
+      T::INFINITY,
+      T::NEG_INFINITY,
+    ])
+    .chain(random_iter())
+    {
+      let expected = Simd::new(value.map(T::round));
+      let actual = Simd::new(value).round();
+
+      assert!(
+        actual ^ expected == Simd::ZERO,
+        "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}",
+      );
+    }
+  });
+}
+
+#[test]
 fn test_round_ties_even() {
   for_simd_types!(|T: Float, N| {
     for value in simd_chunks!([

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -474,7 +474,7 @@ fn test_is_inf() {
 }
 
 #[test]
-fn test_round() {
+fn test_round_ties_even() {
   for_simd_types!(|T: Float, N| {
     for value in simd_chunks!([
       0.0,
@@ -509,10 +509,8 @@ fn test_round() {
     ])
     .chain(random_iter())
     {
-      // TODO:  Currently `round` actually behaves like `round_ties_even`.
-      // Decide the correct behavior then add documentation.
       let expected = Simd::new(value.map(T::round_ties_even));
-      let actual = Simd::new(value).round();
+      let actual = Simd::new(value).round_ties_even();
 
       assert!(
         actual ^ expected == Simd::ZERO,

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -479,34 +479,19 @@ fn test_round() {
     for value in simd_chunks!([
       0.0,
       0.1,
+      (0.5 as T).next_down(),
       0.5,
       0.7,
-      -0.0,
-      -0.1,
-      -0.5,
-      -0.7,
-      2.0,
-      2.1,
-      2.5,
-      2.7,
-      -2.0,
-      -2.1,
-      -2.5,
-      -2.7,
-      5.0,
-      5.1,
-      5.5,
-      5.7,
-      -5.0,
-      -5.1,
-      -5.5,
-      -5.7,
+      8388607.0,
+      4503599627370495.0,
       T::MAX,
-      T::MIN,
-      T::NAN,
       T::INFINITY,
-      T::NEG_INFINITY,
+      T::NAN
     ])
+    .flat_map(|x| {
+      [x, x.map(|x| x + 1.0), x.map(|x| x + 2.0), x.map(|x| x + 3.0)]
+    })
+    .flat_map(|x| [x, x.map(|x| -x)])
     .chain(random_iter())
     {
       let expected = Simd::new(value.map(T::round));
@@ -526,34 +511,19 @@ fn test_round_ties_even() {
     for value in simd_chunks!([
       0.0,
       0.1,
+      (0.5 as T).next_down(),
       0.5,
       0.7,
-      -0.0,
-      -0.1,
-      -0.5,
-      -0.7,
-      2.0,
-      2.1,
-      2.5,
-      2.7,
-      -2.0,
-      -2.1,
-      -2.5,
-      -2.7,
-      5.0,
-      5.1,
-      5.5,
-      5.7,
-      -5.0,
-      -5.1,
-      -5.5,
-      -5.7,
+      8388607.0,
+      4503599627370495.0,
       T::MAX,
-      T::MIN,
-      T::NAN,
       T::INFINITY,
-      T::NEG_INFINITY,
+      T::NAN
     ])
+    .flat_map(|x| {
+      [x, x.map(|x| x + 1.0), x.map(|x| x + 2.0), x.map(|x| x + 3.0)]
+    })
+    .flat_map(|x| [x, x.map(|x| -x)])
     .chain(random_iter())
     {
       let expected = Simd::new(value.map(T::round_ties_even));


### PR DESCRIPTION
Currently `round` consistently behaves like the standard library function `round_ties_even` and unlike standard library `round`.

(The difference between the two is that `round` rounds half way cases away from zero while `round_ties_even` rounds them to an even result).

This PR refactors `round` to be consistent with the standard library and renames the old implementation to `round_ties_even`. Because `round_ties_even` is faster than `round` i included that in the documentation.
