### PR TITLE
feat: Overflowing integer functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 * Added `reduce_mul` for integers.
 
+* Added overflowing arithmetic for integers.
+
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
 
 ## 1.5.0

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -733,6 +733,8 @@ impl i16x16 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  signed_fn_overflowing_div_rem!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -711,6 +711,8 @@ impl i16x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  signed_fn_overflowing_add_sub!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -713,6 +713,26 @@ impl i16x16 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm256_mul_epi16` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i16x16, [i16x8; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i16x16, [i16x8; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -591,6 +591,26 @@ impl i16x32 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm512_mul_epi16` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i16x32, [i16x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i16x32, [i16x16; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -589,6 +589,8 @@ impl i16x32 {
     21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
   ]);
 
+  signed_fn_overflowing_add_sub!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -611,6 +611,8 @@ impl i16x32 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  signed_fn_overflowing_div_rem!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1212,6 +1212,86 @@ impl i16x8 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        let low_wide_mul = i32x4_extmul_low_i16x8(self.simd, rhs.simd);
+        let high_wide_mul = i32x4_extmul_high_i16x8(self.simd, rhs.simd);
+        let low = Self { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
+        let high = Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_s16_s32(
+            vmull_s16(vget_low_s16(self.neon), vget_low_s16(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_s16_s32(
+            vmull_s16(vget_high_s16(self.neon), vget_high_s16(rhs.neon)),
+          );
+          let low_high = vuzpq_s16(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(low.is_negative());
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[i32; 8], [[i16; 2]; 8]>([
+          (self_array[0] as i32).wrapping_mul(rhs_array[0] as i32),
+          (self_array[1] as i32).wrapping_mul(rhs_array[1] as i32),
+          (self_array[2] as i32).wrapping_mul(rhs_array[2] as i32),
+          (self_array[3] as i32).wrapping_mul(rhs_array[3] as i32),
+          (self_array[4] as i32).wrapping_mul(rhs_array[4] as i32),
+          (self_array[5] as i32).wrapping_mul(rhs_array[5] as i32),
+          (self_array[6] as i32).wrapping_mul(rhs_array[6] as i32),
+          (self_array[7] as i32).wrapping_mul(rhs_array[7] as i32),
+        ]);
+        let low = Self::new([
+          widening_mul[0][0],
+          widening_mul[1][0],
+          widening_mul[2][0],
+          widening_mul[3][0],
+          widening_mul[4][0],
+          widening_mul[5][0],
+          widening_mul[6][0],
+          widening_mul[7][0],
+        ]);
+        let high = Self::new([
+          widening_mul[0][1],
+          widening_mul[1][1],
+          widening_mul[2][1],
+          widening_mul[3][1],
+          widening_mul[4][1],
+          widening_mul[5][1],
+          widening_mul[6][1],
+          widening_mul[7][1],
+        ]);
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      }
+    }
+  }
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1210,6 +1210,8 @@ impl i16x8 {
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
+  signed_fn_overflowing_add_sub!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1292,6 +1292,8 @@ impl i16x8 {
     }
   }
 
+  signed_fn_overflowing_div_rem!();
+
   /// Calculates partial dot product.
   /// Multiplies packed signed 16-bit integers, producing intermediate signed
   /// 32-bit integers. Horizontally add adjacent pairs of intermediate 32-bit

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -561,6 +561,54 @@ impl i32x16 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+
+        let even_wide_mul = mul_i32_wide_m512i(self.avx512, rhs.avx512);
+        let odd_wide_mul = mul_i32_wide_m512i(
+          shuffle_i32_m512i::<0b_00_11_00_01>(self.avx512),
+          shuffle_i32_m512i::<0b_00_11_00_01>(rhs.avx512),
+        );
+        let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
+        // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
+        let low = Self {
+          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        };
+        let high = Self {
+          avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else {
+        let [self_a, self_b] = cast::<i32x16, [i32x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<i32x16, [i32x8; 2]>(rhs);
+
+        let result_a = self_a.overflowing_mul(rhs_a);
+        let result_b = self_b.overflowing_mul(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
+      }
+    }
+  }
+
   /// horizontal add of all the elements of the vector
   #[inline]
   #[must_use]

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -609,6 +609,8 @@ impl i32x16 {
     }
   }
 
+  signed_fn_overflowing_div_rem!();
+
   /// horizontal add of all the elements of the vector
   #[inline]
   #[must_use]

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -559,6 +559,8 @@ impl i32x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  signed_fn_overflowing_add_sub!();
+
   /// horizontal add of all the elements of the vector
   #[inline]
   #[must_use]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -886,6 +886,8 @@ impl i32x4 {
 
   integer_fn_saturating_div!([0, 1, 2, 3]);
 
+  signed_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x4 {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -888,6 +888,78 @@ impl i32x4 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        let even_wide_mul = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
+        let odd_wide_mul = mul_widen_i32_odd_m128i(
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(self.sse),
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(rhs.sse),
+        );
+        let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
+        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
+        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else if #[cfg(target_feature="simd128")] {
+        let low_wide_mul = i64x2_extmul_low_i32x4(self.simd, rhs.simd);
+        let high_wide_mul = i64x2_extmul_high_i32x4(self.simd, rhs.simd);
+        let low = Self { simd: i32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
+        let high = Self { simd: i32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_s32_s64(
+            vmull_s32(vget_low_s32(self.neon), vget_low_s32(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_s32_s64(
+            vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)),
+          );
+          let low_high = vuzpq_s32(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(low.is_negative());
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[i64; 4], [[i32; 2]; 4]>([
+          (self_array[0] as i64).wrapping_mul(rhs_array[0] as i64),
+          (self_array[1] as i64).wrapping_mul(rhs_array[1] as i64),
+          (self_array[2] as i64).wrapping_mul(rhs_array[2] as i64),
+          (self_array[3] as i64).wrapping_mul(rhs_array[3] as i64),
+        ]);
+        let low = Self::new([widening_mul[0][0], widening_mul[1][0], widening_mul[2][0], widening_mul[3][0]]);
+        let high = Self::new([widening_mul[0][1], widening_mul[1][1], widening_mul[2][1], widening_mul[3][1]]);
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x4 {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -960,6 +960,8 @@ impl i32x4 {
     }
   }
 
+  signed_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x4 {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -705,6 +705,8 @@ impl i32x8 {
     }
   }
 
+  signed_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x8 {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -665,6 +665,8 @@ impl i32x8 {
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
+  signed_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x8 {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -667,6 +667,44 @@ impl i32x8 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
+        let odd_wide_mul = mul_i64_low_bits_m256i(
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+        );
+        let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
+        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
+        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else {
+        let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<i32x8, [i32x4; 2]>(rhs);
+
+        let result_a = self_a.overflowing_mul(rhs_a);
+        let result_b = self_b.overflowing_mul(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x8 {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -868,4 +868,6 @@ impl i64x2 {
   }
 
   integer_fn_saturating_div!([0, 1]);
+
+  signed_fn_overflowing_add_sub!();
 }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -870,4 +870,29 @@ impl i64x2 {
   integer_fn_saturating_div!([0, 1]);
 
   signed_fn_overflowing_add_sub!();
+
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+    ];
+    (
+      Self::new([result[0].0, result[1].0]),
+      Self::new([-(result[0].1 as i64), -(result[1].1 as i64)]),
+    )
+  }
 }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -895,4 +895,6 @@ impl i64x2 {
       Self::new([-(result[0].1 as i64), -(result[1].1 as i64)]),
     )
   }
+
+  signed_fn_overflowing_div_rem!();
 }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -707,6 +707,8 @@ impl i64x4 {
     )
   }
 
+  signed_fn_overflowing_div_rem!();
+
   // Sometimes used for `transpose`.
   #[must_use]
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -673,6 +673,8 @@ impl i64x4 {
 
   integer_fn_saturating_div!([0, 1, 2, 3]);
 
+  signed_fn_overflowing_add_sub!();
+
   // Sometimes used for `transpose`.
   #[must_use]
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -675,6 +675,38 @@ impl i64x4 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+      self_array[2].overflowing_mul(rhs_array[2]),
+      self_array[3].overflowing_mul(rhs_array[3]),
+    ];
+    (
+      Self::new([result[0].0, result[1].0, result[2].0, result[3].0]),
+      Self::new([
+        -(result[0].1 as i64),
+        -(result[1].1 as i64),
+        -(result[2].1 as i64),
+        -(result[3].1 as i64),
+      ]),
+    )
+  }
+
   // Sometimes used for `transpose`.
   #[must_use]
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -754,6 +754,55 @@ impl i64x8 {
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
   signed_fn_overflowing_add_sub!();
+
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+      self_array[2].overflowing_mul(rhs_array[2]),
+      self_array[3].overflowing_mul(rhs_array[3]),
+      self_array[4].overflowing_mul(rhs_array[4]),
+      self_array[5].overflowing_mul(rhs_array[5]),
+      self_array[6].overflowing_mul(rhs_array[6]),
+      self_array[7].overflowing_mul(rhs_array[7]),
+    ];
+    (
+      Self::new([
+        result[0].0,
+        result[1].0,
+        result[2].0,
+        result[3].0,
+        result[4].0,
+        result[5].0,
+        result[6].0,
+        result[7].0,
+      ]),
+      Self::new([
+        -(result[0].1 as i64),
+        -(result[1].1 as i64),
+        -(result[2].1 as i64),
+        -(result[3].1 as i64),
+        -(result[4].1 as i64),
+        -(result[5].1 as i64),
+        -(result[6].1 as i64),
+        -(result[7].1 as i64),
+      ]),
+    )
+  }
 }
 
 impl Not for i64x8 {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -752,6 +752,8 @@ impl i64x8 {
   }
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
+
+  signed_fn_overflowing_add_sub!();
 }
 
 impl Not for i64x8 {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -803,6 +803,8 @@ impl i64x8 {
       ]),
     )
   }
+
+  signed_fn_overflowing_div_rem!();
 }
 
 impl Not for i64x8 {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1502,6 +1502,101 @@ impl i8x16 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_s8_s16(
+            vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_s8_s16(
+            vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
+          );
+          let low_high = vuzpq_s8(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(low.is_negative());
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[i16; 16], [[i8; 2]; 16]>([
+          (self_array[0] as i16).wrapping_mul(rhs_array[0] as i16),
+          (self_array[1] as i16).wrapping_mul(rhs_array[1] as i16),
+          (self_array[2] as i16).wrapping_mul(rhs_array[2] as i16),
+          (self_array[3] as i16).wrapping_mul(rhs_array[3] as i16),
+          (self_array[4] as i16).wrapping_mul(rhs_array[4] as i16),
+          (self_array[5] as i16).wrapping_mul(rhs_array[5] as i16),
+          (self_array[6] as i16).wrapping_mul(rhs_array[6] as i16),
+          (self_array[7] as i16).wrapping_mul(rhs_array[7] as i16),
+          (self_array[8] as i16).wrapping_mul(rhs_array[8] as i16),
+          (self_array[9] as i16).wrapping_mul(rhs_array[9] as i16),
+          (self_array[10] as i16).wrapping_mul(rhs_array[10] as i16),
+          (self_array[11] as i16).wrapping_mul(rhs_array[11] as i16),
+          (self_array[12] as i16).wrapping_mul(rhs_array[12] as i16),
+          (self_array[13] as i16).wrapping_mul(rhs_array[13] as i16),
+          (self_array[14] as i16).wrapping_mul(rhs_array[14] as i16),
+          (self_array[15] as i16).wrapping_mul(rhs_array[15] as i16),
+        ]);
+        let low = Self::new([
+          widening_mul[0][0],
+          widening_mul[1][0],
+          widening_mul[2][0],
+          widening_mul[3][0],
+          widening_mul[4][0],
+          widening_mul[5][0],
+          widening_mul[6][0],
+          widening_mul[7][0],
+          widening_mul[8][0],
+          widening_mul[9][0],
+          widening_mul[10][0],
+          widening_mul[11][0],
+          widening_mul[12][0],
+          widening_mul[13][0],
+          widening_mul[14][0],
+          widening_mul[15][0],
+        ]);
+        let high = Self::new([
+          widening_mul[0][1],
+          widening_mul[1][1],
+          widening_mul[2][1],
+          widening_mul[3][1],
+          widening_mul[4][1],
+          widening_mul[5][1],
+          widening_mul[6][1],
+          widening_mul[7][1],
+          widening_mul[8][1],
+          widening_mul[9][1],
+          widening_mul[10][1],
+          widening_mul[11][1],
+          widening_mul[12][1],
+          widening_mul[13][1],
+          widening_mul[14][1],
+          widening_mul[15][1],
+        ]);
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      }
+    }
+  }
+
   /// Transpose matrix of 16x16 `i8` matrix. Currently not accelerated.
   #[must_use]
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1500,6 +1500,8 @@ impl i8x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  signed_fn_overflowing_add_sub!();
+
   /// Transpose matrix of 16x16 `i8` matrix. Currently not accelerated.
   #[must_use]
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1597,6 +1597,8 @@ impl i8x16 {
     }
   }
 
+  signed_fn_overflowing_div_rem!();
+
   /// Transpose matrix of 16x16 `i8` matrix. Currently not accelerated.
   #[must_use]
   #[inline]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -576,6 +576,26 @@ impl i8x32 {
 
   signed_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm256_mul_epi8` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i8x32, [i8x16; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -574,6 +574,8 @@ impl i8x32 {
     21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
   ]);
 
+  signed_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -596,6 +596,8 @@ impl i8x32 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  signed_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -251,6 +251,44 @@ macro_rules! signed_fn_overflowing_add_sub {
   };
 }
 
+macro_rules! signed_fn_overflowing_div_rem {
+  () => {
+    /// Returns `self / rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The division (returns `self` if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    ///
+    /// Note that because division has no hardware support, this operation is
+    /// very slow and should be avoided if possible.
+    #[inline]
+    #[must_use]
+    pub fn overflowing_div(self, rhs: Self) -> (Self, Self) {
+      // The second field is equivalent to
+      // `self.simd_eq(Self::MIN) & rhs.simd_eq(-1)` but may be cheaper.
+      (self / rhs, ((self ^ Self::MAX) & rhs).simd_eq(!Self::ZERO))
+    }
+
+    /// Returns `self % rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The remainder (returns zero if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    ///
+    /// Note that because division has no hardware support, this operation is
+    /// very slow and should be avoided if possible.
+    #[inline]
+    #[must_use]
+    pub fn overflowing_rem(self, rhs: Self) -> (Self, Self) {
+      // The second field is equivalent to
+      // `self.simd_eq(Self::MIN) & rhs.simd_eq(-1)` but may be cheaper.
+      (self % rhs, ((self ^ Self::MAX) & rhs).simd_eq(!Self::ZERO))
+    }
+  };
+}
+
 macro_rules! signed_fn_signum {
   () => {
     /// Returns numbers representing the sign of each element.
@@ -298,6 +336,48 @@ macro_rules! unsigned_fn_overflowing_add_sub {
       let overflow = result.simd_gt(self);
 
       (result, overflow)
+    }
+  };
+}
+
+macro_rules! unsigned_fn_overflowing_div_rem {
+  () => {
+    /// Returns `self / rhs` and whether an overflow occured.
+    ///
+    /// Note that for unsigned integers overflow never occurs, so the second
+    /// value is always `false`. This function only exists for consistency with
+    /// signed integers.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The division (returns `self` if an overflow occured)
+    /// - A mask indicating whether an overflow occured (always false)
+    ///
+    /// Note that because division has no hardware support, this operation is
+    /// very slow and should be avoided if possible.
+    #[inline]
+    #[must_use]
+    pub fn overflowing_div(self, rhs: Self) -> (Self, Self) {
+      (self / rhs, Self::ZERO)
+    }
+
+    /// Returns `self % rhs` and whether an overflow occured.
+    ///
+    /// Note that for unsigned integers overflow never occurs, so the second
+    /// value is always `false`. This function only exists for consistency with
+    /// signed integers.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The remainder (returns zero if an overflow occured)
+    /// - A mask indicating whether an overflow occured (always false)
+    ///
+    /// Note that because division has no hardware support, this operation is
+    /// very slow and should be avoided if possible.
+    #[inline]
+    #[must_use]
+    pub fn overflowing_rem(self, rhs: Self) -> (Self, Self) {
+      (self % rhs, Self::ZERO)
     }
   };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -217,6 +217,40 @@ macro_rules! integer_fn_saturating_div {
   };
 }
 
