### PR TITLE
fix: Correct shift operators overflow behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
 
+* Fixed shift operators overflow behavior.
+
 ## 1.5.0
 
 * Added several functions and trait implementations that previously were only

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -248,7 +248,9 @@ macro_rules! impl_shl_t_for_i16x16 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { avx2: shl_all_u16_m256i(self.avx2, shift) }
           } else {
             Self {
@@ -272,7 +274,9 @@ macro_rules! impl_shr_t_for_i16x16 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { avx2: shr_all_i16_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -242,7 +242,9 @@ macro_rules! impl_shl_t_for_i16x32 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512bw")] {
-            let shift = cast(rhs as u16);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u16 & 15, 0]);
             Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -266,7 +268,9 @@ macro_rules! impl_shr_t_for_i16x32 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512bw")] {
-            let shift = cast(rhs as u16);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u16 & 15, 0]);
             Self { avx512: shr_all_i16_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -244,7 +244,7 @@ macro_rules! impl_shl_t_for_i16x32 {
           if #[cfg(target_feature="avx512bw")] {
             // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u16 & 15, 0]);
+            let shift = rhs as u16 & 15;
             Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -270,7 +270,7 @@ macro_rules! impl_shr_t_for_i16x32 {
           if #[cfg(target_feature="avx512bw")] {
             // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u16 & 15, 0]);
+            let shift = rhs as u16 & 15;
             Self { avx512: shr_all_i16_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -376,7 +376,9 @@ macro_rules! impl_shl_t_for_i16x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { sse: shl_all_u16_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i16x8_shl(self.simd, rhs as u32) }
@@ -411,7 +413,9 @@ macro_rules! impl_shr_t_for_i16x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { sse: shr_all_i16_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i16x8_shr(self.simd, rhs as u32) }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -383,7 +383,9 @@ macro_rules! impl_shl_t_for_i16x8 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i16x8_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_s16(self.neon, vmovq_n_s16(rhs as i16)) }}
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_s16(self.neon, vmovq_n_s16(rhs as i16 & 15)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [
@@ -420,7 +422,9 @@ macro_rules! impl_shr_t_for_i16x8 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i16x8_shr(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_s16(self.neon, vmovq_n_s16( -(rhs as i16))) }}
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_s16(self.neon, vmovq_n_s16( -(rhs as i16 & 15))) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -239,7 +239,9 @@ macro_rules! impl_shl_t_for_i32x16 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u32);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u32 & 31, 0]);
             Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -263,7 +265,9 @@ macro_rules! impl_shr_t_for_i32x16 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u32);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u32 & 31, 0]);
             Self { avx512: shr_all_i32_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -217,7 +217,7 @@ impl Shr for i32x16 {
         use core::arch::x86_64::_mm512_srav_epi32;
 
         // Mask `rhs` to 31 to match `wrapping_shr`.
-        let rhs = bitand_m512i(rhs.avx512, set_splat_i16_m512i(31));
+        let rhs = bitand_m512i(rhs.avx512, set_splat_i32_m512i(31));
         // TODO(safe_arch): Add `_mm512_srav_epi32`.
         Self { avx512: m512i(unsafe { _mm512_srav_epi32(self.avx512.0, rhs.0) }) }
       } else {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -241,7 +241,7 @@ macro_rules! impl_shl_t_for_i32x16 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u32 & 31, 0]);
+            let shift = rhs as u32 & 31;
             Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -267,7 +267,7 @@ macro_rules! impl_shr_t_for_i32x16 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u32 & 31, 0]);
