### PR TITLE
fix, feat: Deprecate `blend` and split it into bitwise-blending and lanewise-blending

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
 
+* Deprecated `blend` and replaced it with `select` and `bitselect`.
+
 ## 1.5.0
 
 * Added several functions and trait implementations that previously were only

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -421,19 +421,19 @@ impl f32x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512(
-            bitand_m512(t.avx512, self.avx512),
-            bitandnot_m512(self.avx512, f.avx512),
+            bitand_m512(if_one.avx512, self.avx512),
+            bitandnot_m512(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -709,10 +709,8 @@ impl f32x16 {
           cast(BOUNDS_LIMIT),
         ));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else {
         Self {
           a: self.a.round(),

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -452,14 +452,14 @@ impl f32x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_m512(f.avx512, t.avx512, movepi32_mask_m512(self.avx512)) }
+        Self { avx512: blend_varying_m512(if_false.avx512, if_true.avx512, movepi32_mask_m512(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -439,6 +439,15 @@ impl f32x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -412,6 +412,21 @@ impl f32x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_m512(f.avx512, t.avx512, movepi32_mask_m512(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -410,6 +410,15 @@ impl f32x16 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -412,14 +412,14 @@ impl f32x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_m512(f.avx512, t.avx512, movepi32_mask_m512(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -446,7 +446,7 @@ impl f32x16 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -505,7 +505,7 @@ impl f32x16 {
         // max_m512 seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx512: max_m512(self.avx512, rhs.avx512) })
+        rhs.is_nan().select(self, Self { avx512: max_m512(self.avx512, rhs.avx512) })
       } else {
         Self {
           a: self.a.max(rhs.a),
@@ -541,7 +541,7 @@ impl f32x16 {
         // min_m512 seems to do rhs > self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx512: min_m512(self.avx512, rhs.avx512) })
+        rhs.is_nan().select(self, Self { avx512: min_m512(self.avx512, rhs.avx512) })
       } else {
         Self {
           a: self.a.min(rhs.a),
@@ -560,7 +560,7 @@ impl f32x16 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    is_nan.select(Self::splat(f32::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -923,14 +923,14 @@ impl f32x16 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -961,11 +961,11 @@ impl f32x16 {
 
     let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -973,13 +973,13 @@ impl f32x16 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x16::ZERO).blend(f32x16::PI - z1, z1);
+    let z3 = self.simd_lt(f32x16::ZERO).select(f32x16::PI - z1, z1);
     let z4 = f32x16::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     // asin
     let z3 = f32x16::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     (asin, acos)
@@ -1001,11 +1001,11 @@ impl f32x16 {
 
     let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1014,7 +1014,7 @@ impl f32x16 {
 
     // asin
     let z3 = f32x16::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1036,11 +1036,11 @@ impl f32x16 {
 
     let x1 = f32x16::splat(0.5) * (f32x16::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1048,9 +1048,9 @@ impl f32x16 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x16::ZERO).blend(f32x16::PI - z1, z1);
+    let z3 = self.simd_lt(f32x16::ZERO).select(f32x16::PI - z1, z1);
     let z4 = f32x16::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1072,13 +1072,13 @@ impl f32x16 {
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
     let notbig = t.simd_le(Self::SQRT_2 + Self::ONE);
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
 
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1088,7 +1088,7 @@ impl f32x16 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1109,15 +1109,15 @@ impl f32x16 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 will produce NAN. No problem, fixed below
@@ -1127,8 +1127,8 @@ impl f32x16 {
     // medium: z = (t-1.0) / (t+1.0);
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
 
-    let a = notsmal.blend(t - Self::ONE, t);
-    let b = notsmal.blend(t + Self::ONE, Self::ONE);
+    let a = notsmal.select(t - Self::ONE, t);
+    let b = notsmal.select(t + Self::ONE, Self::ONE);
     let s = notsmal & Self::FRAC_PI_4;
     let z = a / b;
 
@@ -1139,12 +1139,12 @@ impl f32x16 {
     re = re.mul_add(zz * z, z) + s;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1186,24 +1186,24 @@ impl f32x16 {
 
     let mut overflow: f32x16 = cast(q.simd_gt(i32x16::from(0x2000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f32x16::from(0.0), s);
-    c = overflow.blend(f32x16::from(1.0), c);
+    s = overflow.select(f32x16::from(0.0), s);
+    c = overflow.select(f32x16::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f32x16>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f32x16>(swap).select(c, s);
     let sign_sin: i32x16 = (q << 30) ^ cast::<_, i32x16>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f32x16>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f32x16>(swap).select(s, c);
     let sign_cos: i32x16 = ((q + i32x16::from(1)) & i32x16::from(2)) << 30;
     cos1 ^= cast::<_, f32x16>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f32::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1246,7 +1246,7 @@ impl f32x16 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1267,7 +1267,7 @@ impl f32x16 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1288,8 +1288,8 @@ impl f32x16 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1305,7 +1305,7 @@ impl f32x16 {
     let nan = self.is_nan();
 
     let tiny = a.simd_lt(Self::from(f32::MIN_POSITIVE));
-    let a_work = tiny.blend(a * Self::from(16777216.0), a);
+    let a_work = tiny.select(a * Self::from(16777216.0), a);
 
     let e = Self::exponent(a_work) + Self::ONE;
     let d = Self::fraction_2(a_work);
@@ -1337,20 +1337,20 @@ impl f32x16 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f32_as_f32x16!(CBRT2, 1.259921);
     const_f32_as_f32x16!(CBRT4, 1.587401);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(256.0_f32), y);
+    y = tiny.select(y / Self::from(256.0_f32), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1476,11 +1476,11 @@ impl f32x16 {
       let valid = self.simd_ge(f32x16::from(-149.0));
       let shift_f = self + f32x16::from(149.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i32x16>(valid).blend(shift_i, i32x16::ZERO);
+      shift_i = cast::<_, i32x16>(valid).select(shift_i, i32x16::ZERO);
       let mantissa = i32x16::ONE << shift_i;
       let sub_result = cast::<_, f32x16>(mantissa);
-      let sub_result = valid.blend(sub_result, f32x16::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f32x16::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1517,9 +1517,9 @@ impl f32x16 {
     let max_r = f32x16::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1529,14 +1529,14 @@ impl f32x16 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1572,9 +1572,9 @@ impl f32x16 {
     let max_r = f32x16::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1584,20 +1584,20 @@ impl f32x16 {
     let n2 = Self::vm_pow2n(r_safe);
     let exp_val = (z + Self::ONE) * scale * n2;
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -1625,9 +1625,9 @@ impl f32x16 {
     let round = self.round();
     let max_r = f32x16::from(127.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -1639,14 +1639,14 @@ impl f32x16 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1775,8 +1775,8 @@ impl f32x16 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(Self::SQRT_2 * HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let res = polynomial_8!(x, P0, P1, P2, P3, P4, P5, P6, P7, P8);
     let x2 = x * x;
@@ -1791,16 +1791,16 @@ impl f32x16 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~1.4e-45..1.175e-38) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -1821,9 +1821,9 @@ impl f32x16 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -1863,7 +1863,7 @@ impl f32x16 {
     let x1 = self.abs();
     let x = x1.fraction_2();
     let mask = x.simd_gt(f32x16::SQRT_2 * f32x16::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
 
     let x = x - f32x16::ONE;
     let x2 = x * x;
@@ -1873,7 +1873,7 @@ impl f32x16 {
     let lg1 = lg1 * x2 * x;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f32x16::ONE, ef);
+    let ef = mask.select(ef + f32x16::ONE, ef);
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
 
@@ -1907,15 +1907,15 @@ impl f32x16 {
     // Add exponent by integer addition
     let z = cast::<_, f32x16>(cast::<_, i32x16>(z) + (ei << 23));
     // Check for overflow/underflow
-    let z = underflow.blend(f32x16::ZERO, z);
-    let z = overflow.blend(Self::infinity(), z);
+    let z = underflow.select(f32x16::ZERO, z);
+    let z = overflow.select(Self::infinity(), z);
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f32x16::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f32x16::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x16::ZERO).blend(f32x16::ONE, f32x16::ZERO),
+        y.simd_eq(f32x16::ZERO).select(f32x16::ONE, f32x16::ZERO),
       ),
       z,
     );
@@ -1928,10 +1928,10 @@ impl f32x16 {
       // Is y odd?
       let y_odd = cast::<_, i32x16>(y.round_int() << 31).round_float();
 
-      let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
 
-      x_sign.blend(z1, z)
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -1943,7 +1943,7 @@ impl f32x16 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
 
   #[inline]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -2070,6 +2070,8 @@ impl f32x16 {
     }
   }
 
+  fn_blend!();
+
   /// Returns true for each element if its sign bit is set.
   ///
   /// If the sign bit is set, the result has all bits set, not just the sign

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -412,11 +412,13 @@ impl f32x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -443,8 +443,10 @@ impl f32x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -415,7 +415,12 @@ impl f32x16 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_m512(f.avx512, t.avx512, movepi32_mask_m512(self.avx512)) }
+        Self {
+          avx512: bitor_m512(
+            bitand_m512(t.avx512, self.avx512),
+            bitandnot_m512(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -556,6 +556,15 @@ impl f32x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -2389,6 +2389,8 @@ impl f32x4 {
     }
   }
 
+  fn_blend!();
+
   /// Returns true for each element if its sign bit is set.
   ///
   /// If the sign bit is set, the result has all bits set, not just the sign

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -526,6 +526,15 @@ impl f32x4 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -528,11 +528,13 @@ impl f32x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -537,21 +537,21 @@ impl f32x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128(
-            bitand_m128(t.sse, self.sse),
-            bitandnot_m128(self.sse, f.sse),
+            bitand_m128(if_one.sse, self.sse),
+            bitandnot_m128(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_f32(vreinterpretq_u32_f32(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_f32(vreinterpretq_u32_f32(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -530,8 +530,13 @@ impl f32x4 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_m128(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128(
+            bitand_m128(t.sse, self.sse),
+            bitandnot_m128(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -528,6 +528,22 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_m128(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_f32(vreinterpretq_u32_f32(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -911,10 +911,8 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else if #[cfg(target_feature="sse2")] {
         const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
         const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
@@ -932,10 +930,8 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_lt_mask_i32_m128i(cast(self_abs), cast(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
         const_f32_as_f32x4!(HALF_NEXT_DOWN, 0.5_f32.next_down());
         const_f32_as_f32x4!(BOUNDS_LIMIT, 8388608.0);
@@ -952,7 +948,7 @@ impl f32x4 {
         let bounds_mask = Self { simd: i32x4_lt(self_abs.simd, BOUNDS_LIMIT.simd) };
 
         // `abs` keeps the original sign.
-        bounds_mask.abs().blend(result_abs, self)
+        bounds_mask.abs().bitselect(result_abs, self)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vrndaq_f32(self.neon) }}
       } else {
@@ -975,10 +971,8 @@ impl f32x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cast::<_, i32x4>(self_abs).simd_lt(cast::<_, i32x4>(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       }
     }
   }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -560,8 +560,10 @@ impl f32x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -569,16 +569,16 @@ impl f32x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_m128(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_m128(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_f32(vreinterpretq_u32_f32(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_f32(vreinterpretq_u32_f32(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -528,7 +528,7 @@ impl f32x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_m128(f.sse, t.sse, self.sse) }
@@ -561,7 +561,7 @@ impl f32x4 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -652,7 +652,7 @@ impl f32x4 {
         // max_m128 seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { sse: max_m128(self.sse, rhs.sse) })
+        rhs.is_nan().select(self, Self { sse: max_m128(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two max intrinsics:
         // - max: This propagates NaN, that's the opposite of what we need.
@@ -717,7 +717,7 @@ impl f32x4 {
         // min_m128 seems to do self < rhs ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { sse: min_m128(self.sse, rhs.sse) })
+        rhs.is_nan().select(self, Self { sse: min_m128(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two min intrinsics:
         // - min: This propagates NaN, that's the opposite of what we need.
@@ -754,7 +754,7 @@ impl f32x4 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    is_nan.select(Self::splat(f32::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -779,8 +779,8 @@ impl f32x4 {
         // The standard library does not have NaN propagating `min` and `max`
         // functions.
         let mut result = self;
-        result = result.simd_lt(min).blend(min, result);
-        result = result.simd_gt(max).blend(max, result);
+        result = result.simd_lt(min).select(min, result);
+        result = result.simd_gt(max).select(max, result);
         result
       }
     }
@@ -842,7 +842,7 @@ impl f32x4 {
         let f: f32x4 = f32x4 { sse: convert_to_m128_from_i32_m128i(mi) };
         let i: i32x4 = cast(mi);
         let mask: f32x4 = cast(i.simd_eq(i32x4::from(0x80000000_u32 as i32)));
-        mask.blend(self, f)
+        mask.select(self, f)
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f32x4_nearest(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
@@ -865,15 +865,15 @@ impl f32x4 {
         let zero_val: f32x4 = self * f32x4::from(0.0);
 
         let neg_bit: f32x4 = cast(cast::<u32x4, i32x4>(u).simd_lt(i32x4::default()));
-        let x: f32x4 = neg_bit.blend(-self, self);
+        let x: f32x4 = neg_bit.select(-self, self);
         y = x + to_int - to_int - x;
-        y = y.simd_gt(f32x4::from(0.5)).blend(
+        y = y.simd_gt(f32x4::from(0.5)).select(
           y + x - f32x4::from(-1.0),
-          y.simd_lt(f32x4::from(-0.5)).blend(y + x + f32x4::from(1.0), y + x),
+          y.simd_lt(f32x4::from(-0.5)).select(y + x + f32x4::from(1.0), y + x),
         );
-        y = neg_bit.blend(-y, y);
+        y = neg_bit.select(-y, y);
 
-        no_op_mask.blend(no_op_val, zero_mask.blend(zero_val, y))
+        no_op_mask.select(no_op_val, zero_mask.select(zero_val, y))
       }
     }
   }
@@ -941,7 +941,7 @@ impl f32x4 {
         ));
 
         // Reset the sign bit of the mask to preverse the sign of `self`.
-        bounds_mask.abs().blend(result, self)
+        bounds_mask.abs().select(result, self)
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: f32x4_trunc(self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
@@ -960,7 +960,7 @@ impl f32x4 {
         let bounds_mask: Self = cast(cast::<f32x4, i32x4>(self.abs()).simd_lt(i32x4::splat(BOUNDS_LIMIT)));
 
         // Reset the sign bit of the mask to preverse the sign of `self`.
-        bounds_mask.abs().blend(result, self)
+        bounds_mask.abs().select(result, self)
       }
     }
   }
@@ -1176,14 +1176,14 @@ impl f32x4 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -1214,11 +1214,11 @@ impl f32x4 {
 
     let x1 = f32x4::splat(0.5) * (f32x4::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1226,13 +1226,13 @@ impl f32x4 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x4::ZERO).blend(f32x4::PI - z1, z1);
+    let z3 = self.simd_lt(f32x4::ZERO).select(f32x4::PI - z1, z1);
     let z4 = f32x4::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     // asin
     let z3 = f32x4::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     (asin, acos)
@@ -1253,11 +1253,11 @@ impl f32x4 {
 
     let x1 = f32x4::splat(0.5) * (f32x4::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1266,7 +1266,7 @@ impl f32x4 {
 
     // asin
     let z3 = f32x4::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1288,11 +1288,11 @@ impl f32x4 {
 
     let x1 = f32x4::splat(0.5) * (f32x4::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1300,9 +1300,9 @@ impl f32x4 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x4::ZERO).blend(f32x4::PI - z1, z1);
+    let z3 = self.simd_lt(f32x4::ZERO).select(f32x4::PI - z1, z1);
     let z4 = f32x4::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1324,13 +1324,13 @@ impl f32x4 {
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
     let notbig = t.simd_le(Self::SQRT_2 + Self::ONE);
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
 
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1340,7 +1340,7 @@ impl f32x4 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1361,15 +1361,15 @@ impl f32x4 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 will produce NAN. No problem, fixed below
@@ -1379,8 +1379,8 @@ impl f32x4 {
     // medium: z = (t-1.0) / (t+1.0);
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
 
-    let a = notsmal.blend(t - Self::ONE, t);
-    let b = notsmal.blend(t + Self::ONE, Self::ONE);
+    let a = notsmal.select(t - Self::ONE, t);
+    let b = notsmal.select(t + Self::ONE, Self::ONE);
     let s = notsmal & Self::FRAC_PI_4;
     let z = a / b;
 
@@ -1391,12 +1391,12 @@ impl f32x4 {
     re = re.mul_add(zz * z, z) + s;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1438,24 +1438,24 @@ impl f32x4 {
 
     let mut overflow: f32x4 = cast(q.simd_gt(i32x4::from(0x2000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f32x4::from(0.0), s);
-    c = overflow.blend(f32x4::from(1.0), c);
+    s = overflow.select(f32x4::from(0.0), s);
+    c = overflow.select(f32x4::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f32x4>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f32x4>(swap).select(c, s);
     let sign_sin: i32x4 = (q << 30) ^ cast::<_, i32x4>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f32x4>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f32x4>(swap).select(s, c);
     let sign_cos: i32x4 = ((q + i32x4::from(1)) & i32x4::from(2)) << 30;
     cos1 ^= cast::<_, f32x4>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f32::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1496,7 +1496,7 @@ impl f32x4 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1517,7 +1517,7 @@ impl f32x4 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1538,8 +1538,8 @@ impl f32x4 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1555,7 +1555,7 @@ impl f32x4 {
     let nan = self.is_nan();
 
     let tiny = a.simd_lt(Self::from(f32::MIN_POSITIVE));
-    let a_work = tiny.blend(a * Self::from(16777216.0), a);
+    let a_work = tiny.select(a * Self::from(16777216.0), a);
 
     let e = Self::exponent(a_work) + Self::ONE;
     let d = Self::fraction_2(a_work);
@@ -1587,20 +1587,20 @@ impl f32x4 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f32_as_f32x4!(CBRT2, 1.259921);
     const_f32_as_f32x4!(CBRT4, 1.587401);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(256.0_f32), y);
+    y = tiny.select(y / Self::from(256.0_f32), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1764,11 +1764,11 @@ impl f32x4 {
       let valid = self.simd_ge(f32x4::from(-149.0));
       let shift_f = self + f32x4::from(149.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i32x4>(valid).blend(shift_i, i32x4::ZERO);
+      shift_i = cast::<_, i32x4>(valid).select(shift_i, i32x4::ZERO);
       let mantissa = i32x4::ONE << shift_i;
       let sub_result = cast::<_, f32x4>(mantissa);
-      let sub_result = valid.blend(sub_result, f32x4::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f32x4::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1805,9 +1805,9 @@ impl f32x4 {
     let max_r = f32x4::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1817,14 +1817,14 @@ impl f32x4 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1860,9 +1860,9 @@ impl f32x4 {
     let max_r = f32x4::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1872,20 +1872,20 @@ impl f32x4 {
     let n2 = Self::vm_pow2n(r_safe);
     let exp_val = (z + Self::ONE) * scale * n2;
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -1913,9 +1913,9 @@ impl f32x4 {
     let round = self.round();
     let max_r = f32x4::from(127.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -1927,14 +1927,14 @@ impl f32x4 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -2042,8 +2042,8 @@ impl f32x4 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(Self::SQRT_2 * HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let res = polynomial_8!(x, P0, P1, P2, P3, P4, P5, P6, P7, P8);
     let x2 = x * x;
@@ -2058,16 +2058,16 @@ impl f32x4 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~1.4e-45..1.175e-38) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -2088,9 +2088,9 @@ impl f32x4 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -2130,7 +2130,7 @@ impl f32x4 {
     let x = x1.fraction_2();
 
     let mask = x.simd_gt(f32x4::SQRT_2 * f32x4::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
 
     let x = x - f32x4::ONE;
     let x2 = x * x;
@@ -2140,7 +2140,7 @@ impl f32x4 {
     let lg1 = lg1 * x2 * x;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f32x4::ONE, ef);
+    let ef = mask.select(ef + f32x4::ONE, ef);
 
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
@@ -2177,18 +2177,18 @@ impl f32x4 {
 
     // Check for overflow/underflow
     let z = if (overflow | underflow).any() {
-      let z = underflow.blend(f32x4::ZERO, z);
-      overflow.blend(Self::infinity(), z)
+      let z = underflow.select(f32x4::ZERO, z);
+      overflow.select(Self::infinity(), z)
     } else {
       z
     };
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f32x4::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f32x4::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x4::ZERO).blend(f32x4::ONE, f32x4::ZERO),
+        y.simd_eq(f32x4::ZERO).select(f32x4::ONE, f32x4::ZERO),
       ),
       z,
     );
@@ -2200,9 +2200,9 @@ impl f32x4 {
       // Is y odd?
       let y_odd = cast::<_, i32x4>(y.round_int() << 31).round_float();
 
-      let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
-      x_sign.blend(z1, z)
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -2214,7 +2214,7 @@ impl f32x4 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
 
   #[inline]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -413,7 +413,12 @@ impl f32x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        Self { avx: blend_varying_m256(f.avx, t.avx, self.avx) }
+        Self {
+          avx: bitor_m256(
+            bitand_m256(t.avx, self.avx),
+            bitandnot_m256(self.avx, f.avx),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -410,14 +410,14 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: blend_varying_m256(f.avx, t.avx, self.avx) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -443,7 +443,7 @@ impl f32x8 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -503,7 +503,7 @@ impl f32x8 {
         // max_m256 seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx: max_m256(self.avx, rhs.avx) })
+        rhs.is_nan().select(self, Self { avx: max_m256(self.avx, rhs.avx) })
       } else {
         Self {
           a : self.a.max(rhs.a),
@@ -543,7 +543,7 @@ impl f32x8 {
         // min_m256 seems to do rhs > self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx: min_m256(self.avx, rhs.avx) })
+        rhs.is_nan().select(self, Self { avx: min_m256(self.avx, rhs.avx) })
       } else {
         Self {
           a : self.a.min(rhs.a),
@@ -562,7 +562,7 @@ impl f32x8 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    is_nan.select(Self::splat(f32::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -919,14 +919,14 @@ impl f32x8 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -957,11 +957,11 @@ impl f32x8 {
 
     let x1 = f32x8::splat(0.5) * (f32x8::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -969,13 +969,13 @@ impl f32x8 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x8::ZERO).blend(f32x8::PI - z1, z1);
+    let z3 = self.simd_lt(f32x8::ZERO).select(f32x8::PI - z1, z1);
     let z4 = f32x8::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     // asin
     let z3 = f32x8::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     (asin, acos)
@@ -997,11 +997,11 @@ impl f32x8 {
 
     let x1 = f32x8::splat(0.5) * (f32x8::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1010,7 +1010,7 @@ impl f32x8 {
 
     // asin
     let z3 = f32x8::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z);
+    let asin = big.select(z3, z);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1032,11 +1032,11 @@ impl f32x8 {
 
     let x1 = f32x8::splat(0.5) * (f32x8::ONE - xa);
     let x2 = xa * xa;
-    let x3 = big.blend(x1, x2);
+    let x3 = big.select(x1, x2);
 
     let xb = x1.sqrt();
 
-    let x4 = big.blend(xb, xa);
+    let x4 = big.select(xb, xa);
 
     let z = polynomial_4!(x3, P0asinf, P1asinf, P2asinf, P3asinf, P4asinf);
     let z = z.mul_add(x3 * x4, x4);
@@ -1044,9 +1044,9 @@ impl f32x8 {
     let z1 = z + z;
 
     // acos
-    let z3 = self.simd_lt(f32x8::ZERO).blend(f32x8::PI - z1, z1);
+    let z3 = self.simd_lt(f32x8::ZERO).select(f32x8::PI - z1, z1);
     let z4 = f32x8::FRAC_PI_2 - z.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1068,13 +1068,13 @@ impl f32x8 {
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
     let notbig = t.simd_le(Self::SQRT_2 + Self::ONE);
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
 
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1084,7 +1084,7 @@ impl f32x8 {
     re = re.mul_add(zz * z, z) + s;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1105,15 +1105,15 @@ impl f32x8 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 will produce NAN. No problem, fixed below
@@ -1123,8 +1123,8 @@ impl f32x8 {
     // medium: z = (t-1.0) / (t+1.0);
     let notsmal = t.simd_ge(Self::SQRT_2 - Self::ONE);
 
-    let a = notsmal.blend(t - Self::ONE, t);
-    let b = notsmal.blend(t + Self::ONE, Self::ONE);
+    let a = notsmal.select(t - Self::ONE, t);
+    let b = notsmal.select(t + Self::ONE, Self::ONE);
     let s = notsmal & Self::FRAC_PI_4;
     let z = a / b;
 
@@ -1135,12 +1135,12 @@ impl f32x8 {
     re = re.mul_add(zz * z, z) + s;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1182,24 +1182,24 @@ impl f32x8 {
 
     let mut overflow: f32x8 = cast(q.simd_gt(i32x8::from(0x2000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f32x8::from(0.0), s);
-    c = overflow.blend(f32x8::from(1.0), c);
+    s = overflow.select(f32x8::from(0.0), s);
+    c = overflow.select(f32x8::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f32x8>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f32x8>(swap).select(c, s);
     let sign_sin: i32x8 = (q << 30) ^ cast::<_, i32x8>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f32x8>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f32x8>(swap).select(s, c);
     let sign_cos: i32x8 = ((q + i32x8::from(1)) & i32x8::from(2)) << 30;
     cos1 ^= cast::<_, f32x8>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f32::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1239,7 +1239,7 @@ impl f32x8 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1260,7 +1260,7 @@ impl f32x8 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1281,8 +1281,8 @@ impl f32x8 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1298,7 +1298,7 @@ impl f32x8 {
     let nan = self.is_nan();
 
     let tiny = a.simd_lt(Self::from(f32::MIN_POSITIVE));
-    let a_work = tiny.blend(a * Self::from(16777216.0), a);
+    let a_work = tiny.select(a * Self::from(16777216.0), a);
 
     let e = Self::exponent(a_work) + Self::ONE;
     let d = Self::fraction_2(a_work);
@@ -1330,20 +1330,20 @@ impl f32x8 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f32_as_f32x8!(CBRT2, 1.259921);
     const_f32_as_f32x8!(CBRT4, 1.587401);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(256.0_f32), y);
+    y = tiny.select(y / Self::from(256.0_f32), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1455,11 +1455,11 @@ impl f32x8 {
       let valid = self.simd_ge(f32x8::from(-149.0));
       let shift_f = self + f32x8::from(149.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i32x8>(valid).blend(shift_i, i32x8::ZERO);
+      shift_i = cast::<_, i32x8>(valid).select(shift_i, i32x8::ZERO);
       let mantissa = i32x8::ONE << shift_i;
       let sub_result = cast::<_, f32x8>(mantissa);
-      let sub_result = valid.blend(sub_result, f32x8::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f32x8::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1496,9 +1496,9 @@ impl f32x8 {
     let max_r = f32x8::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1508,14 +1508,14 @@ impl f32x8 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1551,9 +1551,9 @@ impl f32x8 {
     let max_r = f32x8::from(127.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1563,20 +1563,20 @@ impl f32x8 {
     let n2 = Self::vm_pow2n(r_safe);
     let exp_val = (z + Self::ONE) * scale * n2;
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -1604,9 +1604,9 @@ impl f32x8 {
     let round = self.round();
     let max_r = f32x8::from(127.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -1618,14 +1618,14 @@ impl f32x8 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1763,8 +1763,8 @@ impl f32x8 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(Self::SQRT_2 * HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let res = polynomial_8!(x, P0, P1, P2, P3, P4, P5, P6, P7, P8);
     let x2 = x * x;
@@ -1779,16 +1779,16 @@ impl f32x8 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~1.4e-45..1.175e-38) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -1809,9 +1809,9 @@ impl f32x8 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -1850,7 +1850,7 @@ impl f32x8 {
     let x1 = self.abs();
     let x = x1.fraction_2();
     let mask = x.simd_gt(f32x8::SQRT_2 * f32x8::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
 
     let x = x - f32x8::ONE;
     let x2 = x * x;
@@ -1860,7 +1860,7 @@ impl f32x8 {
     let lg1 = lg1 * x2 * x;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f32x8::ONE, ef);
+    let ef = mask.select(ef + f32x8::ONE, ef);
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
 
@@ -1894,15 +1894,15 @@ impl f32x8 {
     // Add exponent by integer addition
     let z = cast::<_, f32x8>(cast::<_, i32x8>(z) + (ei << 23));
     // Check for overflow/underflow
-    let z = underflow.blend(f32x8::ZERO, z);
-    let z = overflow.blend(Self::infinity(), z);
+    let z = underflow.select(f32x8::ZERO, z);
+    let z = overflow.select(Self::infinity(), z);
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f32x8::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f32x8::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x8::ZERO).blend(f32x8::ONE, f32x8::ZERO),
+        y.simd_eq(f32x8::ZERO).select(f32x8::ONE, f32x8::ZERO),
       ),
       z,
     );
@@ -1916,9 +1916,9 @@ impl f32x8 {
       let y_odd = cast::<_, i32x8>(y.round_int() << 31).round_float();
 
       let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
+        yi.select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
 
-      x_sign.blend(z1, z)
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -1930,7 +1930,7 @@ impl f32x8 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
   #[inline]
   pub fn powf(self, y: f32) -> Self {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -450,14 +450,14 @@ impl f32x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        Self { avx: blend_varying_m256(f.avx, t.avx, self.avx) }
+        Self { avx: blend_varying_m256(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -437,6 +437,15 @@ impl f32x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -706,10 +706,8 @@ impl f32x8 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i32_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else {
         let [a, b] = cast::<f32x8, [f32x4; 2]>(self);
         cast([a.round(), b.round()])

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -419,19 +419,19 @@ impl f32x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self {
           avx: bitor_m256(
-            bitand_m256(t.avx, self.avx),
-            bitandnot_m256(self.avx, f.avx),
+            bitand_m256(if_one.avx, self.avx),
+            bitandnot_m256(self.avx, if_zero.avx),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -410,6 +410,21 @@ impl f32x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: blend_varying_m256(f.avx, t.avx, self.avx) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
@@ -1915,8 +1930,8 @@ impl f32x8 {
       // Is y odd?
       let y_odd = cast::<_, i32x8>(y.round_int() << 31).round_float();
 
-      let z1 =
-        yi.select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
 
       x_sign.select(z1, z)
     } else {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -2084,6 +2084,8 @@ impl f32x8 {
     }
   }
 
+  fn_blend!();
+
   /// Returns true for each element if its sign bit is set.
   ///
   /// If the sign bit is set, the result has all bits set, not just the sign

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -441,8 +441,10 @@ impl f32x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -408,6 +408,15 @@ impl f32x8 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -410,11 +410,13 @@ impl f32x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -503,6 +503,22 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_m128d(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_f64(vreinterpretq_u64_f64(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -2507,6 +2507,8 @@ impl f64x2 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl From<i32x4> for f64x2 {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -503,7 +503,7 @@ impl f64x2 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_m128d(f.sse, t.sse, self.sse) }
@@ -536,7 +536,7 @@ impl f64x2 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -621,7 +621,7 @@ impl f64x2 {
         // max_m128d seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { sse: max_m128d(self.sse, rhs.sse) })
+        rhs.is_nan().select(self, Self { sse: max_m128d(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two max intrinsics:
         // - max: This propagates NaN, that's the opposite of what we need.
@@ -682,7 +682,7 @@ impl f64x2 {
         // min_m128d seems to do rhs < self ? rhs : self. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { sse: min_m128d(self.sse, rhs.sse) })
+        rhs.is_nan().select(self, Self { sse: min_m128d(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two min intrinsics:
         // - min: This propagates NaN, that's the opposite of what we need.
@@ -717,7 +717,7 @@ impl f64x2 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    is_nan.select(Self::splat(f64::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -742,8 +742,8 @@ impl f64x2 {
         // The standard library does not have NaN propagating `min` and `max`
         // functions.
         let mut result = self;
-        result = result.simd_lt(min).blend(min, result);
-        result = result.simd_gt(max).blend(max, result);
+        result = result.simd_lt(min).select(min, result);
+        result = result.simd_gt(max).select(max, result);
         result
       }
     }
@@ -809,7 +809,7 @@ impl f64x2 {
         let result = self + magic_value - magic_value;
 
         let bounds_mask = self.abs().simd_le(MAGIC_VALUE);
-        bounds_mask.abs().blend(result, self)
+        bounds_mask.abs().select(result, self)
       }
     }
   }
@@ -884,7 +884,7 @@ impl f64x2 {
         let bounds_mask: Self = cast(cast::<f64x2, i64x2>(self.abs()).simd_lt(i64x2::splat(BOUNDS_LIMIT)));
 
         // Reset the sign bit of the mask to preverse the sign of `self`.
-        bounds_mask.abs().blend(result, self)
+        bounds_mask.abs().select(result, self)
       }
     }
   }
@@ -1107,14 +1107,14 @@ impl f64x2 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -1162,7 +1162,7 @@ impl f64x2 {
 
     let big = xa.simd_ge(f64x2::splat(0.625));
 
-    let x1 = big.blend(f64x2::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x2::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1192,8 +1192,8 @@ impl f64x2 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1210,13 +1210,13 @@ impl f64x2 {
 
     // asin
     let z3 = f64x2::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     // acos
-    let z3 = self.simd_lt(f64x2::ZERO).blend(f64x2::PI - z1, z1);
+    let z3 = self.simd_lt(f64x2::ZERO).select(f64x2::PI - z1, z1);
     let z4 = f64x2::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     (asin, acos)
   }
@@ -1253,7 +1253,7 @@ impl f64x2 {
 
     let big = xa.simd_ge(f64x2::splat(0.625));
 
-    let x1 = big.blend(f64x2::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x2::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1283,8 +1283,8 @@ impl f64x2 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1300,9 +1300,9 @@ impl f64x2 {
     }
 
     // acos
-    let z3 = self.simd_lt(f64x2::ZERO).blend(f64x2::PI - z1, z1);
+    let z3 = self.simd_lt(f64x2::ZERO).select(f64x2::PI - z1, z1);
     let z4 = f64x2::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1339,7 +1339,7 @@ impl f64x2 {
 
     let big = xa.simd_ge(f64x2::splat(0.625));
 
-    let x1 = big.blend(f64x2::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x2::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1369,8 +1369,8 @@ impl f64x2 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1387,7 +1387,7 @@ impl f64x2 {
 
     // asin
     let z3 = f64x2::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1421,18 +1421,18 @@ impl f64x2 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1444,7 +1444,7 @@ impl f64x2 {
     re += s + fac;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1476,15 +1476,15 @@ impl f64x2 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 gives NAN here
@@ -1496,18 +1496,18 @@ impl f64x2 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1519,12 +1519,12 @@ impl f64x2 {
     re += s + fac;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1573,24 +1573,24 @@ impl f64x2 {
 
     let mut overflow: f64x2 = cast(q.simd_gt(i64x2::from(0x80000000000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f64x2::from(0.0), s);
-    c = overflow.blend(f64x2::from(1.0), c);
+    s = overflow.select(f64x2::from(0.0), s);
+    c = overflow.select(f64x2::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f64x2>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f64x2>(swap).select(c, s);
     let sign_sin: i64x2 = (q << 62) ^ cast::<_, i64x2>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f64x2>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f64x2>(swap).select(s, c);
     let sign_cos: i64x2 = ((q + i64x2::from(1)) & i64x2::from(2)) << 62;
     cos1 ^= cast::<_, f64x2>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f64::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1633,7 +1633,7 @@ impl f64x2 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1658,7 +1658,7 @@ impl f64x2 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1679,8 +1679,8 @@ impl f64x2 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1698,7 +1698,7 @@ impl f64x2 {
     const SUBN_SCALE: f64 = 1.8014398509481984e16;
     const SUBN_CBRT: f64 = 262144.0;
     let tiny = a.simd_lt(Self::from(f64::MIN_POSITIVE));
-    let a = tiny.blend(a * Self::from(SUBN_SCALE), a);
+    let a = tiny.select(a * Self::from(SUBN_SCALE), a);
 
     let e = Self::exponent(a) + Self::ONE;
     let d = Self::fraction_2(a);
@@ -1730,20 +1730,20 @@ impl f64x2 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f64_as_f64x2!(CBRT2, 1.2599210498948732);
     const_f64_as_f64x2!(CBRT4, 1.5874010519681994);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(SUBN_CBRT), y);
+    y = tiny.select(y / Self::from(SUBN_CBRT), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1864,11 +1864,11 @@ impl f64x2 {
       let valid = self.simd_ge(f64x2::from(-1074.0));
       let shift_f = self + f64x2::from(1074.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i64x2>(valid).blend(shift_i, i64x2::ZERO);
+      shift_i = cast::<_, i64x2>(valid).select(shift_i, i64x2::ZERO);
       let mantissa = i64x2::ONE << shift_i;
       let sub_result = cast::<_, f64x2>(mantissa);
-      let sub_result = valid.blend(sub_result, f64x2::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f64x2::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1906,9 +1906,9 @@ impl f64x2 {
     let max_r = f64x2::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1917,14 +1917,14 @@ impl f64x2 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1963,9 +1963,9 @@ impl f64x2 {
     let max_r = Self::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1977,20 +1977,20 @@ impl f64x2 {
     // Computing (z+1) - 1 would lose low bits for small x (catastrophic
     // cancellation at z ~ 0), so keep z directly.
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -2021,9 +2021,9 @@ impl f64x2 {
     let round = self.round();
     let max_r = f64x2::from(1023.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -2036,14 +2036,14 @@ impl f64x2 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -2193,8 +2193,8 @@ impl f64x2 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(VM_SQRT2 * f64x2::HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let px = polynomial_5!(x, P0, P1, P2, P3, P4, P5);
     let x2 = x * x;
@@ -2211,16 +2211,16 @@ impl f64x2 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~5e-324..2.225e-308) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -2241,9 +2241,9 @@ impl f64x2 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -2293,7 +2293,7 @@ impl f64x2 {
     let x1 = self.abs();
     let x = x1.fraction_2();
     let mask = x.simd_gt(f64x2::SQRT_2 * f64x2::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
     let x = x - f64x2::ONE;
     let x2 = x * x;
     let px = polynomial_6!(x, P0log, P1log, P2log, P3log, P4log, P5log, P6log);
@@ -2302,7 +2302,7 @@ impl f64x2 {
     let lg1 = px / qx;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f64x2::ONE, ef);
+    let ef = mask.select(ef + f64x2::ONE, ef);
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
 
@@ -2335,18 +2335,18 @@ impl f64x2 {
 
     // Check for overflow/underflow
     let z = if (overflow | underflow).any() {
-      let z = underflow.blend(f64x2::ZERO, z);
-      overflow.blend(Self::infinity(), z)
+      let z = underflow.select(f64x2::ZERO, z);
+      overflow.select(Self::infinity(), z)
     } else {
       z
     };
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f64x2::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f64x2::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x2::ZERO).blend(f64x2::ONE, f64x2::ZERO),
+        y.simd_eq(f64x2::ZERO).select(f64x2::ONE, f64x2::ZERO),
       ),
       z,
     );
@@ -2358,9 +2358,9 @@ impl f64x2 {
       // Is y odd?
       let y_odd = cast::<_, i64x2>(y.round_int() << 63).round_float();
 
-      let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
-      x_sign.blend(z1, z)
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -2373,7 +2373,7 @@ impl f64x2 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
 
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -503,11 +503,13 @@ impl f64x2 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -535,8 +535,10 @@ impl f64x2 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -505,8 +505,13 @@ impl f64x2 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_m128d(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128d(
+            bitand_m128d(t.sse, self.sse),
+            bitandnot_m128d(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -512,21 +512,21 @@ impl f64x2 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128d(
-            bitand_m128d(t.sse, self.sse),
-            bitandnot_m128d(self.sse, f.sse),
+            bitand_m128d(if_one.sse, self.sse),
+            bitandnot_m128d(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_f64(vreinterpretq_u64_f64(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_f64(vreinterpretq_u64_f64(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -501,6 +501,15 @@ impl f64x2 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -872,10 +872,8 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i64_m128i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else if #[cfg(target_feature="simd128")] {
         const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
         const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
@@ -891,10 +889,8 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask = Self { simd: i64x2_lt(self_abs.simd, BOUNDS_LIMIT.simd) };
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else {
         const_f64_as_f64x2!(HALF_NEXT_DOWN, 0.5_f64.next_down());
         const_f64_as_f64x2!(BOUNDS_LIMIT, 4503599627370496.0);
@@ -913,10 +909,8 @@ impl f64x2 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cast::<_, i64x2>(self_abs).simd_lt(cast::<_, i64x2>(BOUNDS_LIMIT)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       }
     }
   }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -531,6 +531,15 @@ impl f64x2 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -544,16 +544,16 @@ impl f64x2 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_m128d(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_m128d(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_f64(vreinterpretq_u64_f64(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_f64(vreinterpretq_u64_f64(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -705,10 +705,8 @@ impl f64x4 {
         // Large value, infinity and NaN need special handling.
         let bounds_mask: Self = cast(cmp_gt_mask_i64_m256i(cast(BOUNDS_LIMIT), cast(self_abs)));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else {
         let [a, b] = cast::<f64x4, [f64x2; 2]>(self);
         cast([a.round(), b.round()])

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -433,6 +433,15 @@ impl f64x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -409,7 +409,12 @@ impl f64x4 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        Self { avx: blend_varying_m256d(f.avx, t.avx, self.avx) }
+        Self {
+          avx: bitor_m256d(
+            bitand_m256d(t.avx, self.avx),
+            bitandnot_m256d(self.avx, f.avx),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -406,14 +406,14 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self { avx: blend_varying_m256d(f.avx, t.avx, self.avx) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -440,7 +440,7 @@ impl f64x4 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -501,7 +501,7 @@ impl f64x4 {
         // max_m256d seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx: max_m256d(self.avx, rhs.avx) })
+        rhs.is_nan().select(self, Self { avx: max_m256d(self.avx, rhs.avx) })
       } else {
         Self {
           a : self.a.max(rhs.a),
@@ -540,7 +540,7 @@ impl f64x4 {
         // min_m256d seems to do rhs < self ? self : rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
-        rhs.is_nan().blend(self, Self { avx: min_m256d(self.avx, rhs.avx) })
+        rhs.is_nan().select(self, Self { avx: min_m256d(self.avx, rhs.avx) })
       } else {
         Self {
           a : self.a.min(rhs.a),
@@ -559,7 +559,7 @@ impl f64x4 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    is_nan.select(Self::splat(f64::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -930,14 +930,14 @@ impl f64x4 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -985,7 +985,7 @@ impl f64x4 {
 
     let big = xa.simd_ge(f64x4::splat(0.625));
 
-    let x1 = big.blend(f64x4::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x4::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1016,8 +1016,8 @@ impl f64x4 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1034,13 +1034,13 @@ impl f64x4 {
 
     // asin
     let z3 = f64x4::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     // acos
-    let z3 = self.simd_lt(f64x4::ZERO).blend(f64x4::PI - z1, z1);
+    let z3 = self.simd_lt(f64x4::ZERO).select(f64x4::PI - z1, z1);
     let z4 = f64x4::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     (asin, acos)
   }
@@ -1077,7 +1077,7 @@ impl f64x4 {
 
     let big = xa.simd_ge(f64x4::splat(0.625));
 
-    let x1 = big.blend(f64x4::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x4::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1107,8 +1107,8 @@ impl f64x4 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1124,9 +1124,9 @@ impl f64x4 {
     }
 
     // acos
-    let z3 = self.simd_lt(f64x4::ZERO).blend(f64x4::PI - z1, z1);
+    let z3 = self.simd_lt(f64x4::ZERO).select(f64x4::PI - z1, z1);
     let z4 = f64x4::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1163,7 +1163,7 @@ impl f64x4 {
 
     let big = xa.simd_ge(f64x4::splat(0.625));
 
-    let x1 = big.blend(f64x4::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x4::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1193,8 +1193,8 @@ impl f64x4 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1211,7 +1211,7 @@ impl f64x4 {
 
     // asin
     let z3 = f64x4::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1245,18 +1245,18 @@ impl f64x4 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1268,7 +1268,7 @@ impl f64x4 {
     re += s + fac;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1300,15 +1300,15 @@ impl f64x4 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 gives NAN here
@@ -1320,18 +1320,18 @@ impl f64x4 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1343,12 +1343,12 @@ impl f64x4 {
     re += s + fac;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1397,24 +1397,24 @@ impl f64x4 {
 
     let mut overflow: f64x4 = cast(q.simd_gt(i64x4::from(0x80000000000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f64x4::from(0.0), s);
-    c = overflow.blend(f64x4::from(1.0), c);
+    s = overflow.select(f64x4::from(0.0), s);
+    c = overflow.select(f64x4::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f64x4>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f64x4>(swap).select(c, s);
     let sign_sin: i64x4 = (q << 62) ^ cast::<_, i64x4>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f64x4>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f64x4>(swap).select(s, c);
     let sign_cos: i64x4 = ((q + i64x4::from(1)) & i64x4::from(2)) << 62;
     cos1 ^= cast::<_, f64x4>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f64::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1457,7 +1457,7 @@ impl f64x4 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1482,7 +1482,7 @@ impl f64x4 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1503,8 +1503,8 @@ impl f64x4 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1522,7 +1522,7 @@ impl f64x4 {
     const SUBN_SCALE: f64 = 1.8014398509481984e16;
     const SUBN_CBRT: f64 = 262144.0;
     let tiny = a.simd_lt(Self::from(f64::MIN_POSITIVE));
-    let a = tiny.blend(a * Self::from(SUBN_SCALE), a);
+    let a = tiny.select(a * Self::from(SUBN_SCALE), a);
 
     let e = Self::exponent(a) + Self::ONE;
     let d = Self::fraction_2(a);
@@ -1554,20 +1554,20 @@ impl f64x4 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f64_as_f64x4!(CBRT2, 1.2599210498948732);
     const_f64_as_f64x4!(CBRT4, 1.5874010519681994);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(SUBN_CBRT), y);
+    y = tiny.select(y / Self::from(SUBN_CBRT), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1668,11 +1668,11 @@ impl f64x4 {
       let valid = self.simd_ge(f64x4::from(-1074.0));
       let shift_f = self + f64x4::from(1074.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i64x4>(valid).blend(shift_i, i64x4::ZERO);
+      shift_i = cast::<_, i64x4>(valid).select(shift_i, i64x4::ZERO);
       let mantissa = i64x4::ONE << shift_i;
       let sub_result = cast::<_, f64x4>(mantissa);
-      let sub_result = valid.blend(sub_result, f64x4::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f64x4::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1710,9 +1710,9 @@ impl f64x4 {
     let max_r = f64x4::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1721,14 +1721,14 @@ impl f64x4 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1767,9 +1767,9 @@ impl f64x4 {
     let max_r = f64x4::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1781,20 +1781,20 @@ impl f64x4 {
     // Computing (z+1) - 1 would lose low bits for small x (catastrophic
     // cancellation at z ~ 0), so keep z directly.
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -1825,9 +1825,9 @@ impl f64x4 {
     let round = self.round();
     let max_r = f64x4::from(1023.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -1840,14 +1840,14 @@ impl f64x4 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1985,8 +1985,8 @@ impl f64x4 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(VM_SQRT2 * HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let px = polynomial_5!(x, P0, P1, P2, P3, P4, P5);
     let x2 = x * x;
@@ -2003,16 +2003,16 @@ impl f64x4 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~5e-324..2.225e-308) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -2033,9 +2033,9 @@ impl f64x4 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -2085,7 +2085,7 @@ impl f64x4 {
     let x1 = self.abs();
     let x = x1.fraction_2();
     let mask = x.simd_gt(f64x4::SQRT_2 * f64x4::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
     let x = x - f64x4::ONE;
     let x2 = x * x;
     let px = polynomial_6!(x, P0log, P1log, P2log, P3log, P4log, P5log, P6log);
@@ -2094,7 +2094,7 @@ impl f64x4 {
     let lg1 = px / qx;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f64x4::ONE, ef);
+    let ef = mask.select(ef + f64x4::ONE, ef);
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
 
@@ -2127,18 +2127,18 @@ impl f64x4 {
 
     // Check for overflow/underflow
     let z = if (overflow | underflow).any() {
-      let z = underflow.blend(f64x4::ZERO, z);
-      overflow.blend(Self::infinity(), z)
+      let z = underflow.select(f64x4::ZERO, z);
+      overflow.select(Self::infinity(), z)
     } else {
       z
     };
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f64x4::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f64x4::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x4::ZERO).blend(f64x4::ONE, f64x4::ZERO),
+        y.simd_eq(f64x4::ZERO).select(f64x4::ONE, f64x4::ZERO),
       ),
       z,
     );
@@ -2150,9 +2150,9 @@ impl f64x4 {
       let yi = y.simd_eq(y.round());
       // Is y odd?
       let y_odd = cast::<_, i64x4>(y.round_int() << 63).round_float();
-      let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
-      x_sign.blend(z1, z)
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -2165,7 +2165,7 @@ impl f64x4 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
   #[inline]
   pub fn powf(self, y: f64) -> Self {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -2314,6 +2314,8 @@ impl f64x4 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl From<i32x4> for f64x4 {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -437,8 +437,10 @@ impl f64x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -446,14 +446,14 @@ impl f64x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        Self { avx: blend_varying_m256d(f.avx, t.avx, self.avx) }
+        Self { avx: blend_varying_m256d(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -406,11 +406,13 @@ impl f64x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -404,6 +404,15 @@ impl f64x4 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -415,19 +415,19 @@ impl f64x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
         Self {
           avx: bitor_m256d(
-            bitand_m256d(t.avx, self.avx),
-            bitandnot_m256d(self.avx, f.avx),
+            bitand_m256d(if_one.avx, self.avx),
+            bitandnot_m256d(self.avx, if_zero.avx),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -406,6 +406,21 @@ impl f64x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        Self { avx: blend_varying_m256d(f.avx, t.avx, self.avx) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -429,6 +429,15 @@ impl f64x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -405,7 +405,12 @@ impl f64x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_m512d(f.avx512, t.avx512, movepi64_mask_m512d(self.avx512)) }
+        Self {
+          avx512: bitor_m512d(
+            bitand_m512d(t.avx512, self.avx512),
+            bitandnot_m512d(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -411,19 +411,19 @@ impl f64x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512d(
-            bitand_m512d(t.avx512, self.avx512),
-            bitandnot_m512d(self.avx512, f.avx512),
+            bitand_m512d(if_one.avx512, self.avx512),
+            bitandnot_m512d(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -686,10 +686,8 @@ impl f64x8 {
           cast(BOUNDS_LIMIT),
         ));
 
-        // `abs` keeps the original sign. `blend` cannot be used here because it
-        // doesn't work as an arbitrary bit-blend.
-        let bounds_mask = bounds_mask.abs();
-        result_abs & bounds_mask | self & !bounds_mask
+        // `abs` keeps the original sign.
+        bounds_mask.abs().bitselect(result_abs, self)
       } else {
         Self {
           a: self.a.round(),

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -402,6 +402,21 @@ impl f64x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_m512d(f.avx512, t.avx512, movepi64_mask_m512d(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
@@ -2144,8 +2159,8 @@ impl f64x8 {
       let yi = y.simd_eq(y.round());
       // Is y odd?
       let y_odd = cast::<_, i64x8>(y.round_int() << 63).round_float();
-      let z1 =
-        yi.select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      let z1 = yi
+        .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
       x_sign.select(z1, z)
     } else {
       z

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -2274,6 +2274,8 @@ impl f64x8 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl From<i32x8> for f64x8 {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -442,14 +442,14 @@ impl f64x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_m512d(f.avx512, t.avx512, movepi64_mask_m512d(self.avx512)) }
+        Self { avx512: blend_varying_m512d(if_false.avx512, if_true.avx512, movepi64_mask_m512d(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -402,11 +402,13 @@ impl f64x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -402,14 +402,14 @@ impl f64x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_m512d(f.avx512, t.avx512, movepi64_mask_m512d(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -436,7 +436,7 @@ impl f64x8 {
   pub fn signum(self) -> Self {
     let result = Self::ONE | self & -Self::ZERO;
 
-    self.is_nan().blend(self, result)
+    self.is_nan().select(self, result)
   }
 
   #[inline]
@@ -488,7 +488,7 @@ impl f64x8 {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        rhs.is_nan().blend(self, Self { avx512: max_m512d(self.avx512, rhs.avx512) })
+        rhs.is_nan().select(self, Self { avx512: max_m512d(self.avx512, rhs.avx512) })
       } else {
         Self {
           a: self.a.max(rhs.a),
@@ -518,7 +518,7 @@ impl f64x8 {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        rhs.is_nan().blend(self, Self { avx512: min_m512d(self.avx512, rhs.avx512) })
+        rhs.is_nan().select(self, Self { avx512: min_m512d(self.avx512, rhs.avx512) })
       } else {
         Self {
           a: self.a.min(rhs.a),
@@ -537,7 +537,7 @@ impl f64x8 {
   pub fn clamp(self, min: Self, max: Self) -> Self {
     let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
     let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    is_nan.select(Self::splat(f64::NAN), clamped)
   }
 
   /// Restrict a value to a certain interval unless it is NaN.
@@ -920,14 +920,14 @@ impl f64x8 {
     let q = (self / rhs).trunc();
     (self % rhs)
       .simd_lt(Self::ZERO)
-      .blend(rhs.simd_gt(Self::ZERO).blend(q - Self::ONE, q + Self::ONE), q)
+      .select(rhs.simd_gt(Self::ZERO).select(q - Self::ONE, q + Self::ONE), q)
   }
 
   #[inline]
   #[must_use]
   pub fn rem_euclid(self, rhs: Self) -> Self {
     let r = self % rhs;
-    r.simd_lt(Self::ZERO).blend(r + rhs.abs(), r)
+    r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
   }
 
   #[inline]
@@ -975,7 +975,7 @@ impl f64x8 {
 
     let big = xa.simd_ge(f64x8::splat(0.625));
 
-    let x1 = big.blend(f64x8::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x8::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1006,8 +1006,8 @@ impl f64x8 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1024,13 +1024,13 @@ impl f64x8 {
 
     // asin
     let z3 = f64x8::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     // acos
-    let z3 = self.simd_lt(f64x8::ZERO).blend(f64x8::PI - z1, z1);
+    let z3 = self.simd_lt(f64x8::ZERO).select(f64x8::PI - z1, z1);
     let z4 = f64x8::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     (asin, acos)
   }
@@ -1067,7 +1067,7 @@ impl f64x8 {
 
     let big = xa.simd_ge(f64x8::splat(0.625));
 
-    let x1 = big.blend(f64x8::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x8::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1097,8 +1097,8 @@ impl f64x8 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1114,9 +1114,9 @@ impl f64x8 {
     }
 
     // acos
-    let z3 = self.simd_lt(f64x8::ZERO).blend(f64x8::PI - z1, z1);
+    let z3 = self.simd_lt(f64x8::ZERO).select(f64x8::PI - z1, z1);
     let z4 = f64x8::FRAC_PI_2 - z2.flip_signs(self);
-    let acos = big.blend(z3, z4);
+    let acos = big.select(z3, z4);
 
     acos
   }
@@ -1153,7 +1153,7 @@ impl f64x8 {
 
     let big = xa.simd_ge(f64x8::splat(0.625));
 
-    let x1 = big.blend(f64x8::splat(1.0) - xa, xa * xa);
+    let x1 = big.select(f64x8::splat(1.0) - xa, xa * xa);
 
     let x2 = x1 * x1;
     let x3 = x2 * x1;
@@ -1183,8 +1183,8 @@ impl f64x8 {
         + x2.mul_add(Q2asin, Q0asin);
     };
 
-    let vx = big.blend(rx, px);
-    let wx = big.blend(sx, qx);
+    let vx = big.select(rx, px);
+    let wx = big.select(sx, qx);
 
     let y1 = vx / wx * x1;
 
@@ -1201,7 +1201,7 @@ impl f64x8 {
 
     // asin
     let z3 = f64x8::FRAC_PI_2 - z1;
-    let asin = big.blend(z3, z2);
+    let asin = big.select(z3, z2);
     let asin = asin.flip_signs(self);
 
     asin
@@ -1235,18 +1235,18 @@ impl f64x8 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1258,7 +1258,7 @@ impl f64x8 {
     re += s + fac;
 
     // get sign bit
-    re = (self.is_sign_negative()).blend(-re, re);
+    re = (self.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1290,15 +1290,15 @@ impl f64x8 {
     let y1 = y.abs();
     let swapxy = y1.simd_gt(x1);
     // swap x and y if y1 > x1
-    let mut x2 = swapxy.blend(y1, x1);
-    let mut y2 = swapxy.blend(x1, y1);
+    let mut x2 = swapxy.select(y1, x1);
+    let mut y2 = swapxy.select(x1, y1);
 
     // check for special case: x and y are both +/- INF
     let both_infinite = x.is_inf() & y.is_inf();
     if both_infinite.any() {
       let minus_one = -Self::ONE;
-      x2 = both_infinite.blend(x2 & minus_one, x2);
-      y2 = both_infinite.blend(y2 & minus_one, y2);
+      x2 = both_infinite.select(x2 & minus_one, x2);
+      y2 = both_infinite.select(y2 & minus_one, y2);
     }
 
     // x = y = 0 gives NAN here
@@ -1310,18 +1310,18 @@ impl f64x8 {
     let notbig = t.simd_le(T3PO8);
     let notsmal = t.simd_ge(Self::splat(0.66));
 
-    let mut s = notbig.blend(Self::FRAC_PI_4, Self::FRAC_PI_2);
+    let mut s = notbig.select(Self::FRAC_PI_4, Self::FRAC_PI_2);
     s = notsmal & s;
-    let mut fac = notbig.blend(MORE_BITS_O2, MORE_BITS);
+    let mut fac = notbig.select(MORE_BITS_O2, MORE_BITS);
     fac = notsmal & fac;
 
     // small:  z = t / 1.0;
     // medium: z = (t-1.0) / (t+1.0);
     // big:    z = -1.0 / t;
     let mut a = notbig & t;
-    a = notsmal.blend(a - Self::ONE, a);
+    a = notsmal.select(a - Self::ONE, a);
     let mut b = notbig & Self::ONE;
-    b = notsmal.blend(b + t, b);
+    b = notsmal.select(b + t, b);
     let z = a / b;
 
     let zz = z * z;
@@ -1333,12 +1333,12 @@ impl f64x8 {
     re += s + fac;
 
     // move back in place
-    re = swapxy.blend(Self::FRAC_PI_2 - re, re);
-    re = ((x | y).simd_eq(Self::ZERO)).blend(Self::ZERO, re);
-    re = (x.is_sign_negative()).blend(Self::PI - re, re);
+    re = swapxy.select(Self::FRAC_PI_2 - re, re);
+    re = ((x | y).simd_eq(Self::ZERO)).select(Self::ZERO, re);
+    re = (x.is_sign_negative()).select(Self::PI - re, re);
 
     // get sign bit
-    re = (y.is_sign_negative()).blend(-re, re);
+    re = (y.is_sign_negative()).select(-re, re);
 
     re
   }
@@ -1387,24 +1387,24 @@ impl f64x8 {
 
     let mut overflow: f64x8 = cast(q.simd_gt(i64x8::from(0x80000000000000)));
     overflow &= xa.is_finite();
-    s = overflow.blend(f64x8::from(0.0), s);
-    c = overflow.blend(f64x8::from(1.0), c);
+    s = overflow.select(f64x8::from(0.0), s);
+    c = overflow.select(f64x8::from(1.0), c);
 
     // calc sin
-    let mut sin1 = cast::<_, f64x8>(swap).blend(c, s);
+    let mut sin1 = cast::<_, f64x8>(swap).select(c, s);
     let sign_sin: i64x8 = (q << 62) ^ cast::<_, i64x8>(self);
     sin1 = sin1.flip_signs(cast(sign_sin));
 
     // calc cos
-    let mut cos1 = cast::<_, f64x8>(swap).blend(s, c);
+    let mut cos1 = cast::<_, f64x8>(swap).select(s, c);
     let sign_cos: i64x8 = ((q + i64x8::from(1)) & i64x8::from(2)) << 62;
     cos1 ^= cast::<_, f64x8>(sign_cos);
 
     // IEEE 754: sin/cos(±∞) = NaN, sin/cos(NaN) = NaN
     let finite = self.is_finite();
     let nan = Self::splat(f64::NAN);
-    let sin_final = finite.blend(sin1, nan);
-    let cos_final = finite.blend(cos1, nan);
+    let sin_final = finite.select(sin1, nan);
+    let cos_final = finite.select(cos1, nan);
 
     (sin_final, cos_final)
   }
@@ -1447,7 +1447,7 @@ impl f64x8 {
       let e = a.exp();
       (e - Self::ONE / e) * Self::HALF
     };
-    let result = small.blend(poly, exp_based);
+    let result = small.select(poly, exp_based);
     result.flip_signs(self)
   }
 
@@ -1472,7 +1472,7 @@ impl f64x8 {
       let e = a.exp();
       (e + Self::ONE / e) * Self::HALF
     };
-    small.blend(poly, exp_based)
+    small.select(poly, exp_based)
   }
 
   /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
@@ -1493,8 +1493,8 @@ impl f64x8 {
       let pos = -t / (t + Self::from(2.0));
       pos.flip_signs(self)
     };
-    let result = small.blend(self, exp_based);
-    large.blend(Self::ONE.flip_signs(self), result)
+    let result = small.select(self, exp_based);
+    large.select(Self::ONE.flip_signs(self), result)
   }
 
   /// Calculates the cube root: `self^(1/3)`.
@@ -1512,7 +1512,7 @@ impl f64x8 {
     const SUBN_SCALE: f64 = 1.8014398509481984e16;
     const SUBN_CBRT: f64 = 262144.0;
     let tiny = a.simd_lt(Self::from(f64::MIN_POSITIVE));
-    let a = tiny.blend(a * Self::from(SUBN_SCALE), a);
+    let a = tiny.select(a * Self::from(SUBN_SCALE), a);
 
     let e = Self::exponent(a) + Self::ONE;
     let d = Self::fraction_2(a);
@@ -1544,20 +1544,20 @@ impl f64x8 {
     let three = Self::from(3.0);
     let two = Self::from(2.0);
     let neg = e.simd_lt(Self::ZERO);
-    let e_adj = neg.blend(e - two, e);
+    let e_adj = neg.select(e - two, e);
     let k = (e_adj / three).trunc();
     let r = e - three * k;
     const_f64_as_f64x8!(CBRT2, 1.2599210498948732);
     const_f64_as_f64x8!(CBRT4, 1.5874010519681994);
-    y = r.simd_eq(Self::ONE).blend(y * CBRT2, y);
-    y = r.simd_eq(two).blend(y * CBRT4, y);
+    y = r.simd_eq(Self::ONE).select(y * CBRT2, y);
+    y = r.simd_eq(two).select(y * CBRT4, y);
     y *= Self::vm_pow2n(k);
-    y = tiny.blend(y / Self::from(SUBN_CBRT), y);
+    y = tiny.select(y / Self::from(SUBN_CBRT), y);
 
     let result = y.flip_signs(self);
-    let result = nan.blend(self, result);
-    let result = zero.blend(self, result);
-    let result = inf.blend(self, result);
+    let result = nan.select(self, result);
+    let result = zero.select(self, result);
+    let result = inf.select(self, result);
     result
   }
 
@@ -1659,11 +1659,11 @@ impl f64x8 {
       let valid = self.simd_ge(f64x8::from(-1074.0));
       let shift_f = self + f64x8::from(1074.0);
       let mut shift_i = shift_f.trunc_int();
-      shift_i = cast::<_, i64x8>(valid).blend(shift_i, i64x8::ZERO);
+      shift_i = cast::<_, i64x8>(valid).select(shift_i, i64x8::ZERO);
       let mantissa = i64x8::ONE << shift_i;
       let sub_result = cast::<_, f64x8>(mantissa);
-      let sub_result = valid.blend(sub_result, f64x8::ZERO);
-      is_sub.blend(sub_result, std_result)
+      let sub_result = valid.select(sub_result, f64x8::ZERO);
+      is_sub.select(sub_result, std_result)
     } else {
       std_result
     }
@@ -1701,9 +1701,9 @@ impl f64x8 {
     let max_r = f64x8::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1712,14 +1712,14 @@ impl f64x8 {
     let n2 = Self::vm_pow2n(r_safe);
     let z = (z + Self::ONE) * scale * n2;
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1758,9 +1758,9 @@ impl f64x8 {
     let max_r = f64x8::from(1023.0);
     let r = (self * Self::LOG2_E).round();
     let big = r.simd_gt(max_r);
-    let r_safe = big.blend(max_r, r);
+    let r_safe = big.select(max_r, r);
     let excess = r - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
     let x = r.mul_neg_add(LN2D_HI, self);
     let x = r.mul_neg_add(LN2D_LO, x);
@@ -1772,20 +1772,20 @@ impl f64x8 {
     // Computing (z+1) - 1 would lose low bits for small x (catastrophic
     // cancellation at z ~ 0), so keep z directly.
     let r_is_zero = r.simd_eq(Self::ZERO);
-    let z = r_is_zero.blend(z, exp_val - Self::ONE);
+    let z = r_is_zero.select(z, exp_val - Self::ONE);
     let nan_mask = self.is_nan();
     let finite = self.is_finite();
-    let mut result = nan_mask.blend(Self::nan_pow(), z);
+    let mut result = nan_mask.select(Self::nan_pow(), z);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
+    result = pos_overflow.select(Self::infinity(), result);
     let neg_underflow = self.simd_lt(min_x) & finite;
-    result = neg_underflow.blend(-Self::ONE, result);
+    result = neg_underflow.select(-Self::ONE, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(-Self::ONE, result);
+    result = neg_inf.select(-Self::ONE, result);
     let is_zero = self.simd_eq(Self::ZERO);
-    result = is_zero.blend(self, result);
+    result = is_zero.select(self, result);
     result
   }
 
@@ -1816,9 +1816,9 @@ impl f64x8 {
     let round = self.round();
     let max_r = f64x8::from(1023.0);
     let big = round.simd_gt(max_r);
-    let r_safe = big.blend(max_r, round);
+    let r_safe = big.select(max_r, round);
     let excess = round - max_r;
-    let excess = big.blend(excess, Self::ZERO);
+    let excess = big.select(excess, Self::ZERO);
     let scale = Self::vm_pow2n(excess);
 
     let fract = (self - round) * Self::LN_2;
@@ -1831,14 +1831,14 @@ impl f64x8 {
     let result = fract_exp2 * scale * n2;
 
     let nan_mask = self.is_nan();
-    let mut result = nan_mask.blend(Self::nan_pow(), result);
+    let mut result = nan_mask.select(Self::nan_pow(), result);
     let pos_overflow = self.simd_gt(max_x) & finite;
-    result = pos_overflow.blend(Self::infinity(), result);
-    result = neg_underflow.blend(Self::ZERO, result);
+    result = pos_overflow.select(Self::infinity(), result);
+    result = neg_underflow.select(Self::ZERO, result);
     let pos_inf = !finite & !self.is_sign_negative() & !nan_mask;
-    result = pos_inf.blend(Self::infinity(), result);
+    result = pos_inf.select(Self::infinity(), result);
     let neg_inf = !finite & self.is_sign_negative() & !nan_mask;
-    result = neg_inf.blend(Self::ZERO, result);
+    result = neg_inf.select(Self::ZERO, result);
     result
   }
 
@@ -1979,8 +1979,8 @@ impl f64x8 {
     let x = Self::fraction_2(x1);
     let e = Self::exponent(x1);
     let mask = x.simd_gt(VM_SQRT2 * HALF);
-    let x = (!mask).blend(x + x, x);
-    let fe = mask.blend(e + Self::ONE, e);
+    let x = (!mask).select(x + x, x);
+    let fe = mask.select(e + Self::ONE, e);
     let x = x - Self::ONE;
     let px = polynomial_5!(x, P0, P1, P2, P3, P4, P5);
     let x2 = x * x;
@@ -1997,16 +1997,16 @@ impl f64x8 {
       res
     } else {
       let is_zero = self.is_zero_or_subnormal();
-      let res = underflow.blend(Self::nan_log(), res);
+      let res = underflow.select(Self::nan_log(), res);
       // Note: is_zero_or_subnormal() lumps subnormals (exponent==0) with zero.
       // Both get -Inf here. True subnormal inputs (~5e-324..2.225e-308) should
       // produce a finite negative result, but are vanishingly rare in
       // practice.
-      let res = is_zero.blend(-Self::infinity(), res);
-      let res = overflow.blend(self, res);
+      let res = is_zero.select(-Self::infinity(), res);
+      let res = overflow.select(self, res);
       // This must come *after* overflow.blend to overwrite ln(-∞) = -∞ to NaN
       let res = (!self.is_finite() & self.is_sign_negative())
-        .blend(Self::nan_log(), res);
+        .select(Self::nan_log(), res);
       res
     }
   }
@@ -2027,9 +2027,9 @@ impl f64x8 {
     let eq = u.simd_eq(Self::ONE);
     let ln_u = Self::ln(u);
     let correction = self * (ln_u / (u - Self::ONE));
-    let result = eq.blend(self, correction);
+    let result = eq.select(self, correction);
     let over = u.is_inf();
-    over.blend(ln_u, result)
+    over.select(ln_u, result)
   }
 
   #[inline]
@@ -2079,7 +2079,7 @@ impl f64x8 {
     let x1 = self.abs();
     let x = x1.fraction_2();
     let mask = x.simd_gt(f64x8::SQRT_2 * f64x8::HALF);
-    let x = (!mask).blend(x + x, x);
+    let x = (!mask).select(x + x, x);
     let x = x - f64x8::ONE;
     let x2 = x * x;
     let px = polynomial_6!(x, P0log, P1log, P2log, P3log, P4log, P5log, P6log);
@@ -2088,7 +2088,7 @@ impl f64x8 {
     let lg1 = px / qx;
 
     let ef = x1.exponent();
-    let ef = mask.blend(ef + f64x8::ONE, ef);
+    let ef = mask.select(ef + f64x8::ONE, ef);
     let e1 = (ef * y).round();
     let yr = ef.mul_sub(y, e1);
 
@@ -2121,18 +2121,18 @@ impl f64x8 {
 
     // Check for overflow/underflow
     let z = if (overflow | underflow).any() {
-      let z = underflow.blend(f64x8::ZERO, z);
-      overflow.blend(Self::infinity(), z)
+      let z = underflow.select(f64x8::ZERO, z);
+      overflow.select(Self::infinity(), z)
     } else {
       z
     };
 
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
-    let z = x_zero.blend(
-      y.simd_lt(f64x8::ZERO).blend(
+    let z = x_zero.select(
+      y.simd_lt(f64x8::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x8::ZERO).blend(f64x8::ONE, f64x8::ZERO),
+        y.simd_eq(f64x8::ZERO).select(f64x8::ONE, f64x8::ZERO),
       ),
       z,
     );
@@ -2145,8 +2145,8 @@ impl f64x8 {
       // Is y odd?
       let y_odd = cast::<_, i64x8>(y.round_int() << 63).round_float();
       let z1 =
-        yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
-      x_sign.blend(z1, z)
+        yi.select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
+      x_sign.select(z1, z)
     } else {
       z
     };
@@ -2159,7 +2159,7 @@ impl f64x8 {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).blend(self + y, z)
+    (self.is_nan() | y.is_nan()).select(self + y, z)
   }
 
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -400,6 +400,15 @@ impl f64x8 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -433,8 +433,10 @@ impl f64x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -562,14 +562,14 @@ impl i16x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -874,4 +874,6 @@ impl i16x16 {
   pub fn as_mut_array(&mut self) -> &mut [i16; 16] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -531,19 +531,19 @@ impl i16x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -520,6 +520,15 @@ impl i16x16 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -522,6 +522,21 @@ impl i16x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -553,8 +553,10 @@ impl i16x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -522,11 +522,13 @@ impl i16x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -525,7 +525,12 @@ impl i16x16 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -549,6 +549,15 @@ impl i16x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -522,14 +522,14 @@ impl i16x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -400,6 +400,21 @@ impl i16x32 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -409,19 +409,19 @@ impl i16x32 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -398,6 +398,15 @@ impl i16x32 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -400,14 +400,14 @@ impl i16x32 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -431,8 +431,10 @@ impl i16x32 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -400,11 +400,13 @@ impl i16x32 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -784,6 +784,8 @@ impl i16x32 {
   pub fn as_mut_array(&mut self) -> &mut [i16; 32] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }
 
 impl Not for i16x32 {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -427,6 +427,15 @@ impl i16x32 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -403,7 +403,12 @@ impl i16x32 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -440,14 +440,14 @@ impl i16x32 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1598,4 +1598,6 @@ impl i16x8 {
   pub fn as_mut_array(&mut self) -> &mut [i16; 8] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -865,8 +865,10 @@ impl i16x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -833,6 +833,22 @@ impl i16x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_s16(vreinterpretq_u16_s16(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -874,16 +874,16 @@ impl i16x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s16(vreinterpretq_u16_s16(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s16(vreinterpretq_u16_s16(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -835,8 +835,13 @@ impl i16x8 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -842,21 +842,21 @@ impl i16x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s16(vreinterpretq_u16_s16(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s16(vreinterpretq_u16_s16(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -833,7 +833,7 @@ impl i16x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -1089,7 +1089,7 @@ impl i16x8 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vmaxq_s16(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(rhs, self)
+        self.simd_lt(rhs).select(rhs, self)
       }
     }
   }
@@ -1104,7 +1104,7 @@ impl i16x8 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vminq_s16(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(self, rhs)
+        self.simd_lt(rhs).select(self, rhs)
       }
     }
   }
@@ -1173,7 +1173,7 @@ impl i16x8 {
 
         let no_overflow = high.simd_eq(low.is_negative());
         let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.blend(low, limit)
+        no_overflow.select(low, limit)
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_s16_s32(
@@ -1188,7 +1188,7 @@ impl i16x8 {
 
           let no_overflow = high.simd_eq(low.is_negative());
           let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.blend(low, limit)
+          no_overflow.select(low, limit)
         }
       } else {
         let self_array = self.to_array();

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -833,11 +833,13 @@ impl i16x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -831,6 +831,15 @@ impl i16x8 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -861,6 +861,15 @@ impl i16x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -406,19 +406,19 @@ impl i32x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -783,6 +783,8 @@ impl i32x16 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl Not for i32x16 {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -437,14 +437,14 @@ impl i32x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -424,6 +424,15 @@ impl i32x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -395,6 +395,15 @@ impl i32x16 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -397,14 +397,14 @@ impl i32x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -487,7 +487,7 @@ impl i32x16 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -506,7 +506,7 @@ impl i32x16 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),
@@ -545,7 +545,7 @@ impl i32x16 {
 
         let no_overflow = high.simd_eq(low.is_negative());
         let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.blend(low, limit)
+        no_overflow.select(low, limit)
       } else {
         let [self_a, self_b]: [i32x8; 2] = cast(self);
         let [rhs_a, rhs_b]: [i32x8; 2] = cast(rhs);

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -428,8 +428,10 @@ impl i32x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -397,6 +397,21 @@ impl i32x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -400,7 +400,12 @@ impl i32x16 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -397,11 +397,13 @@ impl i32x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -542,8 +542,13 @@ impl i32x4 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -549,21 +549,21 @@ impl i32x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s32(vreinterpretq_u32_s32(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s32(vreinterpretq_u32_s32(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -540,6 +540,22 @@ impl i32x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_s32(vreinterpretq_u32_s32(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -540,11 +540,13 @@ impl i32x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -581,16 +581,16 @@ impl i32x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s32(vreinterpretq_u32_s32(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s32(vreinterpretq_u32_s32(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -538,6 +538,15 @@ impl i32x4 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -540,7 +540,7 @@ impl i32x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -753,7 +753,7 @@ impl i32x4 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vmaxq_s32(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(rhs, self)
+        self.simd_lt(rhs).select(rhs, self)
       }
     }
   }
@@ -768,7 +768,7 @@ impl i32x4 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vminq_s32(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(self, rhs)
+        self.simd_lt(rhs).select(self, rhs)
       }
     }
   }
@@ -784,7 +784,7 @@ impl i32x4 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqaddq_s32(self.neon, rhs.neon) } }
       } else {
@@ -809,7 +809,7 @@ impl i32x4 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqsubq_s32(self.neon, rhs.neon) } }
       } else {
@@ -844,7 +844,7 @@ impl i32x4 {
 
         let no_overflow = high.simd_eq(low.is_negative());
         let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.blend(low, limit)
+        no_overflow.select(low, limit)
       } else if #[cfg(target_feature="simd128")] {
         let low_wide_mul = i64x2_extmul_low_i32x4(self.simd, rhs.simd);
         let high_wide_mul = i64x2_extmul_high_i32x4(self.simd, rhs.simd);
@@ -853,7 +853,7 @@ impl i32x4 {
 
         let no_overflow = high.simd_eq(low.is_negative());
         let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.blend(low, limit)
+        no_overflow.select(low, limit)
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_s32_s64(
@@ -868,7 +868,7 @@ impl i32x4 {
 
           let no_overflow = high.simd_eq(low.is_negative());
           let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.blend(low, limit)
+          no_overflow.select(low, limit)
         }
       } else {
         let self_array = self.to_array();

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -1081,4 +1081,6 @@ impl i32x4 {
   pub fn as_mut_array(&mut self) -> &mut [i32; 4] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -568,6 +568,15 @@ impl i32x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -572,8 +572,10 @@ impl i32x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -452,14 +452,14 @@ impl i32x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b)
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b)
         }
       }
     }
@@ -605,7 +605,7 @@ impl i32x8 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -624,7 +624,7 @@ impl i32x8 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),
@@ -653,7 +653,7 @@ impl i32x8 {
 
         let no_overflow = high.simd_eq(low.is_negative());
         let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.blend(low, limit)
+        no_overflow.select(low, limit)
       } else {
         let [self_a, self_b]: [i32x4; 2] = cast(self);
         let [rhs_a, rhs_b]: [i32x4; 2] = cast(rhs);

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -483,8 +483,10 @@ impl i32x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -492,14 +492,14 @@ impl i32x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b)
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b)
         }
       }
     }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -461,19 +461,19 @@ impl i32x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b)
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b)
         }
       }
     }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -455,7 +455,12 @@ impl i32x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -479,6 +479,15 @@ impl i32x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -848,6 +848,8 @@ impl i32x8 {
   pub fn as_mut_array(&mut self) -> &mut [i32; 8] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }
 
 impl Not for i32x8 {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -450,6 +450,15 @@ impl i32x8 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -452,6 +452,21 @@ impl i32x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b)
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -452,11 +452,13 @@ impl i32x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -513,11 +513,13 @@ impl i64x2 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -541,6 +541,15 @@ impl i64x2 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -513,7 +513,7 @@ impl i64x2 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -797,13 +797,13 @@ impl i64x2 {
   #[inline]
   #[must_use]
   pub fn min(self, rhs: Self) -> Self {
-    self.simd_lt(rhs).blend(self, rhs)
+    self.simd_lt(rhs).select(self, rhs)
   }
 
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
-    self.simd_gt(rhs).blend(self, rhs)
+    self.simd_gt(rhs).select(self, rhs)
   }
 
   integer_fn_clamp!();
@@ -817,7 +817,7 @@ impl i64x2 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqaddq_s64(self.neon, rhs.neon) } }
       } else {
@@ -840,7 +840,7 @@ impl i64x2 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqsubq_s64(self.neon, rhs.neon) } }
       } else {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -907,4 +907,6 @@ impl i64x2 {
   }
 
   integer_fn_saturating_div!([0, 1]);
+
+  fn_blend!();
 }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -554,16 +554,16 @@ impl i64x2 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s64(vreinterpretq_u64_s64(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s64(vreinterpretq_u64_s64(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -513,6 +513,22 @@ impl i64x2 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_s64(vreinterpretq_u64_s64(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -545,8 +545,10 @@ impl i64x2 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -515,8 +515,13 @@ impl i64x2 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -511,6 +511,15 @@ impl i64x2 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -522,21 +522,21 @@ impl i64x2 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s64(vreinterpretq_u64_s64(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s64(vreinterpretq_u64_s64(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -394,7 +394,12 @@ impl i64x4 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -418,6 +418,15 @@ impl i64x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -391,6 +391,21 @@ impl i64x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -780,6 +780,8 @@ impl i64x4 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl Not for i64x4 {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -391,11 +391,13 @@ impl i64x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -389,6 +389,15 @@ impl i64x4 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -391,14 +391,14 @@ impl i64x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -607,13 +607,13 @@ impl i64x4 {
   #[inline]
   #[must_use]
   pub fn min(self, rhs: Self) -> Self {
-    self.simd_lt(rhs).blend(self, rhs)
+    self.simd_lt(rhs).select(self, rhs)
   }
 
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
-    self.simd_gt(rhs).blend(self, rhs)
+    self.simd_gt(rhs).select(self, rhs)
   }
 
   integer_fn_clamp!();
@@ -627,7 +627,7 @@ impl i64x4 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -646,7 +646,7 @@ impl i64x4 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -431,14 +431,14 @@ impl i64x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2,if_true.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -422,8 +422,10 @@ impl i64x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -400,19 +400,19 @@ impl i64x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -417,7 +417,12 @@ impl i64x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a : self.a.bitselect(t.a, f.a),

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -454,14 +454,14 @@ impl i64x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -414,11 +414,13 @@ impl i64x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -414,14 +414,14 @@ impl i64x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -703,7 +703,7 @@ impl i64x8 {
         let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -722,7 +722,7 @@ impl i64x8 {
         let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
         let negative = self.is_negative();
 
-        overflow.blend(negative.blend(Self::MIN, Self::MAX), result)
+        overflow.select(negative.select(Self::MIN, Self::MAX), result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -423,19 +423,19 @@ impl i64x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a : self.a.bitselect(t.a, f.a),
-          b : self.b.bitselect(t.b, f.b),
+          a : self.a.bitselect(if_one.a, if_zero.a),
+          b : self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -790,6 +790,8 @@ impl i64x8 {
   }
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
+
+  fn_blend!();
 }
 
 impl Not for i64x8 {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -412,6 +412,15 @@ impl i64x8 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -441,6 +441,15 @@ impl i64x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -414,6 +414,21 @@ impl i64x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a : self.a.bitselect(t.a, f.a),
+          b : self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -445,8 +445,10 @@ impl i64x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -861,8 +861,13 @@ impl i8x16 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -857,6 +857,15 @@ impl i8x16 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -859,6 +859,22 @@ impl i8x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_s8(vreinterpretq_u8_s8(self.neon), t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -859,11 +859,13 @@ impl i8x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -900,16 +900,16 @@ impl i8x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s8(vreinterpretq_u8_s8(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s8(vreinterpretq_u8_s8(self.neon), if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -891,8 +891,10 @@ impl i8x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -868,21 +868,21 @@ impl i8x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_s8(vreinterpretq_u8_s8(self.neon), t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_s8(vreinterpretq_u8_s8(self.neon), if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -887,6 +887,15 @@ impl i8x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -859,7 +859,7 @@ impl i8x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -1187,7 +1187,7 @@ impl i8x16 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vmaxq_s8(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(rhs, self)
+        self.simd_lt(rhs).select(rhs, self)
       }
     }
   }
@@ -1202,7 +1202,7 @@ impl i8x16 {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {Self { neon: vminq_s8(self.neon, rhs.neon) }}
       } else {
-        self.simd_lt(rhs).blend(self, rhs)
+        self.simd_lt(rhs).select(self, rhs)
       }
     }
   }
@@ -1468,7 +1468,7 @@ impl i8x16 {
 
           let no_overflow = high.simd_eq(low.is_negative());
           let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.blend(low, limit)
+          no_overflow.select(low, limit)
         }
       } else {
         let self_array = self.to_array();

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1601,4 +1601,6 @@ impl i8x16 {
   pub fn as_mut_array(&mut self) -> &mut [i8; 16] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -421,8 +421,10 @@ impl i8x32 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -390,6 +390,21 @@ impl i8x32 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+      } else {
+        Self {
+          a : self.a.bitselect(t.a, f.a),
+          b : self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -403,9 +403,9 @@ impl i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
-          avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+          avx: bitor_m256i(
+            bitand_m256i(t.avx, self.avx),
+            bitandnot_m256i(self.avx, f.avx),
           ),
         }
       } else {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -388,6 +388,15 @@ impl i8x32 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -390,14 +390,14 @@ impl i8x32 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -794,4 +794,6 @@ impl i8x32 {
   pub fn as_mut_array(&mut self) -> &mut [i8; 32] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -393,7 +393,12 @@ impl i8x32 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a : self.a.bitselect(t.a, f.a),

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -417,6 +417,15 @@ impl i8x32 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -390,11 +390,13 @@ impl i8x32 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -430,14 +430,14 @@ impl i8x32 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+        Self { avx: blend_varying_i8_m256i(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -399,19 +399,19 @@ impl i8x32 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx: bitor_m256i(
-            bitand_m256i(t.avx, self.avx),
-            bitandnot_m256i(self.avx, f.avx),
+            bitand_m256i(if_one.avx, self.avx),
+            bitandnot_m256i(self.avx, if_zero.avx),
           ),
         }
       } else {
         Self {
-          a : self.a.bitselect(t.a, f.a),
-          b : self.b.bitselect(t.b, f.b),
+          a : self.a.bitselect(if_one.a, if_zero.a),
+          b : self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -186,6 +186,30 @@ macro_rules! int_uint_consts {
   };
 }
 
+macro_rules! fn_blend {
+  () => {
+    /// Lanewise selection. This function has been renamed to [`select`].
+    ///
+    /// For each lane this returns `t` where `self` is all ones and `f` where
+    /// `self` is all zeros.
+    ///
+    /// This function assumes `self` is a mask, meaning each lane is either all
+    /// zeros or all ones. For bitwise selection use [`bitselect`].
+    ///
+    /// [`select`]: Self::select
+    /// [`bitselect`]: Self::bitselect
+    #[deprecated(
+      since = "1.6.0",
+      note = "split into `select` and `bitselect` functions"
+    )]
+    #[inline]
+    #[must_use]
+    pub fn blend(self, t: Self, f: Self) -> Self {
+      self.select(t, f)
+    }
+  };
+}
+
 macro_rules! integer_fn_clamp {
   () => {
     /// Restrict each element to a certain interval.

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -658,4 +658,6 @@ impl u16x16 {
   pub fn as_mut_array(&mut self) -> &mut [u16; 16] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -469,19 +469,19 @@ impl u16x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -500,14 +500,14 @@ impl u16x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -460,11 +460,13 @@ impl u16x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -458,6 +458,15 @@ impl u16x16 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -460,14 +460,14 @@ impl u16x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -491,8 +491,10 @@ impl u16x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -463,7 +463,12 @@ impl u16x16 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -460,6 +460,21 @@ impl u16x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -487,6 +487,15 @@ impl u16x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -414,7 +414,12 @@ impl u16x32 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -442,8 +442,10 @@ impl u16x32 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -451,14 +451,14 @@ impl u16x32 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -438,6 +438,15 @@ impl u16x32 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -411,11 +411,13 @@ impl u16x32 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -409,6 +409,15 @@ impl u16x32 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -420,19 +420,19 @@ impl u16x32 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -411,14 +411,14 @@ impl u16x32 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -411,6 +411,21 @@ impl u16x32 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -612,4 +612,6 @@ impl u16x32 {
   pub fn as_mut_array(&mut self) -> &mut [u16; 32] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -1105,4 +1105,6 @@ impl u16x8 {
   pub fn as_mut_array(&mut self) -> &mut [u16; 8] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -611,6 +611,15 @@ impl u16x8 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -613,6 +613,22 @@ impl u16x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_u16(self.neon, t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -622,21 +622,21 @@ impl u16x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u16(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u16(self.neon, if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -613,7 +613,7 @@ impl u16x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -856,7 +856,7 @@ impl u16x8 {
         let high = Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
 
         let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.blend(low, Self::MAX)
+        no_overflow.select(low, Self::MAX)
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_u16_u32(
@@ -870,7 +870,7 @@ impl u16x8 {
           let high = Self { neon: low_high.1 };
 
           let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.blend(low, Self::MAX)
+          no_overflow.select(low, Self::MAX)
         }
       } else {
         let self_array = self.to_array();

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -613,11 +613,13 @@ impl u16x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -645,8 +645,10 @@ impl u16x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -641,6 +641,15 @@ impl u16x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -615,8 +615,13 @@ impl u16x8 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -654,16 +654,16 @@ impl u16x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u16(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u16(self.neon, if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -451,19 +451,19 @@ impl u32x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -445,7 +445,12 @@ impl u32x16 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -708,6 +708,8 @@ impl u32x16 {
   pub fn as_mut_array(&mut self) -> &mut [u32; 16] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }
 
 impl Not for u32x16 {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -473,8 +473,10 @@ impl u32x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -442,14 +442,14 @@ impl u32x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -521,7 +521,7 @@ impl u32x16 {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -537,7 +537,7 @@ impl u32x16 {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),
@@ -575,7 +575,7 @@ impl u32x16 {
         };
 
         let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.blend(low, Self::MAX)
+        no_overflow.select(low, Self::MAX)
       } else {
         let [self_a, self_b]: [u32x8; 2] = cast(self);
         let [rhs_a, rhs_b]: [u32x8; 2] = cast(rhs);

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -482,14 +482,14 @@ impl u32x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -440,6 +440,15 @@ impl u32x16 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -442,11 +442,13 @@ impl u32x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -442,6 +442,21 @@ impl u32x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -469,6 +469,15 @@ impl u32x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -657,8 +657,10 @@ impl u32x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -625,11 +625,13 @@ impl u32x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -623,6 +623,15 @@ impl u32x4 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -625,6 +625,22 @@ impl u32x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_u32(self.neon, t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -625,7 +625,7 @@ impl u32x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -746,7 +746,7 @@ impl u32x4 {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqaddq_u32(self.neon, rhs.neon) } }
       } else {
@@ -768,7 +768,7 @@ impl u32x4 {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqsubq_u32(self.neon, rhs.neon) } }
       } else {
@@ -802,7 +802,7 @@ impl u32x4 {
         let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
 
         let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.blend(low, Self::MAX)
+        no_overflow.select(low, Self::MAX)
       } else if #[cfg(target_feature="simd128")] {
         let low_wide_mul = u64x2_extmul_low_u32x4(self.simd, rhs.simd);
         let high_wide_mul = u64x2_extmul_high_u32x4(self.simd, rhs.simd);
@@ -810,7 +810,7 @@ impl u32x4 {
         let high = Self { simd: u32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
 
         let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.blend(low, Self::MAX)
+        no_overflow.select(low, Self::MAX)
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_u32_u64(
@@ -824,7 +824,7 @@ impl u32x4 {
           let high = Self { neon: low_high.1 };
 
           let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.blend(low, Self::MAX)
+          no_overflow.select(low, Self::MAX)
         }
       } else {
         let self_array = self.to_array();

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -627,8 +627,13 @@ impl u32x4 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -945,4 +945,6 @@ impl u32x4 {
   pub fn as_mut_array(&mut self) -> &mut [u32; 4] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -634,21 +634,21 @@ impl u32x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u32(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u32(self.neon, if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -666,16 +666,16 @@ impl u32x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u32(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u32(self.neon, if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -653,6 +653,15 @@ impl u32x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -537,14 +537,14 @@ impl u32x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -615,7 +615,7 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -631,7 +631,7 @@ impl u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),
@@ -659,7 +659,7 @@ impl u32x8 {
         let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
 
         let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.blend(low, Self::MAX)
+        no_overflow.select(low, Self::MAX)
       } else {
         let [self_a, self_b]: [u32x4; 2] = cast(self);
         let [rhs_a, rhs_b]: [u32x4; 2] = cast(rhs);

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -564,6 +564,15 @@ impl u32x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -537,6 +537,21 @@ impl u32x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -577,14 +577,14 @@ impl u32x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -540,7 +540,12 @@ impl u32x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2, t.avx2, self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -535,6 +535,15 @@ impl u32x8 {
     }
   }
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -537,11 +537,13 @@ impl u32x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -546,19 +546,19 @@ impl u32x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -568,8 +568,10 @@ impl u32x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -767,6 +767,8 @@ impl u32x8 {
   pub fn as_mut_array(&mut self) -> &mut [u32; 8] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }
 
 impl Not for u32x8 {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -505,8 +505,13 @@ impl u64x2 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -503,6 +503,22 @@ impl u64x2 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_u64(self.neon, t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -512,21 +512,21 @@ impl u64x2 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u64(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u64(self.neon, if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -503,7 +503,7 @@ impl u64x2 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -618,13 +618,13 @@ impl u64x2 {
   #[inline]
   #[must_use]
   pub fn min(self, rhs: Self) -> Self {
-    self.simd_lt(rhs).blend(self, rhs)
+    self.simd_lt(rhs).select(self, rhs)
   }
 
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
-    self.simd_gt(rhs).blend(self, rhs)
+    self.simd_gt(rhs).select(self, rhs)
   }
 
   integer_fn_clamp!();
@@ -635,7 +635,7 @@ impl u64x2 {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqaddq_u64(self.neon, rhs.neon) } }
       } else {
@@ -655,7 +655,7 @@ impl u64x2 {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe { Self { neon: vqsubq_u64(self.neon, rhs.neon) } }
       } else {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -733,4 +733,6 @@ impl u64x2 {
       ((arr1[1] as u128 * arr2[1] as u128) >> 64) as u64,
     ])
   }
+
+  fn_blend!();
 }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -531,6 +531,15 @@ impl u64x2 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -501,6 +501,15 @@ impl u64x2 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -535,8 +535,10 @@ impl u64x2 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -503,11 +503,13 @@ impl u64x2 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -544,16 +544,16 @@ impl u64x2 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u64(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u64(self.neon, if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -388,14 +388,14 @@ impl u64x4 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -482,13 +482,13 @@ impl u64x4 {
   #[inline]
   #[must_use]
   pub fn min(self, rhs: Self) -> Self {
-    self.simd_lt(rhs).blend(self, rhs)
+    self.simd_lt(rhs).select(self, rhs)
   }
 
   #[inline]
   #[must_use]
   pub fn max(self, rhs: Self) -> Self {
-    self.simd_gt(rhs).blend(self, rhs)
+    self.simd_gt(rhs).select(self, rhs)
   }
 
   integer_fn_clamp!();
@@ -499,7 +499,7 @@ impl u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -515,7 +515,7 @@ impl u64x4 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -428,14 +428,14 @@ impl u64x4 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+        Self { avx2: blend_varying_i8_m256i(if_false.avx2,if_true.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -388,6 +388,21 @@ impl u64x4 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -388,11 +388,13 @@ impl u64x4 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -391,7 +391,12 @@ impl u64x4 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: blend_varying_i8_m256i(f.avx2,t.avx2,self.avx2) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -601,6 +601,8 @@ impl u64x4 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl Not for u64x4 {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -397,19 +397,19 @@ impl u64x4 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+            bitand_m256i(if_one.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, if_zero.avx2),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -386,6 +386,15 @@ impl u64x4 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -419,8 +419,10 @@ impl u64x4 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -415,6 +415,15 @@ impl u64x4 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -411,6 +411,15 @@ impl u64x8 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -384,6 +384,21 @@ impl u64x8 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -415,8 +415,10 @@ impl u64x8 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -424,14 +424,14 @@ impl u64x8 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -621,6 +621,8 @@ impl u64x8 {
       }
     }
   }
+
+  fn_blend!();
 }
 
 impl Not for u64x8 {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -384,11 +384,13 @@ impl u64x8 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -393,19 +393,19 @@ impl u64x8 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self {
           avx512: bitor_m512i(
-            bitand_m512i(t.avx512, self.avx512),
-            bitandnot_m512i(self.avx512, f.avx512),
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -387,7 +387,12 @@ impl u64x8 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(t.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, f.avx512),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -382,6 +382,15 @@ impl u64x8 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -384,14 +384,14 @@ impl u64x8 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         Self { avx512: blend_varying_i8_m512i(f.avx512,t.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }
@@ -511,7 +511,7 @@ impl u64x8 {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         let result = self + rhs;
-        result.simd_lt(self).blend(Self::MAX, result)
+        result.simd_lt(self).select(Self::MAX, result)
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -527,7 +527,7 @@ impl u64x8 {
     pick! {
       if #[cfg(target_feature="avx512f")] {
         let result = self - rhs;
-        result.simd_gt(self).blend(Self::MIN, result)
+        result.simd_gt(self).select(Self::MIN, result)
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -805,21 +805,21 @@ impl u8x16 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
         Self {
           sse: bitor_m128i(
-            bitand_m128i(t.sse, self.sse),
-            bitandnot_m128i(self.sse, f.sse),
+            bitand_m128i(if_one.sse, self.sse),
+            bitandnot_m128i(self.sse, if_zero.sse),
           ),
         }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_one.simd, if_zero.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u8(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u8(self.neon, if_one.neon, if_zero.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_one, if_zero)
       }
     }
   }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -828,8 +828,10 @@ impl u8x16 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -796,11 +796,13 @@ impl u8x16 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -794,6 +794,15 @@ impl u8x16 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -796,7 +796,7 @@ impl u8x16 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
@@ -1112,7 +1112,7 @@ impl u8x16 {
           let high = Self { neon: low_high.1 };
 
           let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.blend(low, Self::MAX)
+          no_overflow.select(low, Self::MAX)
         }
       } else {
         let self_array = self.to_array();

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -796,6 +796,22 @@ impl u8x16 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {Self { neon: vbslq_u8(self.neon, t.neon, f.neon) }}
+      } else {
+        generic_bit_blend(self, t, f)
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -824,6 +824,15 @@ impl u8x16 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1359,4 +1359,6 @@ impl u8x16 {
   pub fn as_mut_array(&mut self) -> &mut [u8; 16] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -798,8 +798,13 @@ impl u8x16 {
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+      if #[cfg(target_feature="sse2")] {
+        Self {
+          sse: bitor_m128i(
+            bitand_m128i(t.sse, self.sse),
+            bitandnot_m128i(self.sse, f.sse),
+          ),
+        }
       } else if #[cfg(target_feature="simd128")] {
         Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -837,16 +837,16 @@ impl u8x16 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
-        Self { sse: blend_varying_i8_m128i(f.sse, t.sse, self.sse) }
+        Self { sse: blend_varying_i8_m128i(if_false.sse, if_true.sse, self.sse) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: v128_bitselect(t.simd, f.simd, self.simd) }
+        Self { simd: v128_bitselect(if_true.simd, if_false.simd, self.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe {Self { neon: vbslq_u8(self.neon, t.neon, f.neon) }}
+        unsafe {Self { neon: vbslq_u8(self.neon, if_true.neon, if_false.neon) }}
       } else {
-        generic_bit_blend(self, t, f)
+        generic_bit_blend(self, if_true, if_false)
       }
     }
   }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -423,11 +423,13 @@ impl u8x32 {
 
   /// Bitwise selection.
   ///
-  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
-  /// `0`.
+  /// For each bit of `self`:
   ///
-  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
-  /// consider using [`select`] which is faster.
+  /// - If the bit is one, return the corresponding bit of `if_one`
+  /// - If the bit is zero, return the corresponding bit of `if_zero`
+  ///
+  /// If you know `self` is a mask, meaning each lane is either all zeros or all
+  /// ones, consider using [`select`] which is faster.
   ///
   /// [`select`]: Self::select
   #[inline]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -463,14 +463,14 @@ impl u8x32 {
   /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
-  pub fn select(self, t: Self, f: Self) -> Self {
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+        Self { avx: blend_varying_i8_m256i(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(t.a, f.a),
-          b : self.b.select(t.b, f.b),
+          a : self.a.select(if_true.a, if_false.a),
+          b : self.b.select(if_true.b, if_false.b),
         }
       }
     }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -421,6 +421,15 @@ impl u8x32 {
 
   simd_comparison_fns!();
 
+  /// Bitwise selection.
+  ///
+  /// For each bit this returns `t` where `self` is `1` and `f` where `self` is
+  /// `0`.
+  ///
+  /// If `self` is a mask, meaning each lane is either all zeros or all ones,
+  /// consider using [`select`] which is faster.
+  ///
+  /// [`select`]: Self::select
   #[inline]
   #[must_use]
   pub fn bitselect(self, t: Self, f: Self) -> Self {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -423,14 +423,14 @@ impl u8x32 {
 
   #[inline]
   #[must_use]
-  pub fn blend(self, t: Self, f: Self) -> Self {
+  pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
       } else {
         Self {
-          a : self.a.blend(t.a, f.a),
-          b : self.b.blend(t.b, f.b),
+          a : self.a.select(t.a, f.a),
+          b : self.b.select(t.b, f.b),
         }
       }
     }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -426,7 +426,12 @@ impl u8x32 {
   pub fn bitselect(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+        Self {
+          avx2: bitor_m256i(
+            bitand_m256i(t.avx2, self.avx2),
+            bitandnot_m256i(self.avx2, f.avx2),
+          ),
+        }
       } else {
         Self {
           a: self.a.bitselect(t.a, f.a),

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -450,6 +450,15 @@ impl u8x32 {
     }
   }
 
+  /// Lanewise selection.
+  ///
+  /// For each lane this returns `t` where `self` is all ones and `f` where
+  /// `self` is all zeros.
+  ///
+  /// This function assumes `self` is a mask, meaning each lane is either all
+  /// zeros or all ones. For bitwise selection use [`bitselect`].
+  ///
+  /// [`bitselect`]: Self::bitselect
   #[inline]
   #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -436,9 +436,9 @@ impl u8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
-          avx2: bitor_m256i(
-            bitand_m256i(t.avx2, self.avx2),
-            bitandnot_m256i(self.avx2, f.avx2),
+          avx: bitor_m256i(
+            bitand_m256i(t.avx, self.avx),
+            bitandnot_m256i(self.avx, f.avx),
           ),
         }
       } else {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -432,19 +432,19 @@ impl u8x32 {
   /// [`select`]: Self::select
   #[inline]
   #[must_use]
-  pub fn bitselect(self, t: Self, f: Self) -> Self {
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
         Self {
           avx: bitor_m256i(
-            bitand_m256i(t.avx, self.avx),
-            bitandnot_m256i(self.avx, f.avx),
+            bitand_m256i(if_one.avx, self.avx),
+            bitandnot_m256i(self.avx, if_zero.avx),
           ),
         }
       } else {
         Self {
-          a: self.a.bitselect(t.a, f.a),
-          b: self.b.bitselect(t.b, f.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -454,8 +454,10 @@ impl u8x32 {
 
   /// Lanewise selection.
   ///
-  /// For each lane this returns `t` where `self` is all ones and `f` where
-  /// `self` is all zeros.
+  /// For each lane of `self`:
+  ///
+  /// - If all bits are one, return the corresponding lane of `if_true`
+  /// - If all bits are zero, return the corresponding lane of `if_false`
   ///
   /// This function assumes `self` is a mask, meaning each lane is either all
   /// zeros or all ones. For bitwise selection use [`bitselect`].

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -649,4 +649,6 @@ impl u8x32 {
   pub fn as_mut_array(&mut self) -> &mut [u8; 32] {
     cast_mut(self)
   }
+
+  fn_blend!();
 }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -423,6 +423,21 @@ impl u8x32 {
 
   #[inline]
   #[must_use]
+  pub fn bitselect(self, t: Self, f: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx: blend_varying_i8_m256i(f.avx, t.avx, self.avx) }
+      } else {
+        Self {
+          a: self.a.bitselect(t.a, f.a),
+          b: self.b.bitselect(t.b, f.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  #[must_use]
   pub fn select(self, t: Self, f: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -2010,6 +2010,53 @@ fn test_simd_ge_scalar() {
 }
 
 #[test]
+fn test_bitselect() {
+  for_simd_types!(|T: Float, N| {
+    for [value, if_true, if_false] in simd_chunks!(
+      [1.45, 1.1, -4.0, 11.0, -41.0, -17.0, 61.0, -1.5],
+      [0.0, -0.0, 1.0, 2.0, -3.1, 5.3, 1e3, -20.1],
+      [5.0, 0.0, 5.0, 3.1, 6.3, -30.2, 1e4, 53.2],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        T::from_bits(
+          if_true[i].to_bits() & value[i].to_bits()
+            | if_false[i].to_bits() & !value[i].to_bits(),
+        )
+      }));
+      let actual =
+        Simd::new(value).bitselect(Simd::new(if_true), Simd::new(if_false));
+
+      assert!(
+        actual ^ expected == Simd::ZERO,
+        "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}\n if_true: {if_true:?}\nif_false: {if_false:?}",
+      );
+    }
+  });
+  for_simd_types!(|T: Integer, N| {
+    for [value, if_true, if_false] in simd_chunks!(
+      [0, 0, !0, 0, !0, !0, 0, !0],
+      [4, 6, 3, 20, T::MAX, 5, 123, 111],
+      [5, 1, 4, 50, 1, T::MIN, 120, 112],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        if_true[i] & value[i] | if_false[i] & !value[i]
+      }));
+      let actual =
+        Simd::new(value).bitselect(Simd::new(if_true), Simd::new(if_false));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    mask: {value:?}\n if_true: {if_true:?}\nif_false: {if_false:?}",
+      );
+    }
+  });
+}
+
+#[test]
 fn test_select() {
   for_simd_types!(|T: Float, N| {
     for [mask, if_true, if_false] in simd_chunks!(

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -2010,25 +2010,21 @@ fn test_simd_ge_scalar() {
 }
 
 #[test]
-fn test_blend() {
+fn test_select() {
   for_simd_types!(|T: Float, N| {
     for [mask, if_true, if_false] in simd_chunks!(
-      [0, 0, !0, 0, !0, !0, 0, !0].map(T::from_bits),
+      [1.0, 1.0, -1.0, 1.0, -1.0, -1.0, 1.0, -1.0],
       [0.0, -0.0, 1.0, 2.0, -3.1, 5.3, 1e3, -20.1],
       [5.0, 0.0, 5.0, 3.1, 6.3, -30.2, 1e4, 53.2],
     )
-    // TODO: Decide if `blend` should work for arbitrary bit patterns then
-    // document it. This breaks some implementations:
-    //.chain(random_iter())
+    .chain(random_iter())
     {
       let expected = Simd::new(std::array::from_fn(|i| {
-        T::from_bits(
-          if_true[i].to_bits() & mask[i].to_bits()
-            | if_false[i].to_bits() & !mask[i].to_bits(),
-        )
+        if mask[i].is_sign_negative() { if_true[i] } else { if_false[i] }
       }));
-      let actual =
-        Simd::new(mask).blend(Simd::new(if_true), Simd::new(if_false));
+      let actual = Simd::new(mask)
+        .is_sign_negative()
+        .select(Simd::new(if_true), Simd::new(if_false));
 
       assert!(
         actual ^ expected == Simd::ZERO,
@@ -2042,15 +2038,14 @@ fn test_blend() {
       [4, 6, 3, 20, T::MAX, 5, 123, 111],
       [5, 1, 4, 50, 1, T::MIN, 120, 112],
     )
-    // TODO: Decide if `blend` should work for arbitrary bit patterns then
-    // document it. This breaks some implementations:
-    //.chain(random_iter())
+    .chain(random_iter())
     {
       let expected = Simd::new(std::array::from_fn(|i| {
-        if_true[i] & mask[i] | if_false[i] & !mask[i]
+        if mask[i] > 0 { if_true[i] } else { if_false[i] }
       }));
-      let actual =
-        Simd::new(mask).blend(Simd::new(if_true), Simd::new(if_false));
+      let actual = Simd::new(mask)
+        .simd_gt(Simd::ZERO)
+        .select(Simd::new(if_true), Simd::new(if_false));
 
       assert!(
         actual == expected,


### PR DESCRIPTION
# Reasoning

Currently `blend` doesn't have any specified behavior. I imagine it is used downstream as lanewise selection from a mask, and sometimes **incorrectly** as bitwise selection.

The current implementation sometimes works as bitwise selection and sometimes picks lanes based on the sign bit.

Since there are two use cases (lanewise from a mask and bitwise), and one of them is faster (lanewise) the function needs to be split into two functions.

# Changes

This deprecates `blend` and replaces it with two new functions `select` and `bitselect`. I chose these names but the functions can be renamed if there are better names.

`select` assumes each lane is either all zeros or all ones and is intended for masks. `bitselect` works as bitwise selection which is slower on x86 because there are no direct intrinsics for it.

`blend` now redirects to `select`, which has the original `blend` implementation without any changes. I chose to redirect `blend` to `select` and not `bitselect` because it already didn't work as bitwise selection.

If you think this change is too breaking perhaps there is a better solution, but this is a good baseline.