+macro_rules! signed_fn_overflowing_add_sub {
+  () => {
+    /// Returns `self + rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The addition (returns the wrapped value if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    #[inline]
+    #[must_use]
+    pub fn overflowing_add(self, rhs: Self) -> (Self, Self) {
+      let result = self + rhs;
+      let overflow = (!(self ^ rhs) & (self ^ result)).is_negative();
+
+      (result, overflow)
+    }
+
+    /// Returns `self - rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The subtraction (returns the wrapped value if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    #[inline]
+    #[must_use]
+    pub fn overflowing_sub(self, rhs: Self) -> (Self, Self) {
+      let result = self - rhs;
+      let overflow = ((self ^ rhs) & (self ^ result)).is_negative();
+
+      (result, overflow)
+    }
+  };
+}
+
 macro_rules! signed_fn_signum {
   () => {
     /// Returns numbers representing the sign of each element.
@@ -230,6 +264,40 @@ macro_rules! signed_fn_signum {
       // Flip signs because the result for true in `is_positive/negative` is
       // `-1` (all bits set).
       self.is_negative() - self.is_positive()
+    }
+  };
+}
+
+macro_rules! unsigned_fn_overflowing_add_sub {
+  () => {
+    /// Returns `self + rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The addition (returns the wrapped value if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    #[inline]
+    #[must_use]
+    pub fn overflowing_add(self, rhs: Self) -> (Self, Self) {
+      let result = self + rhs;
+      let overflow = result.simd_lt(self);
+
+      (result, overflow)
+    }
+
+    /// Returns `self - rhs` and whether an overflow occured.
+    ///
+    /// Returns a tuple with:
+    ///
+    /// - The subtraction (returns the wrapped value if an overflow occured)
+    /// - A mask indicating whether an overflow occured
+    #[inline]
+    #[must_use]
+    pub fn overflowing_sub(self, rhs: Self) -> (Self, Self) {
+      let result = self - rhs;
+      let overflow = result.simd_gt(self);
+
+      (result, overflow)
     }
   };
 }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -574,6 +574,8 @@ impl u16x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -596,6 +596,8 @@ impl u16x16 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -576,6 +576,26 @@ impl u16x16 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm256_mul_epu16` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -528,6 +528,8 @@ impl u16x32 {
     21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
   ]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -530,6 +530,26 @@ impl u16x32 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm512_mul_epu16` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -550,6 +550,8 @@ impl u16x32 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -894,6 +894,86 @@ impl u16x8 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        let low_wide_mul = u32x4_extmul_low_u16x8(self.simd, rhs.simd);
