### PR TITLE
fix: Edge case in `powf`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
 
+* Fixed bug in `powf`.
+
 ## 1.5.0
 
 * Added several functions and trait implementations that previously were only

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -1925,8 +1925,8 @@ impl f32x16 {
       // Y into an integer
       let yi = y.simd_eq(y.round());
 
-      // Is y odd?
-      let y_odd = cast::<_, i32x16>(y.round_int() << 31).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i32x16, f32x16>(y.round_int() << 31);
 
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -2197,8 +2197,8 @@ impl f32x4 {
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
-      // Is y odd?
-      let y_odd = cast::<_, i32x4>(y.round_int() << 31).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i32x4, f32x4>(y.round_int() << 31);
 
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -1912,8 +1912,8 @@ impl f32x8 {
       // Y into an integer
       let yi = y.simd_eq(y.round());
 
-      // Is y odd?
-      let y_odd = cast::<_, i32x8>(y.round_int() << 31).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i32x8, f32x8>(y.round_int() << 31);
 
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -2355,8 +2355,8 @@ impl f64x2 {
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
-      // Is y odd?
-      let y_odd = cast::<_, i64x2>(y.round_int() << 63).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i64x2, f64x2>(y.round_int() << 63);
 
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -2148,8 +2148,9 @@ impl f64x4 {
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
-      // Is y odd?
-      let y_odd = cast::<_, i64x4>(y.round_int() << 63).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i64x4, f64x4>(y.round_int() << 63);
+
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
       x_sign.blend(z1, z)

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -2142,8 +2142,9 @@ impl f64x8 {
     let z = if x_sign.any() {
       // Y into an integer
       let yi = y.simd_eq(y.round());
-      // Is y odd?
-      let y_odd = cast::<_, i64x8>(y.round_int() << 63).round_float();
+      // Is y odd? If yes flip the sign of the result.
+      let y_odd = cast::<i64x8, f64x8>(y.round_int() << 63);
+
       let z1 =
         yi.blend(z | y_odd, self.simd_eq(Self::ZERO).blend(z, Self::nan_pow()));
       x_sign.blend(z1, z)

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -1637,26 +1637,17 @@ fn test_log10() {
 
 #[test]
 fn test_pow_simd() {
-  // TODO: fix `powf` which currently breaks when, possibly among other cases,
-  // `self` is negative and `n` is an odd number. These inputs lead to an
-  // incorrect result:
-  //
-  // simd_chunks!(
-  //  [
-  //    1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
-  //    -3.1, -3.0, -4.0, 5.1,
-  //  ],
-  //  [
-  //    0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
-  //    2.7, 4.0, -3.0, 29.0,
-  //  ],
-  // )
-
   for_simd_types!(|T: Float, N| {
     #[expect(clippy::approx_constant)]
     for [value, n] in simd_chunks!(
-      [1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, 5.1],
-      [0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 29.0],
+      [
+        1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
+        -3.1, -3.0, -4.0, 5.1,
+      ],
+      [
+        0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
+        2.7, 4.0, -3.0, 29.0,
+      ],
     ) {
       let expected = Simd::new(std::array::from_fn(|i| value[i].powf(n[i])));
       let actual = pow_simd(Simd::new(value), Simd::new(n));
@@ -1673,27 +1664,15 @@ fn test_pow_simd() {
 
 #[test]
 fn test_powf() {
-  // TODO: fix `powf` which currently breaks when, possibly among other cases,
-  // `self` is negative and `n` is an odd number. These inputs lead to an
-  // incorrect result:
-  //
-  // simd_chunks!(
-  //  [
-  //    1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
-  //    -3.1, -3.0, -4.0, 5.1,
-  //  ],
-  //  [
-  //    0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
-  //    2.7, 4.0, -3.0, 29.0,
-  //  ],
-  // )
-
   for_simd_types!(|T: Float, N| {
-    for value in simd_chunks!([1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3]) {
+    for value in simd_chunks!([
+      1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
+      -3.1, -3.0, -4.0, 5.1,
+    ]) {
       #[expect(clippy::approx_constant)]
       for n in [
-        0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 2.7,
-        4.0, -3.0, 29.0,
+        0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
+        2.7, 4.0, -3.0, 29.0,
       ] {
         let expected = Simd::new(std::array::from_fn(|i| value[i].powf(n)));
         let actual = Simd::new(value).powf(n);


### PR DESCRIPTION
This fixes a bug in `powf` which was marked with this TODO:

```
// TODO: fix `powf` which currently breaks when, possibly among other cases,
// `self` is negative and `n` is an odd number. These inputs lead to an
// incorrect result:
//
// simd_chunks!(
//  [
//    1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
//    -3.1, -3.0, -4.0, 5.1,
//  ],
//  [
//    0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
//    2.7, 4.0, -3.0, 29.0,
//  ],
// )
```

# Explanation

The bug did occur specifically when `x` is negative and `n` is an odd integer. The implementation checks for this case and is supposed to flip the sign of the result if it occurs by shifting the least significant bit of `round_int` into the sign bit. The bug was caused by using `round_float` instead of `cast` to convert the shifted sign bit value into a float.