+            let shift = rhs as u32 & 31;
             Self { avx512: shr_all_i32_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -261,7 +261,9 @@ macro_rules! impl_shl_t_for_i32x4 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { sse: shl_all_u32_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i32x4_shl(self.simd, rhs as u32) }
@@ -292,7 +294,9 @@ macro_rules! impl_shr_t_for_i32x4 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { sse: shr_all_i32_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i32x4_shr(self.simd, rhs as u32) }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -268,7 +268,9 @@ macro_rules! impl_shl_t_for_i32x4 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i32x4_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_s32(self.neon, vmovq_n_s32(rhs as i32)) }}
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_s32(self.neon, vmovq_n_s32(rhs as i32 & 31)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [
@@ -301,7 +303,9 @@ macro_rules! impl_shr_t_for_i32x4 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i32x4_shr(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_s32(self.neon, vmovq_n_s32( -(rhs as i32))) }}
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_s32(self.neon, vmovq_n_s32( -(rhs as i32 & 31))) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -181,7 +181,9 @@ macro_rules! impl_shl_t_for_i32x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
           } else {
             Self {
@@ -205,7 +207,9 @@ macro_rules! impl_shr_t_for_i32x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { avx2: shr_all_i32_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -281,7 +281,9 @@ macro_rules! impl_shl_t_for_i64x2 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { sse: shl_all_u64_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i64x2_shl(self.simd, rhs as u32) }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -288,7 +288,9 @@ macro_rules! impl_shl_t_for_i64x2 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: i64x2_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_s64(self.neon, vmovq_n_s64(rhs as i64)) }}
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_s64(self.neon, vmovq_n_s64(rhs as i64 & 63)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -211,7 +211,9 @@ macro_rules! impl_shl_t_for_i64x4 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -256,7 +256,9 @@ macro_rules! impl_shl_t_for_i64x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u64);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -280,7 +282,9 @@ macro_rules! impl_shr_t_for_i64x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u64);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx512: shr_all_i64_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -258,7 +258,7 @@ macro_rules! impl_shl_t_for_i64x8 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u64 & 63, 0]);
+            let shift = rhs as u64 & 63;
             Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -284,7 +284,7 @@ macro_rules! impl_shr_t_for_i64x8 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u64 & 63, 0]);
+            let shift = rhs as u64 & 63;
             Self { avx512: shr_all_i64_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -244,7 +244,9 @@ macro_rules! impl_shl_t_for_u16x16 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { avx2: shl_all_u16_m256i(self.avx2, shift) }
           } else {
             Self {
@@ -268,7 +270,9 @@ macro_rules! impl_shr_t_for_u16x16 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { avx2: shr_all_u16_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -238,7 +238,7 @@ macro_rules! impl_shl_t_for_u16x32 {
           if #[cfg(target_feature="avx512bw")] {
             // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u16 & 15, 0]);
+            let shift = rhs as u16 & 15;
             Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -264,7 +264,7 @@ macro_rules! impl_shr_t_for_u16x32 {
           if #[cfg(target_feature="avx512bw")] {
             // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u16 & 15, 0]);
+            let shift = rhs as u16 & 15;
             Self { avx512: shr_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -236,7 +236,9 @@ macro_rules! impl_shl_t_for_u16x32 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512bw")] {
-            let shift = cast(rhs as u16);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u16 & 15, 0]);
             Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -260,7 +262,9 @@ macro_rules! impl_shr_t_for_u16x32 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512bw")] {
-            let shift = cast(rhs as u16);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u16 & 15, 0]);
             Self { avx512: shr_all_u16_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -383,7 +383,9 @@ macro_rules! impl_shl_t_for_u16x8 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u16x8_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u16(self.neon, vmovq_n_s16(rhs as i16)) }}
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u16(self.neon, vmovq_n_s16(rhs as i16 & 15)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [
@@ -420,7 +422,9 @@ macro_rules! impl_shr_t_for_u16x8 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u16x8_shr(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u16(self.neon, vmovq_n_s16( -(rhs as i16))) }}
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u16(self.neon, vmovq_n_s16( -(rhs as i16 & 15))) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -376,7 +376,9 @@ macro_rules! impl_shl_t_for_u16x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { sse: shl_all_u16_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u16x8_shl(self.simd, rhs as u32) }
@@ -411,7 +413,9 @@ macro_rules! impl_shr_t_for_u16x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 15, 0]);
             Self { sse: shr_all_u16_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u16x8_shr(self.simd, rhs as u32) }

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -238,7 +238,7 @@ macro_rules! impl_shl_t_for_u32x16 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u32 & 31, 0]);
+            let shift = rhs as u32 & 31;
             Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -264,7 +264,7 @@ macro_rules! impl_shr_t_for_u32x16 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u32 & 31, 0]);