+        let high_wide_mul = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
+        let low = Self { simd: u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
+        let high = Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_u16_u32(
+            vmull_u16(vget_low_u16(self.neon), vget_low_u16(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_u16_u32(
+            vmull_u16(vget_high_u16(self.neon), vget_high_u16(rhs.neon)),
+          );
+          let low_high = vuzpq_u16(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(Self::ZERO);
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[u32; 8], [[u16; 2]; 8]>([
+          (self_array[0] as u32).wrapping_mul(rhs_array[0] as u32),
+          (self_array[1] as u32).wrapping_mul(rhs_array[1] as u32),
+          (self_array[2] as u32).wrapping_mul(rhs_array[2] as u32),
+          (self_array[3] as u32).wrapping_mul(rhs_array[3] as u32),
+          (self_array[4] as u32).wrapping_mul(rhs_array[4] as u32),
+          (self_array[5] as u32).wrapping_mul(rhs_array[5] as u32),
+          (self_array[6] as u32).wrapping_mul(rhs_array[6] as u32),
+          (self_array[7] as u32).wrapping_mul(rhs_array[7] as u32),
+        ]);
+        let low = Self::new([
+          widening_mul[0][0],
+          widening_mul[1][0],
+          widening_mul[2][0],
+          widening_mul[3][0],
+          widening_mul[4][0],
+          widening_mul[5][0],
+          widening_mul[6][0],
+          widening_mul[7][0],
+        ]);
+        let high = Self::new([
+          widening_mul[0][1],
+          widening_mul[1][1],
+          widening_mul[2][1],
+          widening_mul[3][1],
+          widening_mul[4][1],
+          widening_mul[5][1],
+          widening_mul[6][1],
+          widening_mul[7][1],
+        ]);
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      }
+    }
+  }
+
   /// Unpack the lower half of the input and zero expand it to `u16` values.
   #[inline]
   #[must_use]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -974,6 +974,8 @@ impl u16x8 {
     }
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   /// Unpack the lower half of the input and zero expand it to `u16` values.
   #[inline]
   #[must_use]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -892,6 +892,8 @@ impl u16x8 {
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   /// Unpack the lower half of the input and zero expand it to `u16` values.
   #[inline]
   #[must_use]

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -640,6 +640,8 @@ impl u32x16 {
     }
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -589,6 +589,8 @@ impl u32x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -591,6 +591,55 @@ impl u32x16 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+
+        let even_wide_mul = mul_u32_wide_m512i(self.avx512, rhs.avx512);
+        let odd_wide_mul = mul_u32_wide_m512i(
+          shuffle_i32_m512i::<0b_00_11_00_01>(self.avx512),
+          shuffle_i32_m512i::<0b_00_11_00_01>(rhs.avx512),
+        );
+
+        let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
+        // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
+        let low = Self {
+          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        };
+        let high = Self {
+          avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        };
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      } else {
+        let [self_a, self_b] = cast::<u32x16, [u32x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u32x16, [u32x8; 2]>(rhs);
+
+        let result_a = self_a.overflowing_mul(rhs_a);
+        let result_b = self_b.overflowing_mul(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -842,6 +842,8 @@ impl u32x4 {
 
   integer_fn_saturating_div!([0, 1, 2, 3]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -844,6 +844,79 @@ impl u32x4 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        let even_wide_mul = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
+        let odd_wide_mul = mul_widen_u32_odd_m128i(
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(self.sse),
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(rhs.sse),
+        );
+
+        let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
+        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
+        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      } else if #[cfg(target_feature="simd128")] {
+        let low_wide_mul = u64x2_extmul_low_u32x4(self.simd, rhs.simd);
+        let high_wide_mul = u64x2_extmul_high_u32x4(self.simd, rhs.simd);
+        let low = Self { simd: u32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
+        let high = Self { simd: u32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_u32_u64(
+            vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_u32_u64(
+            vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon)),
+          );
+          let low_high = vuzpq_u32(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(Self::ZERO);
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[u64; 4], [[u32; 2]; 4]>([
+          (self_array[0] as u64).wrapping_mul(rhs_array[0] as u64),
+          (self_array[1] as u64).wrapping_mul(rhs_array[1] as u64),
+          (self_array[2] as u64).wrapping_mul(rhs_array[2] as u64),
+          (self_array[3] as u64).wrapping_mul(rhs_array[3] as u64),
+        ]);
+        let low = Self::new([widening_mul[0][0], widening_mul[1][0], widening_mul[2][0], widening_mul[3][0]]);
+        let high = Self::new([widening_mul[0][1], widening_mul[1][1], widening_mul[2][1], widening_mul[3][1]]);
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -917,6 +917,8 @@ impl u32x4 {
     }
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn any(self) -> bool {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -694,7 +694,7 @@ impl u32x8 {
         let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
         let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
 
-        let overflow = high.simd_ne(low.is_negative());
+        let overflow = high.simd_ne(Self::ZERO);
 
         (low, overflow)
       } else {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -711,6 +711,8 @@ impl u32x8 {
     }
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -671,6 +671,8 @@ impl u32x8 {
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -673,6 +673,44 @@ impl u32x8 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let even_wide_mul = mul_u64_low_bits_m256i(self.avx2, rhs.avx2);
+        let odd_wide_mul = mul_u64_low_bits_m256i(
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+        );
+        let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
+        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
+        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
+
+        let overflow = high.simd_ne(low.is_negative());
+
+        (low, overflow)
+      } else {
+        let [self_a, self_b] = cast::<u32x8, [u32x4; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u32x8, [u32x4; 2]>(rhs);
+
+        let result_a = self_a.overflowing_mul(rhs_a);
+        let result_b = self_b.overflowing_mul(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
+      }
+    }
+  }
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -684,6 +684,8 @@ impl u64x2 {
 
   integer_fn_saturating_div!([0, 1]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -711,6 +711,8 @@ impl u64x2 {
     )
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -686,6 +686,31 @@ impl u64x2 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+    ];
+    (
+      Self::new([result[0].0, result[1].0]),
+      Self::new([-(result[0].1 as i64) as u64, -(result[1].1 as i64) as u64]),
+    )
+  }
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -576,6 +576,8 @@ impl u64x4 {
     )
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -544,6 +544,38 @@ impl u64x4 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+      self_array[2].overflowing_mul(rhs_array[2]),
+      self_array[3].overflowing_mul(rhs_array[3]),
+    ];
+    (
+      Self::new([result[0].0, result[1].0, result[2].0, result[3].0]),
+      Self::new([
+        -(result[0].1 as i64) as u64,
+        -(result[1].1 as i64) as u64,
+        -(result[2].1 as i64) as u64,
+        -(result[3].1 as i64) as u64,
+      ]),
+    )
+  }
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -542,6 +542,8 @@ impl u64x4 {
 
   integer_fn_saturating_div!([0, 1, 2, 3]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -558,6 +558,8 @@ impl u64x8 {
 
   integer_fn_saturating_div!([0, 1, 2, 3, 4, 5, 6, 7]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -609,6 +609,8 @@ impl u64x8 {
     )
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -560,6 +560,55 @@ impl u64x8 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let result = [
+      self_array[0].overflowing_mul(rhs_array[0]),
+      self_array[1].overflowing_mul(rhs_array[1]),
+      self_array[2].overflowing_mul(rhs_array[2]),
+      self_array[3].overflowing_mul(rhs_array[3]),
+      self_array[4].overflowing_mul(rhs_array[4]),
+      self_array[5].overflowing_mul(rhs_array[5]),
+      self_array[6].overflowing_mul(rhs_array[6]),
+      self_array[7].overflowing_mul(rhs_array[7]),
+    ];
+    (
+      Self::new([
+        result[0].0,
+        result[1].0,
+        result[2].0,
+        result[3].0,
+        result[4].0,
+        result[5].0,
+        result[6].0,
+        result[7].0,
+      ]),
+      Self::new([
+        -(result[0].1 as i64) as u64,
+        -(result[1].1 as i64) as u64,
+        -(result[2].1 as i64) as u64,
+        -(result[3].1 as i64) as u64,
+        -(result[4].1 as i64) as u64,
+        -(result[5].1 as i64) as u64,
+        -(result[6].1 as i64) as u64,
+        -(result[7].1 as i64) as u64,
+      ]),
+    )
+  }
+
   #[inline]
   #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1241,6 +1241,8 @@ impl u8x16 {
     }
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   /// Unpack and interleave low lanes of two `u8x16`
   #[inline]
   #[must_use]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1146,6 +1146,101 @@ impl u8x16 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_u8_u16(
+            vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_u8_u16(
+            vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
+          );
+          let low_high = vuzpq_u8(low_wide_mul, high_wide_mul);
+          let low = Self { neon: low_high.0 };
+          let high = Self { neon: low_high.1 };
+
+          let overflow = high.simd_ne(Self::ZERO);
+
+          (low, overflow)
+        }
+      } else {
+        // TODO(perf): This implementation looks quite bad. Is there a better
+        // one?
+
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        let widening_mul = cast::<[u16; 16], [[u8; 2]; 16]>([
+          (self_array[0] as u16).wrapping_mul(rhs_array[0] as u16),
+          (self_array[1] as u16).wrapping_mul(rhs_array[1] as u16),
+          (self_array[2] as u16).wrapping_mul(rhs_array[2] as u16),
+          (self_array[3] as u16).wrapping_mul(rhs_array[3] as u16),
+          (self_array[4] as u16).wrapping_mul(rhs_array[4] as u16),
+          (self_array[5] as u16).wrapping_mul(rhs_array[5] as u16),
+          (self_array[6] as u16).wrapping_mul(rhs_array[6] as u16),
+          (self_array[7] as u16).wrapping_mul(rhs_array[7] as u16),
+          (self_array[8] as u16).wrapping_mul(rhs_array[8] as u16),
+          (self_array[9] as u16).wrapping_mul(rhs_array[9] as u16),
+          (self_array[10] as u16).wrapping_mul(rhs_array[10] as u16),
+          (self_array[11] as u16).wrapping_mul(rhs_array[11] as u16),
+          (self_array[12] as u16).wrapping_mul(rhs_array[12] as u16),
+          (self_array[13] as u16).wrapping_mul(rhs_array[13] as u16),
+          (self_array[14] as u16).wrapping_mul(rhs_array[14] as u16),
+          (self_array[15] as u16).wrapping_mul(rhs_array[15] as u16),
+        ]);
+        let low = Self::new([
+          widening_mul[0][0],
+          widening_mul[1][0],
+          widening_mul[2][0],
+          widening_mul[3][0],
+          widening_mul[4][0],
+          widening_mul[5][0],
+          widening_mul[6][0],
+          widening_mul[7][0],
+          widening_mul[8][0],
+          widening_mul[9][0],
+          widening_mul[10][0],
+          widening_mul[11][0],
+          widening_mul[12][0],
+          widening_mul[13][0],
+          widening_mul[14][0],
+          widening_mul[15][0],
+        ]);
+        let high = Self::new([
+          widening_mul[0][1],
+          widening_mul[1][1],
+          widening_mul[2][1],
+          widening_mul[3][1],
+          widening_mul[4][1],
+          widening_mul[5][1],
+          widening_mul[6][1],
+          widening_mul[7][1],
+          widening_mul[8][1],
+          widening_mul[9][1],
+          widening_mul[10][1],
+          widening_mul[11][1],
+          widening_mul[12][1],
+          widening_mul[13][1],
+          widening_mul[14][1],
+          widening_mul[15][1],
+        ]);
+
+        let overflow = high.simd_ne(Self::ZERO);
+
+        (low, overflow)
+      }
+    }
+  }
+
   /// Unpack and interleave low lanes of two `u8x16`
   #[inline]
   #[must_use]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1144,6 +1144,8 @@ impl u8x16 {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
   ]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   /// Unpack and interleave low lanes of two `u8x16`
   #[inline]
   #[must_use]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -540,6 +540,26 @@ impl u8x32 {
 
   unsigned_fn_overflowing_add_sub!();
 
+  /// Returns `self * rhs` and whether an overflow occured.
+  ///
+  /// Returns a tuple with:
+  ///
+  /// - The multiplication (returns the wrapped value if an overflow occured)
+  /// - A mask indicating whether an overflow occured
+  #[inline]
+  #[must_use]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    // x86 has no `_mm256_mul_epu8` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+
+    let result_a = self_a.overflowing_mul(rhs_a);
+    let result_b = self_b.overflowing_mul(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -560,6 +560,8 @@ impl u8x32 {
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
   }
 
+  unsigned_fn_overflowing_div_rem!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -538,6 +538,8 @@ impl u8x32 {
     21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
   ]);
 
+  unsigned_fn_overflowing_add_sub!();
+
   #[inline]
   #[must_use]
   #[doc(alias("movemask", "move_mask"))]

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -386,6 +386,122 @@ fn test_overflowing_mul() {
 }
 
 #[test]
+fn test_overflowing_div() {
+  for_simd_types!(|T: Integer, N| {
+    for [left, mut right] in simd_chunks!(
+      [11, 15, 2, 3, T::MAX, 0, T::MAX, T::MAX - 1],
+      [2, 5, 5, 8, 10, 5, 2, 10],
+    )
+    .chain(random_iter())
+    {
+      for right in &mut right {
+        if *right == 0 {
+          *right = 3;
+        }
+      }
+
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_div(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_div(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_div(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Signed, N| {
+    for [left, mut right] in simd_chunks!(
+      [11, 15, -13, -16, T::MIN, 0, T::MIN, T::MIN + 1],
+      [-2, -5, 3, -6, -2, -1, -1, -1],
+    )
+    .chain(random_iter())
+    {
+      for right in &mut right {
+        if *right == 0 {
+          *right = 3;
+        }
+      }
+
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_div(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_div(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_div(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
+fn test_overflowing_rem() {
+  for_simd_types!(|T: Integer, N| {
+    for [left, mut right] in simd_chunks!(
+      [11, 15, 2, 3, T::MAX, 0, T::MAX, T::MAX - 1],
+      [2, 5, 5, 8, 10, 5, 2, 10],
+    )
+    .chain(random_iter())
+    {
+      for right in &mut right {
+        if *right == 0 {
+          *right = 3;
+        }
+      }
+
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_rem(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_rem(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_rem(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Signed, N| {
+    for [left, mut right] in simd_chunks!(
+      [11, 15, -13, -16, T::MIN, 0, T::MIN, T::MIN + 1],
+      [-2, -5, 3, -6, -2, -1, -1, -1],
+    )
+    .chain(random_iter())
+    {
+      for right in &mut right {
+        if *right == 0 {
+          *right = 3;
+        }
+      }
+
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_rem(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_rem(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_rem(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
 fn test_from_big_truncate() {
   // `from_{big}_truncate` is inconsistently missing from types.
 

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -290,6 +290,102 @@ fn test_overflowing_sub() {
 }
 
 #[test]
+fn test_overflowing_mul() {
+  for_simd_types!(|T: Signed, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MIN + 1,
+        T::MIN,
+        2,
+        3,
+        4,
+        5,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        T::MAX / 2,
+        T::MIN / 2,
+      ],
+      [17, -18, 1, 1, -1, -2, -6, 3, 3, 2, 1, 3, 3],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_mul(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_mul(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_mul(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        3,
+        4,
+        5,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+      ],
+      [
+        17,
+        18,
+        9,
+        1,
+        0,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+      ],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_mul(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_mul(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_mul(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
 fn test_from_big_truncate() {
   // `from_{big}_truncate` is inconsistently missing from types.
 

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -210,6 +210,86 @@ fn test_saturating_div() {
 }
 
 #[test]
+fn test_overflowing_add() {
+  for_simd_types!(|T: Integer, N| {
+    for [left, right] in simd_chunks!(
+      [1, 2, T::MAX - 1, T::MAX - 1, 15, 20, 100, T::MAX - 1, T::MAX / 2],
+      [17, 18, 1, 2, 20, 5, T::MAX - 5, 50, 100],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_add(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_add(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_add(Simd::new(right));
+
+      assert_eq!(expected, actual);
+    }
+  });
+  for_simd_types!(|T: Signed, N| {
+    for [left, right] in simd_chunks!(
+      [1, 2, T::MAX - 1, T::MIN + 1, T::MIN + 2, T::MIN / 2, 9],
+      [-17, 18, T::MAX, -2, -20, -100, 10],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_add(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_add(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_add(Simd::new(right));
+
+      assert_eq!(expected, actual);
+    }
+  });
+}
+
+#[test]
+fn test_overflowing_sub() {
+  for_simd_types!(|T: Integer, N| {
+    for [left, right] in simd_chunks!(
+      [1, 2, T::MIN + 1, T::MIN + 1, 15, 20, 100, T::MIN + 1, T::MIN / 2],
+      [17, 18, 1, 2, 20, 5, T::MAX - 5, 50, 100],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_sub(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_sub(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_sub(Simd::new(right));
+
+      assert_eq!(expected, actual);
+    }
+  });
+  for_simd_types!(|T: Signed, N| {
+    for [left, right] in simd_chunks!(
+      [1, 2, T::MAX - 1, T::MIN + 1, T::MIN + 2, T::MAX / 2],
+      [17, -18, T::MIN, 2, 20, -100],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].overflowing_sub(right[i]).0)),
+        Simd::new(std::array::from_fn(|i| {
+          if left[i].overflowing_sub(right[i]).1 { !0 } else { 0 }
+        })),
+      );
+      let actual = Simd::new(left).overflowing_sub(Simd::new(right));
+
+      assert_eq!(expected, actual);
+    }
+  });
+}
+
+#[test]
 fn test_from_big_truncate() {
   // `from_{big}_truncate` is inconsistently missing from types.
 


### PR DESCRIPTION
This PR adds `overflowing_add/sub/mul/div/rem` for integers which return the wrapped result and whether an overflow occured.

`overflowing_div/rem` are quite niche, but they are included for consistency.