### PR TITLE
fix, perf, refactor: Fix and optimize `clamp` and make additional guarantees for `fast_clamp`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 * Fixed bugs in the fallback paths of `any`, `all`, `none` and `fast_clamp`.
 
+* Fixed `clamp` and added guarantees for `fast_clamp`.
+
 ## 1.5.0
 
 * Added several functions and trait implementations that previously were only

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -558,9 +558,18 @@ impl f32x16 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      } else {
+        // Some targets have better implementations than the above one.
+        Self {
+          a: self.a.clamp(min.a, max.a),
+          b: self.b.clamp(min.b, max.b),
+        }
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -553,8 +553,8 @@ impl f32x16 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -565,9 +565,8 @@ impl f32x16 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -584,7 +584,7 @@ impl f32x16 {
       if #[cfg(target_feature="avx512f")] {
         // For both `min_m512` and `max_m512` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { avx512: min_m512(max.avx512, max_m512(min.avx512, self.avx512)) }
+        Self { avx512: max_m512(min.avx512, min_m512(max.avx512, self.avx512)) }
       } else {
         Self {
           a: self.a.fast_clamp(min.a, max.a),

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -778,17 +778,17 @@ impl f32x4 {
       if #[cfg(target_feature="sse")] {
         // For both `min_m128` and `max_m128` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { sse: min_m128(max.sse, max_m128(min.sse, self.sse)) }
+        Self { sse: max_m128(min.sse, min_m128(max.sse, self.sse)) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: f32x4_min(f32x4_max(self.simd, min.simd), max.simd) }
+        Self { simd: f32x4_max(f32x4_min(self.simd, max.simd), min.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        unsafe { Self { neon: vminq_f32(vmaxq_f32(self.neon, min.neon), max.neon) } }
+        unsafe { Self { neon: vmaxq_f32(vminq_f32(self.neon, max.neon), min.neon) } }
       } else {
         // The standard library does not have NaN propagating `min` and `max`
         // functions.
         let mut result = self;
-        result = result.simd_lt(min).blend(min, result);
         result = result.simd_gt(max).blend(max, result);
+        result = result.simd_lt(min).blend(min, result);
         result
       }
     }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -747,8 +747,8 @@ impl f32x4 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -759,9 +759,8 @@ impl f32x4 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -752,9 +752,18 @@ impl f32x4 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    pick! {
+      if #[cfg(any(
+        target_feature="simd128",
+        all(target_feature="neon",target_arch="aarch64"),
+      ))] {
+        // `fast_clamp` already works.
+        self.fast_clamp(min, max)
+      } else {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -555,8 +555,8 @@ impl f32x8 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -567,9 +567,8 @@ impl f32x8 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -586,7 +586,7 @@ impl f32x8 {
       if #[cfg(target_feature="avx")] {
         // For both `min_m256` and `max_m256` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { avx: min_m256(max.avx, max_m256(min.avx, self.avx)) }
+        Self { avx: max_m256(min.avx, min_m256(max.avx, self.avx)) }
       } else {
         Self {
           a: self.a.fast_clamp(min.a, max.a),

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -560,9 +560,18 @@ impl f32x8 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f32::NAN), clamped)
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      } else {
+        // Some targets have better implementations than the above one.
+        Self {
+          a: self.a.clamp(min.a, max.a),
+          b: self.b.clamp(min.b, max.b),
+        }
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -715,9 +715,18 @@ impl f64x2 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    pick! {
+      if #[cfg(any(
+        target_feature="simd128",
+        all(target_feature="neon",target_arch="aarch64"),
+      ))] {
+        // `fast_clamp` already works.
+        self.fast_clamp(min, max)
+      } else {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -710,8 +710,8 @@ impl f64x2 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -722,9 +722,8 @@ impl f64x2 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -741,17 +741,17 @@ impl f64x2 {
       if #[cfg(target_feature="sse2")] {
         // For both `min_m128d` and `max_m128d` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { sse: min_m128d(max.sse, max_m128d(min.sse, self.sse)) }
+        Self { sse: max_m128d(min.sse, min_m128d(max.sse, self.sse)) }
       } else if #[cfg(target_feature="simd128")] {
-        Self { simd: f64x2_min(f64x2_max(self.simd, min.simd), max.simd) }
+        Self { simd: f64x2_max(f64x2_min(self.simd, max.simd), min.simd) }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        unsafe { Self { neon: vminq_f64(vmaxq_f64(self.neon, min.neon), max.neon) } }
+        unsafe { Self { neon: vmaxq_f64(vminq_f64(self.neon, max.neon), min.neon) } }
       } else {
         // The standard library does not have NaN propagating `min` and `max`
         // functions.
         let mut result = self;
-        result = result.simd_lt(min).blend(min, result);
         result = result.simd_gt(max).blend(max, result);
+        result = result.simd_lt(min).blend(min, result);
         result
       }
     }

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -583,7 +583,7 @@ impl f64x4 {
       if #[cfg(target_feature="avx")] {
         // For both `min_m256d` and `max_m256d` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { avx: min_m256d(max.avx, max_m256d(min.avx, self.avx)) }
+        Self { avx: max_m256d(min.avx, min_m256d(max.avx, self.avx)) }
       } else {
         Self {
           a: self.a.fast_clamp(min.a, max.a),

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -557,9 +557,18 @@ impl f64x4 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    pick! {
+      if #[cfg(target_feature="avx")] {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      } else {
+        // Some targets have better implementations than the above one.
+        Self {
+          a: self.a.clamp(min.a, max.a),
+          b: self.b.clamp(min.b, max.b),
+        }
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -552,8 +552,8 @@ impl f64x4 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -564,9 +564,8 @@ impl f64x4 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -561,7 +561,7 @@ impl f64x8 {
       if #[cfg(target_feature="avx512f")] {
         // For both `min_m512d` and `max_m512d` if any input is NaN, `rhs` gets
         // chosen. For `self` to be chosen, `self` must be the second argument.
-        Self { avx512: min_m512d(max.avx512, max_m512d(min.avx512, self.avx512)) }
+        Self { avx512: max_m512d(min.avx512, min_m512d(max.avx512, self.avx512)) }
       } else {
         Self {
           a: self.a.fast_clamp(min.a, max.a),

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -535,9 +535,18 @@ impl f64x8 {
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
-    let is_nan = self.is_nan() | min.is_nan() | max.is_nan();
-    let clamped = self.fast_min(max).fast_max(min);
-    is_nan.blend(Self::splat(f64::NAN), clamped)
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        // This works since all bits set is NaN.
+        self.fast_clamp(min, max) | min.is_nan() | max.is_nan()
+      } else {
+        // Some targets have better implementations than the above one.
+        Self {
+          a: self.a.clamp(min.a, max.a),
+          b: self.b.clamp(min.b, max.b),
+        }
+      }
+    }
   }
 
   /// Restrict a value to a certain interval unless it is NaN.

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -530,8 +530,8 @@ impl f64x8 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// If `self` is NaN, or `min` is NaN, or `max` is NaN, the result is NaN.
-  /// If `min > max`, the result is `min`, since `fast_max(min)` dominates.
+  /// If `self`, `min` or `max` are NaN, the result is NaN.  If `min > max`, the
+  /// result is `min` since `max(min)` dominates.
   #[inline]
   #[must_use]
   pub fn clamp(self, min: Self, max: Self) -> Self {
@@ -542,9 +542,8 @@ impl f64x8 {
 
   /// Restrict a value to a certain interval unless it is NaN.
   ///
-  /// Avoids NaN detection; same speed as the old `clamp` prior to IEEE 754-2019
-  /// compliance. Does not specify any
-  /// behavior if NaNs are involved, and if `min > max` the result is
+  /// If `self` is NaN, the result is NaN.  If `min > max`, the result is `min`
+  /// since `max(min)` dominates. If `min` or `max` are NaN, the result is
   /// unspecified.
   #[inline]
   #[must_use]

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -1,7 +1,5 @@
 use wide::{f32x4, f32x8, f32x16, f64x2, f64x4, f64x8, i32x4, i32x8, i32x16};
 
-use bytemuck::cast;
-
 use crate::utils::{for_simd_types, random_iter, simd_chunks};
 
 #[test]
@@ -275,14 +273,22 @@ fn test_clamp() {
       [5.0, 10.0, 10.0, T::NAN, T::INFINITY, T::NEG_INFINITY],
       [3.0, 11.0, 5.0, 1.0, -1.0, -1.0],
       [8.0, 14.0, 9.0, 3.0, 1.0, 1.0],
-    ) {
-      let expected =
-        Simd::new(std::array::from_fn(|i| value[i].clamp(min[i], max[i])));
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        if min[i].is_nan() || max[i].is_nan() {
+          T::NAN
+        } else if min[i] > max[i] {
+          min[i]
+        } else {
+          value[i].clamp(min[i], max[i])
+        }
+      }));
       let actual = Simd::new(value).clamp(Simd::new(min), Simd::new(max));
 
-      assert_eq!(
-        actual ^ expected,
-        Simd::ZERO,
+      assert!(
+        (actual.simd_eq(expected) | expected.is_nan() & actual.is_nan()).all(),
         "expected: {expected:?}\n  actual: {actual:?}"
       );
     }
@@ -290,57 +296,31 @@ fn test_clamp() {
 }
 
 #[test]
-fn test_clamp_nan_bounds() {
-  for_simd_types!(|T: Float, N| {
-    // 1. Test min > max results in min
-    let val = Simd::splat(5.0);
-    let min = Simd::splat(10.0);
-    let max = Simd::splat(2.0);
-    let res = val.clamp(min, max);
-    let res_arr: [T; N] = cast(res);
-    for x in res_arr {
-      assert_eq!(x, 10.0);
-    }
-
-    // 2. Test NaN propagation
-    let nan = Simd::splat(T::NAN);
-    let five = Simd::splat(5.0);
-    let two = Simd::splat(2.0);
-    let ten = Simd::splat(10.0);
-
-    // self is NaN
-    let res_arr: [T; N] = cast(nan.clamp(two, ten));
-    for x in res_arr {
-      assert!(x.is_nan());
-    }
-
-    // min is NaN
-    let res_arr: [T; N] = cast(five.clamp(nan, ten));
-    for x in res_arr {
-      assert!(x.is_nan());
-    }
-
-    // max is NaN
-    let res_arr: [T; N] = cast(five.clamp(two, nan));
-    for x in res_arr {
-      assert!(x.is_nan());
-    }
-  });
-}
-
-#[test]
 fn test_fast_clamp() {
   for_simd_types!(|T: Float, N| {
-    for [value, min, max] in
-      simd_chunks!([5.0, 10.0, 10.0], [3.0, 11.0, 5.0], [8.0, 14.0, 9.0],)
+    for [value, mut min, mut max] in simd_chunks!(
+      [5.0, 10.0, 10.0, T::NAN, T::INFINITY, T::NEG_INFINITY],
+      [3.0, 11.0, 5.0, 1.0, -1.0, -1.0],
+      [8.0, 14.0, 9.0, 3.0, 1.0, 1.0],
+    )
+    .chain(random_iter())
     {
-      let expected =
-        Simd::new(std::array::from_fn(|i| value[i].clamp(min[i], max[i])));
+      for i in 0..N {
+        if min[i].is_nan() {
+          min[i] = 0.0;
+        }
+        if max[i].is_nan() {
+          max[i] = 0.0;
+        }
+      }
+
+      let expected = Simd::new(std::array::from_fn(|i| {
+        if min[i] > max[i] { min[i] } else { value[i].clamp(min[i], max[i]) }
+      }));
       let actual = Simd::new(value).fast_clamp(Simd::new(min), Simd::new(max));
 
-      assert_eq!(
-        actual ^ expected,
-        Simd::ZERO,
+      assert!(
+        (actual.simd_eq(expected) | expected.is_nan() & actual.is_nan()).all(),
         "expected: {expected:?}\n  actual: {actual:?}"
       );
     }

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -277,7 +277,7 @@ fn test_clamp() {
     .chain(random_iter())
     {
       let expected = Simd::new(std::array::from_fn(|i| {
-        if min[i].is_nan() || max[i].is_nan() {
+        if value[i].is_nan() || min[i].is_nan() || max[i].is_nan() {
           T::NAN
         } else if min[i] > max[i] {
           min[i]
@@ -289,7 +289,7 @@ fn test_clamp() {
 
       assert!(
         (actual.simd_eq(expected) | expected.is_nan() & actual.is_nan()).all(),
-        "expected: {expected:?}\n  actual: {actual:?}"
+        "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}\n     min: {min:?}\n     max: {max:?}"
       );
     }
   });
@@ -315,13 +315,19 @@ fn test_fast_clamp() {
       }
 
       let expected = Simd::new(std::array::from_fn(|i| {
-        if min[i] > max[i] { min[i] } else { value[i].clamp(min[i], max[i]) }
+        if value[i].is_nan() {
+          T::NAN
+        } else if min[i] > max[i] {
+          min[i]
+        } else {
+          value[i].clamp(min[i], max[i])
+        }
       }));
       let actual = Simd::new(value).fast_clamp(Simd::new(min), Simd::new(max));
 
       assert!(
         (actual.simd_eq(expected) | expected.is_nan() & actual.is_nan()).all(),
-        "expected: {expected:?}\n  actual: {actual:?}"
+        "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}\n     min: {min:?}\n     max: {max:?}"
       );
     }
   });


### PR DESCRIPTION
Changes:

- `fast_clamp` now specifies its behavior when `self` is NaN and when `min > max`. The reasoning for this is that following these rules doesn't add any overhead on any supported target.

- `clamp` now doesn't perform unnecessary checks on targets where `fast_clamp` is already sufficient.

- `clamp` now correctly returns `min` when `min > max`, as already promised in the documentation. Previously `max` was returned instead, while the docs already promised `min` would be returned.