+            let shift = rhs as u32 & 31;
             Self { avx512: shr_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -236,7 +236,9 @@ macro_rules! impl_shl_t_for_u32x16 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u32);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u32 & 31, 0]);
             Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -260,7 +262,9 @@ macro_rules! impl_shr_t_for_u32x16 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u32);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u32 & 31, 0]);
             Self { avx512: shr_all_u32_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -268,7 +268,9 @@ macro_rules! impl_shl_t_for_u32x4 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u32x4_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u32(self.neon, vmovq_n_s32(rhs as i32)) }}
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u32(self.neon, vmovq_n_s32(rhs as i32 & 31)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [
@@ -301,7 +303,9 @@ macro_rules! impl_shr_t_for_u32x4 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u32x4_shr(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u32(self.neon, vmovq_n_s32( -(rhs as i32))) }}
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u32(self.neon, vmovq_n_s32( -(rhs as i32 & 31))) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -261,7 +261,9 @@ macro_rules! impl_shl_t_for_u32x4 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { sse: shl_all_u32_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u32x4_shl(self.simd, rhs as u32) }
@@ -292,7 +294,9 @@ macro_rules! impl_shr_t_for_u32x4 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { sse: shr_all_u32_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u32x4_shr(self.simd, rhs as u32) }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -240,7 +240,9 @@ macro_rules! impl_shl_t_for_u32x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
           } else {
             Self {
@@ -264,7 +266,9 @@ macro_rules! impl_shr_t_for_u32x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 32` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 31, 0]);
             Self { avx2: shr_all_u32_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -289,7 +289,9 @@ macro_rules! impl_shl_t_for_u64x2 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u64x2_shl(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u64(self.neon, vmovq_n_s64(rhs as i64)) }}
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u64(self.neon, vmovq_n_s64(rhs as i64 & 63)) }}
           } else {
             let u = rhs as u32;
             Self { arr: [
@@ -354,7 +356,9 @@ macro_rules! impl_shr_t_for_u64x2 {
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u64x2_shr(self.simd, rhs as u32) }
           } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-            unsafe {Self { neon: vshlq_u64(self.neon, vmovq_n_s64(-(rhs as i64))) }}
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            unsafe {Self { neon: vshlq_u64(self.neon, vmovq_n_s64(-(rhs as i64 & 63))) }}
           } else {
             let u = rhs as u32;
             Self { arr: [

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -282,7 +282,9 @@ macro_rules! impl_shl_t_for_u64x2 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { sse: shl_all_u64_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u64x2_shl(self.simd, rhs as u32) }
@@ -345,7 +347,9 @@ macro_rules! impl_shr_t_for_u64x2 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="sse2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { sse: shr_all_u64_m128i(self.sse, shift) }
           } else if #[cfg(target_feature="simd128")] {
             Self { simd: u64x2_shr(self.simd, rhs as u32) }

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -211,7 +211,9 @@ macro_rules! impl_shl_t_for_u64x4 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
           } else {
             Self {
@@ -260,7 +262,9 @@ macro_rules! impl_shr_t_for_u64x4 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx2")] {
-            let shift = cast([rhs as u64, 0]);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx2: shr_all_u64_m256i(self.avx2, shift) }
           } else {
             Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -192,7 +192,7 @@ macro_rules! impl_shl_t_for_u64x8 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u64 & 63, 0]);
+            let shift = rhs as u64 & 63;
             Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -218,7 +218,7 @@ macro_rules! impl_shr_t_for_u64x8 {
           if #[cfg(target_feature="avx512f")] {
             // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
             #[expect(clippy::suspicious_arithmetic_impl)]
-            let shift = cast([rhs as u64 & 63, 0]);
+            let shift = rhs as u64 & 63;
             Self { avx512: shr_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -240,7 +240,9 @@ impl Shr for u64x8 {
   fn shr(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: shr_each_u64_m512i(self.avx512, rhs.avx512) }
+        // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+        let rhs = bitand_m512i(rhs.avx512, set_splat_i64_m512i(63));
+        Self { avx512: shr_each_u64_m512i(self.avx512, rhs) }
       } else {
         Self {
           a : self.a.shr(rhs.a),
@@ -258,7 +260,9 @@ impl Shl for u64x8 {
   fn shl(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        Self { avx512: shl_each_u64_m512i(self.avx512, rhs.avx512) }
+        // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+        let rhs = bitand_m512i(rhs.avx512, set_splat_i64_m512i(63));
+        Self { avx512: shl_each_u64_m512i(self.avx512, rhs) }
       } else {
         Self {
           a : self.a.shl(rhs.a),

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -190,7 +190,9 @@ macro_rules! impl_shl_t_for_u64x8 {
       fn shl(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u64);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {
@@ -214,7 +216,9 @@ macro_rules! impl_shr_t_for_u64x8 {
       fn shr(self, rhs: $shift_type) -> Self::Output {
         pick! {
           if #[cfg(target_feature="avx512f")] {
-            let shift = cast(rhs as u64);
+            // Use `rhs % 64` to perform wrapping shift and not unbounded shift.
+            #[expect(clippy::suspicious_arithmetic_impl)]
+            let shift = cast([rhs as u64 & 63, 0]);
             Self { avx512: shr_all_u64_m512i(self.avx512, shift) }
           } else {
             Self {

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -864,11 +864,6 @@ fn test_shl() {
     )
     .chain(random_iter())
     {
-      // TODO: Decide how shift operators should behave then harden this test.
-      // Currently implementations either behave like `wrapping_shl/r` or
-      // `unbounded_shl/r` depending on target features.
-      let right = right.map(|x| x & (T::BITS - 1) as T);
-
       let expected = Simd::new(std::array::from_fn(|i| {
         left[i].wrapping_shl(right[i] as u32)
       }));
@@ -901,11 +896,6 @@ fn test_shl() {
     )
     .chain(random_iter())
     {
-      // TODO: Decide how shift operators should behave then harden this test.
-      // Currently implementations either behave like `wrapping_shl/r` or
-      // `unbounded_shl/r` depending on target features.
-      let right = right.map(|x| x & (T::BITS - 1) as T);
-
       #[allow(clippy::unnecessary_cast)]
       let expected = Simd::new(std::array::from_fn(|i| {
         left[i].wrapping_shl(right[i] as u32)
@@ -923,7 +913,7 @@ fn test_shl() {
 #[test]
 fn test_shl_scalar() {
   for_simd_types!(|T: Signed, N| {
-    for left in simd_chunks!([
+    for (left, right) in simd_chunks!([
       1,
       2,
       T::MAX - 1,
@@ -938,41 +928,34 @@ fn test_shl_scalar() {
       T::MIN + 1,
       T::MIN / 2,
     ])
+    .flat_map(|left| [1, 0, 3, -2, -6, 100].map(|right| (left, right)))
     .chain(random_iter())
     {
-      for right in [1, 0, 3, -2, -6, 100] {
-        // TODO: Decide how shift operators should behave then harden this test.
-        // Currently implementations either behave like `wrapping_shl/r` or
-        // `unbounded_shl/r` depending on target features.
-        let right = right & (T::BITS - 1) as i32;
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].wrapping_shl(right as u32)));
 
-        let expected = Simd::new(std::array::from_fn(|i| {
-          left[i].wrapping_shl(right as u32)
-        }));
-
-        for actual in [
-          Simd::new(left) << right as i8,
-          Simd::new(left) << right as u8,
-          Simd::new(left) << right as i16,
-          Simd::new(left) << right as u16,
-          Simd::new(left) << right,
-          Simd::new(left) << right as u32,
-          Simd::new(left) << right as i64,
-          Simd::new(left) << right as u64,
-          Simd::new(left) << right as i128,
-          Simd::new(left) << right as u128,
-          // `simd << isize` and `simd << usize` are missing.
-        ] {
-          assert!(
-            actual == expected,
-            "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
-          );
-        }
+      for actual in [
+        Simd::new(left) << right as i8,
+        Simd::new(left) << right as u8,
+        Simd::new(left) << right as i16,
+        Simd::new(left) << right as u16,
+        Simd::new(left) << right,
+        Simd::new(left) << right as u32,
+        Simd::new(left) << right as i64,
+        Simd::new(left) << right as u64,
+        Simd::new(left) << right as i128,
+        Simd::new(left) << right as u128,
+        // `simd << isize` and `simd << usize` are missing.
+      ] {
+        assert!(
+          actual == expected,
+          "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+        );
       }
     }
   });
   for_simd_types!(|T: Unsigned, N| {
-    for left in simd_chunks!([
+    for (left, right) in simd_chunks!([
       1,
       2,
       T::MAX - 1,
@@ -987,36 +970,29 @@ fn test_shl_scalar() {
       T::MIN + 1,
       T::MIN / 2,
     ])
+    .flat_map(|left| [1, 0, 3, -2, -6, 100].map(|right| (left, right)))
     .chain(random_iter())
     {
-      for right in [1, 0, 3, -2, -6, 100] {
-        // TODO: Decide how shift operators should behave then harden this test.
-        // Currently implementations either behave like `wrapping_shl/r` or
-        // `unbounded_shl/r` depending on target features.
-        let right = right & (T::BITS - 1) as i32;
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].wrapping_shl(right as u32)));
 
-        let expected = Simd::new(std::array::from_fn(|i| {
-          left[i].wrapping_shl(right as u32)
-        }));
-
-        for actual in [
-          Simd::new(left) << right as i8,
-          Simd::new(left) << right as u8,
-          Simd::new(left) << right as i16,
-          Simd::new(left) << right as u16,
-          Simd::new(left) << right,
-          Simd::new(left) << right as u32,
-          Simd::new(left) << right as i64,
-          Simd::new(left) << right as u64,
-          Simd::new(left) << right as i128,
-          Simd::new(left) << right as u128,
-          // `simd << isize` and `simd << usize` are missing.
-        ] {
-          assert!(
-            actual == expected,
-            "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
-          );
-        }
+      for actual in [
+        Simd::new(left) << right as i8,
+        Simd::new(left) << right as u8,
+        Simd::new(left) << right as i16,
+        Simd::new(left) << right as u16,
+        Simd::new(left) << right,
+        Simd::new(left) << right as u32,
+        Simd::new(left) << right as i64,
+        Simd::new(left) << right as u64,
+        Simd::new(left) << right as i128,
+        Simd::new(left) << right as u128,
+        // `simd << isize` and `simd << usize` are missing.
+      ] {
+        assert!(
+          actual == expected,
+          "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+        );
       }
     }
   });
@@ -1047,11 +1023,6 @@ fn test_shr() {
     )
     .chain(random_iter())
     {
-      // TODO: Decide how shift operators should behave then harden this test.
-      // Currently implementations either behave like `wrapping_shl/r` or
-      // `unbounded_shl/r` depending on target features.
-      let right = right.map(|x| x & (T::BITS - 1) as T);
-
       let expected = Simd::new(std::array::from_fn(|i| {
         left[i].wrapping_shr(right[i] as u32)
       }));
@@ -1084,11 +1055,6 @@ fn test_shr() {
     )
     .chain(random_iter())
     {
-      // TODO: Decide how shift operators should behave then harden this test.
-      // Currently implementations either behave like `wrapping_shl/r` or
-      // `unbounded_shl/r` depending on target features.
-      let right = right.map(|x| x & (T::BITS - 1) as T);
-
       #[allow(clippy::unnecessary_cast)]
       let expected = Simd::new(std::array::from_fn(|i| {
         left[i].wrapping_shr(right[i] as u32)
@@ -1106,7 +1072,7 @@ fn test_shr() {
 #[test]
 fn test_shr_scalar() {
   for_simd_types!(|T: Signed, N| {
-    for left in simd_chunks!([
+    for (left, right) in simd_chunks!([
       1,
       2,
       T::MAX - 1,
@@ -1121,41 +1087,34 @@ fn test_shr_scalar() {
       T::MIN + 1,
       T::MIN / 2,
     ])
+    .flat_map(|left| [1, 0, 3, -2, -6, 100].map(|right| (left, right)))
     .chain(random_iter())
     {
-      for right in [1, 0, 3, -2, -6, 100] {
-        // TODO: Decide how shift operators should behave then harden this test.
-        // Currently implementations either behave like `wrapping_shl/r` or
-        // `unbounded_shl/r` depending on target features.
-        let right = right & (T::BITS - 1) as i32;
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].wrapping_shr(right as u32)));
 
-        let expected = Simd::new(std::array::from_fn(|i| {
-          left[i].wrapping_shr(right as u32)
-        }));
-
-        for actual in [
-          Simd::new(left) >> right as i8,
-          Simd::new(left) >> right as u8,
-          Simd::new(left) >> right as i16,
-          Simd::new(left) >> right as u16,
-          Simd::new(left) >> right,
-          Simd::new(left) >> right as u32,
-          Simd::new(left) >> right as i64,
-          Simd::new(left) >> right as u64,
-          Simd::new(left) >> right as i128,
-          Simd::new(left) >> right as u128,
-          // `simd >> isize` and `simd >> usize` are missing.
-        ] {
-          assert!(
-            actual == expected,
-            "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
-          );
-        }
+      for actual in [
+        Simd::new(left) >> right as i8,
+        Simd::new(left) >> right as u8,
+        Simd::new(left) >> right as i16,
+        Simd::new(left) >> right as u16,
+        Simd::new(left) >> right,
+        Simd::new(left) >> right as u32,
+        Simd::new(left) >> right as i64,
+        Simd::new(left) >> right as u64,
+        Simd::new(left) >> right as i128,
+        Simd::new(left) >> right as u128,
+        // `simd >> isize` and `simd >> usize` are missing.
+      ] {
+        assert!(
+          actual == expected,
+          "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+        );
       }
     }
   });
   for_simd_types!(|T: Unsigned, N| {
-    for left in simd_chunks!([
+    for (left, right) in simd_chunks!([
       1,
       2,
       T::MAX - 1,
@@ -1170,36 +1129,29 @@ fn test_shr_scalar() {
       T::MIN + 1,
       T::MIN / 2,
     ])
+    .flat_map(|left| [1, 0, 3, -2, -6, 100].map(|right| (left, right)))
     .chain(random_iter())
     {
-      for right in [1, 0, 3, -2, -6, 100] {
-        // TODO: Decide how shift operators should behave then harden this test.
-        // Currently implementations either behave like `wrapping_shl/r` or
-        // `unbounded_shl/r` depending on target features.
-        let right = right & (T::BITS - 1) as i32;
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].wrapping_shr(right as u32)));
 
-        let expected = Simd::new(std::array::from_fn(|i| {
-          left[i].wrapping_shr(right as u32)
-        }));
-
-        for actual in [
-          Simd::new(left) >> right as i8,
-          Simd::new(left) >> right as u8,
-          Simd::new(left) >> right as i16,
-          Simd::new(left) >> right as u16,
-          Simd::new(left) >> right,
-          Simd::new(left) >> right as u32,
-          Simd::new(left) >> right as i64,
-          Simd::new(left) >> right as u64,
-          Simd::new(left) >> right as i128,
-          Simd::new(left) >> right as u128,
-          // `simd >> isize` and `simd >> usize` are missing.
-        ] {
-          assert!(
-            actual == expected,
-            "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
-          );
-        }
+      for actual in [
+        Simd::new(left) >> right as i8,
+        Simd::new(left) >> right as u8,
+        Simd::new(left) >> right as i16,
+        Simd::new(left) >> right as u16,
+        Simd::new(left) >> right,
+        Simd::new(left) >> right as u32,
+        Simd::new(left) >> right as i64,
+        Simd::new(left) >> right as u64,
+        Simd::new(left) >> right as i128,
+        Simd::new(left) >> right as u128,
+        // `simd >> isize` and `simd >> usize` are missing.
+      ] {
+        assert!(
+          actual == expected,
+          "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+        );
       }
     }
   });

--- a/tests/utils/random_iter.rs
+++ b/tests/utils/random_iter.rs
@@ -137,3 +137,13 @@ where
     std::array::from_fn(|_| T::random(state))
   }
 }
+
+impl<T0, T1> Random for (T0, T1)
+where
+  T0: Random,
+  T1: Random,
+{
+  fn random(state: &mut u64) -> Self {
+    (T0::random(state), T1::random(state))
+  }
+}


### PR DESCRIPTION
Currently some shift operator implementations incorrectly behave like `unbounded_shl/r` instead of `wrapping_shl/r` (`std` primitive shift operators behave like `wrapping_shl/r` when overflow checks are disabled).

This PR changes the remaining implementations to behave like `wrapping_shl/r`.