### PR TITLE
feat, refactor: Add more integer multiplication functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added `reduce_mul` for integers.
+* Added integer functions `reduce_mul` and `mul_keep_low_high`.
 
 * Added overflowing arithmetic for integers.
 * Added float function `round_ties_even`.
@@ -17,6 +17,9 @@
 * Fixed shift operators overflow behavior.
 * Fixed `round` which previously behaved like `round_ties_even`.
 * Fixed `UpperExp` formatting for floats.
+* Renamed integer function `mul_widen` to `widening_mul` and added it for
+  remaining types.
+* Added integer function `mul_keep_high` for remaining types.
 * Added missing `#[must_use]` annotations
 * Updated documenattion.
 

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -224,6 +224,8 @@ impl_simd_int! {
     N = 16,
     Simd = i16x16,
     UnsignedSimd = u16x16,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -487,23 +489,49 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [i16x8; 2] = cast(self);
-    let [rhs_a, rhs_b]: [i16x8; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u16x16, i16x16>(low);
+
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i32x16 {
+      // x86 has no `_mm256_mul_epi16` intrinsic so there is no `avx2`
+      // optimization.
+
+      let [self_a, self_b] = cast::<i16x16, [i16x8; 2]>(self);
+      let [rhs_a, rhs_b] = cast::<i16x16, [i16x8; 2]>(rhs);
+
+      cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+    }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u16x16, i16x16) {
     // x86 has no `_mm256_mul_epi16` intrinsic so there is no `avx2`
     // optimization.
 
     let [self_a, self_b] = cast::<i16x16, [i16x8; 2]>(self);
     let [rhs_a, rhs_b] = cast::<i16x16, [i16x8; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm256_mul_epi16` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i16x16, [i16x8; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i16x16, [i16x8; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 
   #[inline]

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -256,6 +256,8 @@ impl_simd_int! {
     N = 32,
     Simd = i16x32,
     UnsignedSimd = u16x32,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
@@ -510,23 +512,40 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [i16x16; 2] = cast(self);
-    let [rhs_a, rhs_b]: [i16x16; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u16x32, i16x32>(low);
+
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i32x32` type.
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u16x32, i16x32) {
     // x86 has no `_mm512_mul_epi16` intrinsic so there is no `avx512`
     // optimization.
 
     let [self_a, self_b] = cast::<i16x32, [i16x16; 2]>(self);
     let [rhs_a, rhs_b] = cast::<i16x32, [i16x16; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm512_mul_epi16` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i16x32, [i16x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i16x32, [i16x16; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1008,8 +1008,8 @@ impl_simd_int! {
         let low_wide_mul = i32x4_extmul_low_i16x8(self.simd, rhs.simd);
         let high_wide_mul = i32x4_extmul_high_i16x8(self.simd, rhs.simd);
         (
-          Self { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) },
-          Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) },
+          u16x8 { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) },
+          i16x8 { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) },
         )
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -1021,8 +1021,8 @@ impl_simd_int! {
           );
           let low_high = vuzpq_s16(low_wide_mul, high_wide_mul);
           (
-            Self { neon: low_high.0 },
-            Self { neon: low_high.1 },
+            u16x8 { neon: vreinterpretq_u16_s16(low_high.0) },
+            i16x8 { neon: low_high.1 },
           )
         }
       } else {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -449,6 +449,8 @@ impl_simd_int! {
     N = 8,
     Simd = i16x8,
     UnsignedSimd = u16x8,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -946,63 +948,69 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        let low_wide_mul = i32x4_extmul_low_i16x8(self.simd, rhs.simd);
-        let high_wide_mul = i32x4_extmul_high_i16x8(self.simd, rhs.simd);
-        let low = Self { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u16x8, i16x8>(low);
 
-        let no_overflow = high.simd_eq(low.is_negative());
-        let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.select(low, limit)
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        unsafe {
-          let low_wide_mul = vreinterpretq_s16_s32(
-            vmull_s16(vget_low_s16(self.neon), vget_low_s16(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_s16_s32(
-            vmull_s16(vget_high_s16(self.neon), vget_high_s16(rhs.neon)),
-          );
-          let low_high = vuzpq_s16(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
 
-          let no_overflow = high.simd_eq(low.is_negative());
-          let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.select(low, limit)
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i32x8 {
+      pick! {
+        if #[cfg(target_feature="avx2")] {
+          let a = convert_to_i32_m256i_from_i16_m128i(self.sse);
+          let b = convert_to_i32_m256i_from_i16_m128i(rhs.sse);
+          i32x8 { avx2: mul_i32_keep_low_m256i(a,b) }
+        } else if #[cfg(target_feature="sse2")] {
+          let low = mul_i16_keep_low_m128i(self.sse, rhs.sse);
+          let high = mul_i16_keep_high_m128i(self.sse, rhs.sse);
+          i32x8 {
+            a: i32x4 { sse:unpack_low_i16_m128i(low, high) },
+            b: i32x4 { sse:unpack_high_i16_m128i(low, high) }
+          }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+          let lhs_low = unsafe { vget_low_s16(self.neon) };
+          let rhs_low = unsafe { vget_low_s16(rhs.neon) };
+
+          let lhs_high = unsafe { vget_high_s16(self.neon) };
+          let rhs_high = unsafe { vget_high_s16(rhs.neon) };
+
+          let low = unsafe { vmull_s16(lhs_low, rhs_low) };
+          let high = unsafe { vmull_s16(lhs_high, rhs_high) };
+
+          i32x8 { a: i32x4 { neon: low }, b: i32x4 {neon: high } }
+        } else {
+          let a = self.as_array();
+          let b = rhs.as_array();
+
+          i32x8::new([
+            i32::from(a[0]) * i32::from(b[0]),
+            i32::from(a[1]) * i32::from(b[1]),
+            i32::from(a[2]) * i32::from(b[2]),
+            i32::from(a[3]) * i32::from(b[3]),
+            i32::from(a[4]) * i32::from(b[4]),
+            i32::from(a[5]) * i32::from(b[5]),
+            i32::from(a[6]) * i32::from(b[6]),
+            i32::from(a[7]) * i32::from(b[7]),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-          self_array[4].saturating_mul(rhs_array[4]),
-          self_array[5].saturating_mul(rhs_array[5]),
-          self_array[6].saturating_mul(rhs_array[6]),
-          self_array[7].saturating_mul(rhs_array[7]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u16x8, i16x8) {
     pick! {
       if #[cfg(target_feature="simd128")] {
         let low_wide_mul = i32x4_extmul_low_i16x8(self.simd, rhs.simd);
         let high_wide_mul = i32x4_extmul_high_i16x8(self.simd, rhs.simd);
-        let low = Self { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
-
-        let overflow = high.simd_ne(low.is_negative());
-
-        (low, overflow)
+        (
+          Self { simd: i16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) },
+          Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) },
+        )
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_s16_s32(
@@ -1012,12 +1020,10 @@ impl_simd_int! {
             vmull_s16(vget_high_s16(self.neon), vget_high_s16(rhs.neon)),
           );
           let low_high = vuzpq_s16(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
-
-          let overflow = high.simd_ne(low.is_negative());
-
-          (low, overflow)
+          (
+            Self { neon: low_high.0 },
+            Self { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -1026,7 +1032,7 @@ impl_simd_int! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[i32; 8], [[i16; 2]; 8]>([
+        let widening_mul = [
           (self_array[0] as i32).wrapping_mul(rhs_array[0] as i32),
           (self_array[1] as i32).wrapping_mul(rhs_array[1] as i32),
           (self_array[2] as i32).wrapping_mul(rhs_array[2] as i32),
@@ -1035,31 +1041,73 @@ impl_simd_int! {
           (self_array[5] as i32).wrapping_mul(rhs_array[5] as i32),
           (self_array[6] as i32).wrapping_mul(rhs_array[6] as i32),
           (self_array[7] as i32).wrapping_mul(rhs_array[7] as i32),
-        ]);
-        let low = Self::new([
-          widening_mul[0][0],
-          widening_mul[1][0],
-          widening_mul[2][0],
-          widening_mul[3][0],
-          widening_mul[4][0],
-          widening_mul[5][0],
-          widening_mul[6][0],
-          widening_mul[7][0],
-        ]);
-        let high = Self::new([
-          widening_mul[0][1],
-          widening_mul[1][1],
-          widening_mul[2][1],
-          widening_mul[3][1],
-          widening_mul[4][1],
-          widening_mul[5][1],
-          widening_mul[6][1],
-          widening_mul[7][1],
-        ]);
+        ];
 
-        let overflow = high.simd_ne(low.is_negative());
+        (
+          u16x8::new([
+            widening_mul[0] as u16,
+            widening_mul[1] as u16,
+            widening_mul[2] as u16,
+            widening_mul[3] as u16,
+            widening_mul[4] as u16,
+            widening_mul[5] as u16,
+            widening_mul[6] as u16,
+            widening_mul[7] as u16,
+          ]),
+          i16x8::new([
+            (widening_mul[0] >> 16) as i16,
+            (widening_mul[1] >> 16) as i16,
+            (widening_mul[2] >> 16) as i16,
+            (widening_mul[3] >> 16) as i16,
+            (widening_mul[4] >> 16) as i16,
+            (widening_mul[5] >> 16) as i16,
+            (widening_mul[6] >> 16) as i16,
+            (widening_mul[7] >> 16) as i16,
+          ]),
+        )
+      }
+    }
+  }
 
-        (low, overflow)
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: mul_i16_keep_high_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        let lhs_low = unsafe { vget_low_s16(self.neon) };
+        let rhs_low = unsafe { vget_low_s16(rhs.neon) };
+
+        let lhs_high = unsafe { vget_high_s16(self.neon) };
+        let rhs_high = unsafe { vget_high_s16(rhs.neon) };
+
+        let low = unsafe { vmull_s16(lhs_low, rhs_low) };
+        let high = unsafe { vmull_s16(lhs_high, rhs_high) };
+
+        Self {
+          neon: unsafe {
+            vreinterpretq_s16_u16(
+              vuzpq_u16(vreinterpretq_u16_s32(low),
+              vreinterpretq_u16_s32(high)).1
+            )
+          }
+        }
+      } else if #[cfg(target_feature="simd128")] {
+        let low =  i32x4_extmul_low_i16x8(self.simd, rhs.simd);
+        let high = i32x4_extmul_high_i16x8(self.simd, rhs.simd);
+
+        Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
+      } else {
+        i16x8::new([
+          ((i32::from(rhs.as_array()[0]) * i32::from(self.as_array()[0])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[1]) * i32::from(self.as_array()[1])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[2]) * i32::from(self.as_array()[2])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[3]) * i32::from(self.as_array()[3])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[4]) * i32::from(self.as_array()[4])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[5]) * i32::from(self.as_array()[5])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[6]) * i32::from(self.as_array()[6])) >> 16) as i16,
+          ((i32::from(rhs.as_array()[7]) * i32::from(self.as_array()[7])) >> 16) as i16,
+        ])
       }
     }
   }
@@ -1328,88 +1376,6 @@ impl i16x8 {
     }
   }
 
-  /// Multiples two `i16x8` and return the high part of intermediate `i32x8`
-  #[inline]
-  #[must_use]
-  pub fn mul_keep_high(lhs: Self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse2")] {
-        Self { sse: mul_i16_keep_high_m128i(lhs.sse, rhs.sse) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        let lhs_low = unsafe { vget_low_s16(lhs.neon) };
-        let rhs_low = unsafe { vget_low_s16(rhs.neon) };
-
-        let lhs_high = unsafe { vget_high_s16(lhs.neon) };
-        let rhs_high = unsafe { vget_high_s16(rhs.neon) };
-
-        let low = unsafe { vmull_s16(lhs_low, rhs_low) };
-        let high = unsafe { vmull_s16(lhs_high, rhs_high) };
-
-        i16x8 { neon: unsafe { vreinterpretq_s16_u16(vuzpq_u16(vreinterpretq_u16_s32(low), vreinterpretq_u16_s32(high)).1) } }
-      } else if #[cfg(target_feature="simd128")] {
-        let low =  i32x4_extmul_low_i16x8(lhs.simd, rhs.simd);
-        let high = i32x4_extmul_high_i16x8(lhs.simd, rhs.simd);
-
-        Self { simd: i16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
-      } else {
-        i16x8::new([
-          ((i32::from(rhs.as_array()[0]) * i32::from(lhs.as_array()[0])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[1]) * i32::from(lhs.as_array()[1])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[2]) * i32::from(lhs.as_array()[2])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[3]) * i32::from(lhs.as_array()[3])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[4]) * i32::from(lhs.as_array()[4])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[5]) * i32::from(lhs.as_array()[5])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[6]) * i32::from(lhs.as_array()[6])) >> 16) as i16,
-          ((i32::from(rhs.as_array()[7]) * i32::from(lhs.as_array()[7])) >> 16) as i16,
-        ])
-      }
-    }
-  }
-
-  /// multiplies two `i16x8` and returns the result as a widened `i32x8`
-  #[inline]
-  #[must_use]
-  pub fn mul_widen(self, rhs: Self) -> i32x8 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let a = convert_to_i32_m256i_from_i16_m128i(self.sse);
-        let b = convert_to_i32_m256i_from_i16_m128i(rhs.sse);
-        i32x8 { avx2: mul_i32_keep_low_m256i(a,b) }
-      } else if #[cfg(target_feature="sse2")] {
-         let low = mul_i16_keep_low_m128i(self.sse, rhs.sse);
-         let high = mul_i16_keep_high_m128i(self.sse, rhs.sse);
-         i32x8 {
-          a: i32x4 { sse:unpack_low_i16_m128i(low, high) },
-          b: i32x4 { sse:unpack_high_i16_m128i(low, high) }
-        }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-         let lhs_low = unsafe { vget_low_s16(self.neon) };
-         let rhs_low = unsafe { vget_low_s16(rhs.neon) };
-
-         let lhs_high = unsafe { vget_high_s16(self.neon) };
-         let rhs_high = unsafe { vget_high_s16(rhs.neon) };
-
-         let low = unsafe { vmull_s16(lhs_low, rhs_low) };
-         let high = unsafe { vmull_s16(lhs_high, rhs_high) };
-
-         i32x8 { a: i32x4 { neon: low }, b: i32x4 {neon: high } }
-       } else {
-        let a = self.as_array();
-        let b = rhs.as_array();
-         i32x8::new([
-           i32::from(a[0]) * i32::from(b[0]),
-           i32::from(a[1]) * i32::from(b[1]),
-           i32::from(a[2]) * i32::from(b[2]),
-           i32::from(a[3]) * i32::from(b[3]),
-           i32::from(a[4]) * i32::from(b[4]),
-           i32::from(a[5]) * i32::from(b[5]),
-           i32::from(a[6]) * i32::from(b[6]),
-           i32::from(a[7]) * i32::from(b[7]),
-         ])
-       }
-    }
-  }
-
   #[inline]
   #[must_use]
   /// Multiply and scale, equivalent to `((self * rhs) + 0x4000) >> 15` on each
@@ -1453,5 +1419,20 @@ impl i16x8 {
         ]}
       }
     }
+  }
+
+  /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+  /// vector of larger integers.
+  ///
+  /// The returned value is always exact and can never overflow.
+  ///
+  /// This function has been renamed to [`widening_mul`].
+  ///
+  /// [`widening_mul`]: Self::widening_mul
+  #[inline]
+  #[must_use]
+  #[deprecated(since = "1.6.0", note = "renamed to `widening_mul`")]
+  pub fn mul_widen(self, rhs: Self) -> i32x8 {
+    self.widening_mul(rhs)
   }
 }

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -518,10 +518,10 @@ impl_simd_int! {
         let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
         // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
         (
-          Self {
+          u32x16 {
             avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
           },
-          Self {
+          i32x16 {
             avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
           },
         )
@@ -544,9 +544,9 @@ impl_simd_int! {
     pick! {
       if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
         #[cfg(target_arch = "x86")]
-        use core::arch::x86::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+        use core::arch::x86::_mm512_unpackhi_epi64;
         #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+        use core::arch::x86_64::_mm512_unpackhi_epi64;
 
         let even_wide_mul = mul_i32_wide_m512i(self.avx512, rhs.avx512);
         let odd_wide_mul = mul_i32_wide_m512i(
@@ -558,7 +558,7 @@ impl_simd_int! {
         // TODO(safe_arch): Add `_mm512_unpackhi_epi64`.
         Self {
           avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        },
+        }
       } else {
         let [self_a, self_b] = cast::<i32x16, [i32x8; 2]>(self);
         let [rhs_a, rhs_b] = cast::<i32x16, [i32x8; 2]>(rhs);

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -225,6 +225,8 @@ impl_simd_int! {
     N = 16,
     Simd = i32x16,
     UnsignedSimd = u32x16,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -486,7 +488,20 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u32x16, i32x16>(low);
+
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i64x16` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u32x16, i32x16) {
     pick! {
       if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
         #[cfg(target_arch = "x86")]
@@ -499,31 +514,33 @@ impl_simd_int! {
           shuffle_i32_m512i::<0b_00_11_00_01>(self.avx512),
           shuffle_i32_m512i::<0b_00_11_00_01>(rhs.avx512),
         );
-
         let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
         // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
-        let low = Self {
-          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-        let high = Self {
-          avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-
-        let no_overflow = high.simd_eq(low.is_negative());
-        let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.select(low, limit)
+        (
+          Self {
+            avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
+          },
+          Self {
+            avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
+          },
+        )
       } else {
-        let [self_a, self_b]: [i32x8; 2] = cast(self);
-        let [rhs_a, rhs_b]: [i32x8; 2] = cast(rhs);
+        let [self_a, self_b] = cast::<i32x16, [i32x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<i32x16, [i32x8; 2]>(rhs);
 
-        cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+        let result_a = self_a.mul_keep_low_high(rhs_a);
+        let result_b = self_b.mul_keep_low_high(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
         #[cfg(target_arch = "x86")]
@@ -538,27 +555,15 @@ impl_simd_int! {
         );
         let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
-        // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
-        let low = Self {
-          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-        let high = Self {
+        // TODO(safe_arch): Add `_mm512_unpackhi_epi64`.
+        Self {
           avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-
-        let overflow = high.simd_ne(low.is_negative());
-
-        (low, overflow)
+        },
       } else {
         let [self_a, self_b] = cast::<i32x16, [i32x8; 2]>(self);
         let [rhs_a, rhs_b] = cast::<i32x16, [i32x8; 2]>(rhs);
 
-        let result_a = self_a.overflowing_mul(rhs_a);
-        let result_b = self_b.overflowing_mul(rhs_b);
-        (
-          cast([result_a.0, result_b.0]),
-          cast([result_a.1, result_b.1]),
-        )
+        cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
       }
     }
   }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -331,6 +331,8 @@ impl_simd_int! {
     N = 4,
     Simd = i32x4,
     UnsignedSimd = u32x4,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3],
   }
 
@@ -704,64 +706,60 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse4.1")] {
-        let even_wide_mul = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
-        let odd_wide_mul = mul_widen_i32_odd_m128i(
-          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(self.sse),
-          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(rhs.sse),
-        );
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u32x4, i32x4>(low);
 
-        let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
-        let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
-        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
-        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
 
-        let no_overflow = high.simd_eq(low.is_negative());
-        let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.select(low, limit)
-      } else if #[cfg(target_feature="simd128")] {
-        let low_wide_mul = i64x2_extmul_low_i32x4(self.simd, rhs.simd);
-        let high_wide_mul = i64x2_extmul_high_i32x4(self.simd, rhs.simd);
-        let low = Self { simd: i32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: i32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i64x4 {
+      pick! {
+        if #[cfg(target_feature="avx2")] {
+          let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
+          let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
+          cast(mul_i64_low_bits_m256i(a, b))
+        } else if #[cfg(target_feature="sse4.1")] {
+            let evenp = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
 
-        let no_overflow = high.simd_eq(low.is_negative());
-        let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.select(low, limit)
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        unsafe {
-          let low_wide_mul = vreinterpretq_s32_s64(
-            vmull_s32(vget_low_s32(self.neon), vget_low_s32(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_s32_s64(
-            vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)),
-          );
-          let low_high = vuzpq_s32(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
+            let oddp = mul_widen_i32_odd_m128i(
+              shr_imm_u64_m128i::<32>(self.sse),
+              shr_imm_u64_m128i::<32>(rhs.sse));
 
-          let no_overflow = high.simd_eq(low.is_negative());
-          let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.select(low, limit)
+            i64x4 {
+              a: i64x2 { sse: unpack_low_i64_m128i(evenp, oddp)},
+              b: i64x2 { sse: unpack_high_i64_m128i(evenp, oddp)}
+            }
+        } else if #[cfg(target_feature="simd128")] {
+            i64x4 {
+              a: i64x2 { simd: i64x2_extmul_low_i32x4(self.simd, rhs.simd) },
+              b: i64x2 { simd: i64x2_extmul_high_i32x4(self.simd, rhs.simd) },
+            }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+          unsafe {
+            i64x4 { a: i64x2 { neon: vmull_s32(vget_low_s32(self.neon), vget_low_s32(rhs.neon)) },
+                    b: i64x2 { neon: vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)) } }
+          }
+        } else {
+          let a = self.as_array();
+          let b = rhs.as_array();
+
+          cast([
+            i64::from(a[0]) * i64::from(b[0]),
+            i64::from(a[1]) * i64::from(b[1]),
+            i64::from(a[2]) * i64::from(b[2]),
+            i64::from(a[3]) * i64::from(b[3]),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u32x4, i32x4) {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         let even_wide_mul = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
@@ -771,21 +769,19 @@ impl_simd_int! {
         );
         let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
-        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
-        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
 
-        let overflow = high.simd_ne(low.is_negative());
-
-        (low, overflow)
+        (
+          u32x4 { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) },
+          i32x4 { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) },
+        )
       } else if #[cfg(target_feature="simd128")] {
         let low_wide_mul = i64x2_extmul_low_i32x4(self.simd, rhs.simd);
         let high_wide_mul = i64x2_extmul_high_i32x4(self.simd, rhs.simd);
-        let low = Self { simd: i32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: i32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
 
-        let overflow = high.simd_ne(low.is_negative());
-
-        (low, overflow)
+        (
+          u32x4 { simd: i32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) },
+          i32x4 { simd: i32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) },
+        )
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_s32_s64(
@@ -795,12 +791,11 @@ impl_simd_int! {
             vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)),
           );
           let low_high = vuzpq_s32(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
 
-          let overflow = high.simd_ne(low.is_negative());
-
-          (low, overflow)
+          (
+            u32x4 { neon: vreinterpretq_u32_s32(low_high.0) },
+            i32x4 { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -809,18 +804,70 @@ impl_simd_int! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[i64; 4], [[i32; 2]; 4]>([
+        let widening_mul = [
           (self_array[0] as i64).wrapping_mul(rhs_array[0] as i64),
           (self_array[1] as i64).wrapping_mul(rhs_array[1] as i64),
           (self_array[2] as i64).wrapping_mul(rhs_array[2] as i64),
           (self_array[3] as i64).wrapping_mul(rhs_array[3] as i64),
-        ]);
-        let low = Self::new([widening_mul[0][0], widening_mul[1][0], widening_mul[2][0], widening_mul[3][0]]);
-        let high = Self::new([widening_mul[0][1], widening_mul[1][1], widening_mul[2][1], widening_mul[3][1]]);
+        ];
 
-        let overflow = high.simd_ne(low.is_negative());
+        (
+          u32x4::new([
+            widening_mul[0] as u32,
+            widening_mul[1] as u32,
+            widening_mul[2] as u32,
+            widening_mul[3] as u32,
+          ]),
+          i32x4::new([
+            (widening_mul[0] >> 32) as i32,
+            (widening_mul[1] >> 32) as i32,
+            (widening_mul[2] >> 32) as i32,
+            (widening_mul[3] >> 32) as i32,
+          ]),
+        )
+      }
+    }
+  }
 
-        (low, overflow)
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse4.1")] {
+        let even_wide_mul = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
+        let odd_wide_mul = mul_widen_i32_odd_m128i(
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(self.sse),
+          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(rhs.sse),
+        );
+        let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
+
+        Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) }
+      } else if #[cfg(target_feature="simd128")] {
+        let low_wide_mul = i64x2_extmul_low_i32x4(self.simd, rhs.simd);
+        let high_wide_mul = i64x2_extmul_high_i32x4(self.simd, rhs.simd);
+
+        Self { simd: i32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_s32_s64(
+            vmull_s32(vget_low_s32(self.neon), vget_low_s32(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_s32_s64(
+            vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)),
+          );
+
+          Self { neon: vuzpq_s32(low_wide_mul, high_wide_mul).1 }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          ((self_array[0] as i64).wrapping_mul(rhs_array[0] as i64) >> 32) as i32,
+          ((self_array[1] as i64).wrapping_mul(rhs_array[1] as i64) >> 32) as i32,
+          ((self_array[2] as i64).wrapping_mul(rhs_array[2] as i64) >> 32) as i32,
+          ((self_array[3] as i64).wrapping_mul(rhs_array[3] as i64) >> 32) as i32,
+        ])
       }
     }
   }
@@ -870,53 +917,6 @@ impl_simd_int! {
 }
 
 impl i32x4 {
-  /// Multiplies corresponding 32 bit lanes and returns the 64 bit result
-  /// on the corresponding lanes.
-  ///
-  /// Effectively does two multiplies on 128 bit platforms, but is easier
-  /// to use than wrapping `mul_widen_i32_odd_m128i` individually.
-  #[inline]
-  #[must_use]
-  pub fn mul_widen(self, rhs: Self) -> i64x4 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
-        let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
-        cast(mul_i64_low_bits_m256i(a, b))
-      } else if #[cfg(target_feature="sse4.1")] {
-          let evenp = mul_widen_i32_odd_m128i(self.sse, rhs.sse);
-
-          let oddp = mul_widen_i32_odd_m128i(
-            shr_imm_u64_m128i::<32>(self.sse),
-            shr_imm_u64_m128i::<32>(rhs.sse));
-
-          i64x4 {
-            a: i64x2 { sse: unpack_low_i64_m128i(evenp, oddp)},
-            b: i64x2 { sse: unpack_high_i64_m128i(evenp, oddp)}
-          }
-      } else if #[cfg(target_feature="simd128")] {
-          i64x4 {
-            a: i64x2 { simd: i64x2_extmul_low_i32x4(self.simd, rhs.simd) },
-            b: i64x2 { simd: i64x2_extmul_high_i32x4(self.simd, rhs.simd) },
-          }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        unsafe {
-          i64x4 { a: i64x2 { neon: vmull_s32(vget_low_s32(self.neon), vget_low_s32(rhs.neon)) },
-                  b: i64x2 { neon: vmull_s32(vget_high_s32(self.neon), vget_high_s32(rhs.neon)) } }
-        }
-      } else {
-        let a: [i32; 4] = cast(self);
-        let b: [i32; 4] = cast(rhs);
-        cast([
-          i64::from(a[0]) * i64::from(b[0]),
-          i64::from(a[1]) * i64::from(b[1]),
-          i64::from(a[2]) * i64::from(b[2]),
-          i64::from(a[3]) * i64::from(b[3]),
-        ])
-      }
-    }
-  }
-
   #[inline]
   #[must_use]
   pub fn round_float(self) -> f32x4 {
@@ -937,5 +937,20 @@ impl i32x4 {
         ])
       }
     }
+  }
+
+  /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+  /// vector of larger integers.
+  ///
+  /// The returned value is always exact and can never overflow.
+  ///
+  /// This function has been renamed to [`widening_mul`].
+  ///
+  /// [`widening_mul`]: Self::widening_mul
+  #[inline]
+  #[must_use]
+  #[deprecated(since = "1.6.0", note = "renamed to `widening_mul`")]
+  pub fn mul_widen(self, rhs: Self) -> i64x4 {
+    self.widening_mul(rhs)
   }
 }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -544,8 +544,8 @@ impl_simd_int! {
           let m2367 = unpack_high_i64_m256i(even_wide_mul, odd_wide_mul);
 
           cast([
-            shuffle_abi_i128z_all_m256i::<0b_1010_0000>(m0145, m2367),
-            shuffle_abi_i128z_all_m256i::<0b_1011_0001>(m0145, m2367),
+            shuffle_abi_i128z_all_m256i::<0b_0010_0000>(m0145, m2367),
+            shuffle_abi_i128z_all_m256i::<0b_0011_0001>(m0145, m2367),
           ])
         } else {
           let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -523,7 +523,7 @@ impl_simd_int! {
     pub fn widening_mul(self, rhs: Self) -> i64x8 {
       pick! {
         if #[cfg(all(target_feature="avx512f", target_feature="avx2"))] {
-          const SHUFFLE_INDICES: __m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]);
+          const SHUFFLE_INDICES: m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]).avx512;
 
           let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
           let odd_wide_mul = mul_i64_low_bits_m256i(
@@ -544,8 +544,8 @@ impl_simd_int! {
           let m2367 = unpack_high_i64_m256i(even_wide_mul, odd_wide_mul);
 
           cast([
-            shuffle_abi_i128z_all_m256i::<0b_1010_0000>(m0156, m2367),
-            shuffle_abi_i128z_all_m256i::<0b_1011_0001>(m0156, m2367),
+            shuffle_abi_i128z_all_m256i::<0b_1010_0000>(m0145, m2367),
+            shuffle_abi_i128z_all_m256i::<0b_1011_0001>(m0145, m2367),
           ])
         } else {
           let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);
@@ -570,8 +570,8 @@ impl_simd_int! {
         let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
 
         (
-          Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) },
-          Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) },
+          u32x8 { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) },
+          i32x8 { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) },
         )
       } else {
         let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -250,6 +250,8 @@ impl_simd_int! {
     N = 8,
     Simd = i32x8,
     UnsignedSimd = u32x8,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -508,34 +510,55 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
-        let odd_wide_mul = mul_i64_low_bits_m256i(
-          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
-          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
-        );
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u32x8, i32x8>(low);
 
-        let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
-        let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
-        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
-        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
 
-        let no_overflow = high.simd_eq(low.is_negative());
-        let limit = Self::MAX ^ (self ^ rhs).is_negative();
-        no_overflow.select(low, limit)
-      } else {
-        let [self_a, self_b]: [i32x4; 2] = cast(self);
-        let [rhs_a, rhs_b]: [i32x4; 2] = cast(rhs);
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i64x8 {
+      pick! {
+        if #[cfg(all(target_feature="avx512f", target_feature="avx2"))] {
+          const SHUFFLE_INDICES: __m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]);
 
-        cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+          let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
+          let odd_wide_mul = mul_i64_low_bits_m256i(
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+          );
+          let even_then_odd = cast::<[m256i; 2], m512i>([even_wide_mul, odd_wide_mul]);
+          i64x8 {
+            avx512: permute_i64_m512i(SHUFFLE_INDICES, even_then_odd),
+          }
+        } else if #[cfg(target_feature="avx2")] {
+          let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
+          let odd_wide_mul = mul_i64_low_bits_m256i(
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+          );
+          let m0145 = unpack_low_i64_m256i(even_wide_mul, odd_wide_mul);
+          let m2367 = unpack_high_i64_m256i(even_wide_mul, odd_wide_mul);
+
+          cast([
+            shuffle_abi_i128z_all_m256i::<0b_1010_0000>(m0156, m2367),
+            shuffle_abi_i128z_all_m256i::<0b_1011_0001>(m0156, m2367),
+          ])
+        } else {
+          let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);
+          let [rhs_a, rhs_b] = cast::<i32x8, [i32x4; 2]>(rhs);
+
+          cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+        }
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u32x8, i32x8) {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
@@ -545,22 +568,43 @@ impl_simd_int! {
         );
         let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
-        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
-        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
 
-        let overflow = high.simd_ne(low.is_negative());
-
-        (low, overflow)
+        (
+          Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) },
+          Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) },
+        )
       } else {
         let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);
         let [rhs_a, rhs_b] = cast::<i32x8, [i32x4; 2]>(rhs);
 
-        let result_a = self_a.overflowing_mul(rhs_a);
-        let result_b = self_b.overflowing_mul(rhs_b);
+        let result_a = self_a.mul_keep_low_high(rhs_a);
+        let result_b = self_b.mul_keep_low_high(rhs_b);
         (
           cast([result_a.0, result_b.0]),
           cast([result_a.1, result_b.1]),
         )
+      }
+    }
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let even_wide_mul = mul_i64_low_bits_m256i(self.avx2, rhs.avx2);
+        let odd_wide_mul = mul_i64_low_bits_m256i(
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+        );
+        let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
+        let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
+
+        Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) }
+      } else {
+        let [self_a, self_b] = cast::<i32x8, [i32x4; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<i32x8, [i32x4; 2]>(rhs);
+
+        cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
       }
     }
   }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -292,6 +292,8 @@ impl_simd_int! {
     N = 2,
     Simd = i64x2,
     UnsignedSimd = u64x2,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1],
   }
 
@@ -603,20 +605,10 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -629,6 +621,46 @@ impl_simd_int! {
       Self::new([result[0].0, result[1].0]),
       Self::new([-(result[0].1 as i64), -(result[1].1 as i64)]),
     )
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i128x2` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u64x2, i64x2) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as i128).wrapping_mul(rhs_array[0] as i128),
+      (self_array[1] as i128).wrapping_mul(rhs_array[1] as i128),
+    ];
+
+    (
+      u64x2::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+      ]),
+      i64x2::new([
+        (widening_mul[0] >> 64) as i64,
+        (widening_mul[1] >> 64) as i64,
+      ]),
+    )
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    Self::new([
+      ((self_array[0] as i128).wrapping_mul(rhs_array[0] as i128) >> 64) as i64,
+      ((self_array[1] as i128).wrapping_mul(rhs_array[1] as i128) >> 64) as i64,
+    ])
   }
 
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -218,6 +218,8 @@ impl_simd_int! {
     N = 4,
     Simd = i64x4,
     UnsignedSimd = u64x4,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1, 2, 3],
   }
 
@@ -473,22 +475,10 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-      self_array[2].saturating_mul(rhs_array[2]),
-      self_array[3].saturating_mul(rhs_array[3]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -508,6 +498,54 @@ impl_simd_int! {
         -(result[3].1 as i64),
       ]),
     )
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i128x4` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u64x4, i64x4) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as i128).wrapping_mul(rhs_array[0] as i128),
+      (self_array[1] as i128).wrapping_mul(rhs_array[1] as i128),
+      (self_array[2] as i128).wrapping_mul(rhs_array[2] as i128),
+      (self_array[3] as i128).wrapping_mul(rhs_array[3] as i128),
+    ];
+
+    (
+      u64x4::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+        widening_mul[2] as u64,
+        widening_mul[3] as u64,
+      ]),
+      i64x4::new([
+        (widening_mul[0] >> 64) as i64,
+        (widening_mul[1] >> 64) as i64,
+        (widening_mul[2] >> 64) as i64,
+        (widening_mul[3] >> 64) as i64,
+      ]),
+    )
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    Self::new([
+      ((self_array[0] as i128).wrapping_mul(rhs_array[0] as i128) >> 64) as i64,
+      ((self_array[1] as i128).wrapping_mul(rhs_array[1] as i128) >> 64) as i64,
+      ((self_array[2] as i128).wrapping_mul(rhs_array[2] as i128) >> 64) as i64,
+      ((self_array[3] as i128).wrapping_mul(rhs_array[3] as i128) >> 64) as i64,
+    ])
   }
 
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -214,6 +214,8 @@ impl_simd_int! {
     N = 8,
     Simd = i64x8,
     UnsignedSimd = u64x8,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -506,26 +508,10 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-      self_array[2].saturating_mul(rhs_array[2]),
-      self_array[3].saturating_mul(rhs_array[3]),
-      self_array[4].saturating_mul(rhs_array[4]),
-      self_array[5].saturating_mul(rhs_array[5]),
-      self_array[6].saturating_mul(rhs_array[6]),
-      self_array[7].saturating_mul(rhs_array[7]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -562,6 +548,70 @@ impl_simd_int! {
         -(result[7].1 as i64),
       ]),
     )
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i128x8` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u64x8, i64x8) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as i128).wrapping_mul(rhs_array[0] as i128),
+      (self_array[1] as i128).wrapping_mul(rhs_array[1] as i128),
+      (self_array[2] as i128).wrapping_mul(rhs_array[2] as i128),
+      (self_array[3] as i128).wrapping_mul(rhs_array[3] as i128),
+      (self_array[4] as i128).wrapping_mul(rhs_array[4] as i128),
+      (self_array[5] as i128).wrapping_mul(rhs_array[5] as i128),
+      (self_array[6] as i128).wrapping_mul(rhs_array[6] as i128),
+      (self_array[7] as i128).wrapping_mul(rhs_array[7] as i128),
+    ];
+
+    (
+      u64x8::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+        widening_mul[2] as u64,
+        widening_mul[3] as u64,
+        widening_mul[4] as u64,
+        widening_mul[5] as u64,
+        widening_mul[6] as u64,
+        widening_mul[7] as u64,
+      ]),
+      i64x8::new([
+        (widening_mul[0] >> 64) as i64,
+        (widening_mul[1] >> 64) as i64,
+        (widening_mul[2] >> 64) as i64,
+        (widening_mul[3] >> 64) as i64,
+        (widening_mul[4] >> 64) as i64,
+        (widening_mul[5] >> 64) as i64,
+        (widening_mul[6] >> 64) as i64,
+        (widening_mul[7] >> 64) as i64,
+      ]),
+    )
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    Self::new([
+      ((self_array[0] as i128).wrapping_mul(rhs_array[0] as i128) >> 64) as i64,
+      ((self_array[1] as i128).wrapping_mul(rhs_array[1] as i128) >> 64) as i64,
+      ((self_array[2] as i128).wrapping_mul(rhs_array[2] as i128) >> 64) as i64,
+      ((self_array[3] as i128).wrapping_mul(rhs_array[3] as i128) >> 64) as i64,
+      ((self_array[4] as i128).wrapping_mul(rhs_array[4] as i128) >> 64) as i64,
+      ((self_array[5] as i128).wrapping_mul(rhs_array[5] as i128) >> 64) as i64,
+      ((self_array[6] as i128).wrapping_mul(rhs_array[6] as i128) >> 64) as i64,
+      ((self_array[7] as i128).wrapping_mul(rhs_array[7] as i128) >> 64) as i64,
+    ])
   }
 
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -422,6 +422,8 @@ impl_simd_int! {
     N = 16,
     Simd = i8x16,
     UnsignedSimd = u8x16,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -1070,52 +1072,58 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        unsafe {
-          let low_wide_mul = vreinterpretq_s8_s16(
-            vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_s8_s16(
-            vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
-          );
-          let low_high = vuzpq_s8(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u8x16, i8x16>(low);
 
-          let no_overflow = high.simd_eq(low.is_negative());
-          let limit = Self::MAX ^ (self ^ rhs).is_negative();
-          no_overflow.select(low, limit)
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i16x16 {
+      pick! {
+        if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+          unsafe {
+            let low_wide_mul = vreinterpretq_s8_s16(
+              vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon)),
+            );
+            let high_wide_mul = vreinterpretq_s8_s16(
+              vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
+            );
+
+            cast([low_wide_mul, high_wide_mul])
+          }
+        } else {
+          let self_array = self.to_array();
+          let rhs_array = rhs.to_array();
+
+          i16x16::new([
+            (self_array[0] as i16).wrapping_mul(rhs_array[0] as i16),
+            (self_array[1] as i16).wrapping_mul(rhs_array[1] as i16),
+            (self_array[2] as i16).wrapping_mul(rhs_array[2] as i16),
+            (self_array[3] as i16).wrapping_mul(rhs_array[3] as i16),
+            (self_array[4] as i16).wrapping_mul(rhs_array[4] as i16),
+            (self_array[5] as i16).wrapping_mul(rhs_array[5] as i16),
+            (self_array[6] as i16).wrapping_mul(rhs_array[6] as i16),
+            (self_array[7] as i16).wrapping_mul(rhs_array[7] as i16),
+            (self_array[8] as i16).wrapping_mul(rhs_array[8] as i16),
+            (self_array[9] as i16).wrapping_mul(rhs_array[9] as i16),
+            (self_array[10] as i16).wrapping_mul(rhs_array[10] as i16),
+            (self_array[11] as i16).wrapping_mul(rhs_array[11] as i16),
+            (self_array[12] as i16).wrapping_mul(rhs_array[12] as i16),
+            (self_array[13] as i16).wrapping_mul(rhs_array[13] as i16),
+            (self_array[14] as i16).wrapping_mul(rhs_array[14] as i16),
+            (self_array[15] as i16).wrapping_mul(rhs_array[15] as i16),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-          self_array[4].saturating_mul(rhs_array[4]),
-          self_array[5].saturating_mul(rhs_array[5]),
-          self_array[6].saturating_mul(rhs_array[6]),
-          self_array[7].saturating_mul(rhs_array[7]),
-          self_array[8].saturating_mul(rhs_array[8]),
-          self_array[9].saturating_mul(rhs_array[9]),
-          self_array[10].saturating_mul(rhs_array[10]),
-          self_array[11].saturating_mul(rhs_array[11]),
-          self_array[12].saturating_mul(rhs_array[12]),
-          self_array[13].saturating_mul(rhs_array[13]),
-          self_array[14].saturating_mul(rhs_array[14]),
-          self_array[15].saturating_mul(rhs_array[15]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u8x16, i8x16) {
     pick! {
       if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
@@ -1126,12 +1134,11 @@ impl_simd_int! {
             vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
           );
           let low_high = vuzpq_s8(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
 
-          let overflow = high.simd_ne(low.is_negative());
-
-          (low, overflow)
+          (
+            Self { neon: low_high.0 },
+            Self { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -1140,7 +1147,7 @@ impl_simd_int! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[i16; 16], [[i8; 2]; 16]>([
+        let widening_mul = [
           (self_array[0] as i16).wrapping_mul(rhs_array[0] as i16),
           (self_array[1] as i16).wrapping_mul(rhs_array[1] as i16),
           (self_array[2] as i16).wrapping_mul(rhs_array[2] as i16),
@@ -1157,47 +1164,86 @@ impl_simd_int! {
           (self_array[13] as i16).wrapping_mul(rhs_array[13] as i16),
           (self_array[14] as i16).wrapping_mul(rhs_array[14] as i16),
           (self_array[15] as i16).wrapping_mul(rhs_array[15] as i16),
-        ]);
-        let low = Self::new([
-          widening_mul[0][0],
-          widening_mul[1][0],
-          widening_mul[2][0],
-          widening_mul[3][0],
-          widening_mul[4][0],
-          widening_mul[5][0],
-          widening_mul[6][0],
-          widening_mul[7][0],
-          widening_mul[8][0],
-          widening_mul[9][0],
-          widening_mul[10][0],
-          widening_mul[11][0],
-          widening_mul[12][0],
-          widening_mul[13][0],
-          widening_mul[14][0],
-          widening_mul[15][0],
-        ]);
-        let high = Self::new([
-          widening_mul[0][1],
-          widening_mul[1][1],
-          widening_mul[2][1],
-          widening_mul[3][1],
-          widening_mul[4][1],
-          widening_mul[5][1],
-          widening_mul[6][1],
-          widening_mul[7][1],
-          widening_mul[8][1],
-          widening_mul[9][1],
-          widening_mul[10][1],
-          widening_mul[11][1],
-          widening_mul[12][1],
-          widening_mul[13][1],
-          widening_mul[14][1],
-          widening_mul[15][1],
-        ]);
+        ];
 
-        let overflow = high.simd_ne(low.is_negative());
+        (
+          u8x16::new([
+            widening_mul[0] as u8,
+            widening_mul[1] as u8,
+            widening_mul[2] as u8,
+            widening_mul[3] as u8,
+            widening_mul[4] as u8,
+            widening_mul[5] as u8,
+            widening_mul[6] as u8,
+            widening_mul[7] as u8,
+            widening_mul[8] as u8,
+            widening_mul[9] as u8,
+            widening_mul[10] as u8,
+            widening_mul[11] as u8,
+            widening_mul[12] as u8,
+            widening_mul[13] as u8,
+            widening_mul[14] as u8,
+            widening_mul[15] as u8,
+          ]),
+          i8x16::new([
+            (widening_mul[0] >> 8) as i8,
+            (widening_mul[1] >> 8) as i8,
+            (widening_mul[2] >> 8) as i8,
+            (widening_mul[3] >> 8) as i8,
+            (widening_mul[4] >> 8) as i8,
+            (widening_mul[5] >> 8) as i8,
+            (widening_mul[6] >> 8) as i8,
+            (widening_mul[7] >> 8) as i8,
+            (widening_mul[8] >> 8) as i8,
+            (widening_mul[9] >> 8) as i8,
+            (widening_mul[10] >> 8) as i8,
+            (widening_mul[11] >> 8) as i8,
+            (widening_mul[12] >> 8) as i8,
+            (widening_mul[13] >> 8) as i8,
+            (widening_mul[14] >> 8) as i8,
+            (widening_mul[15] >> 8) as i8,
+          ])
+        )
+      }
+    }
+  }
 
-        (low, overflow)
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_s8_s16(
+            vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_s8_s16(
+            vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
+          );
+
+          Self { neon: vuzpq_s8(low_wide_mul, high_wide_mul).1 }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          ((self_array[0] as i16).wrapping_mul(rhs_array[0] as i16) >> 8) as i8,
+          ((self_array[1] as i16).wrapping_mul(rhs_array[1] as i16) >> 8) as i8,
+          ((self_array[2] as i16).wrapping_mul(rhs_array[2] as i16) >> 8) as i8,
+          ((self_array[3] as i16).wrapping_mul(rhs_array[3] as i16) >> 8) as i8,
+          ((self_array[4] as i16).wrapping_mul(rhs_array[4] as i16) >> 8) as i8,
+          ((self_array[5] as i16).wrapping_mul(rhs_array[5] as i16) >> 8) as i8,
+          ((self_array[6] as i16).wrapping_mul(rhs_array[6] as i16) >> 8) as i8,
+          ((self_array[7] as i16).wrapping_mul(rhs_array[7] as i16) >> 8) as i8,
+          ((self_array[8] as i16).wrapping_mul(rhs_array[8] as i16) >> 8) as i8,
+          ((self_array[9] as i16).wrapping_mul(rhs_array[9] as i16) >> 8) as i8,
+          ((self_array[10] as i16).wrapping_mul(rhs_array[10] as i16) >> 8) as i8,
+          ((self_array[11] as i16).wrapping_mul(rhs_array[11] as i16) >> 8) as i8,
+          ((self_array[12] as i16).wrapping_mul(rhs_array[12] as i16) >> 8) as i8,
+          ((self_array[13] as i16).wrapping_mul(rhs_array[13] as i16) >> 8) as i8,
+          ((self_array[14] as i16).wrapping_mul(rhs_array[14] as i16) >> 8) as i8,
+          ((self_array[15] as i16).wrapping_mul(rhs_array[15] as i16) >> 8) as i8,
+        ])
       }
     }
   }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1086,14 +1086,13 @@ impl_simd_int! {
       pick! {
         if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
           unsafe {
-            let low_wide_mul = vreinterpretq_s8_s16(
-              vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon)),
-            );
-            let high_wide_mul = vreinterpretq_s8_s16(
-              vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon)),
-            );
+            let low_wide_mul = vmull_s8(vget_low_s8(self.neon), vget_low_s8(rhs.neon));
+            let high_wide_mul = vmull_s8(vget_high_s8(self.neon), vget_high_s8(rhs.neon));
 
-            cast([low_wide_mul, high_wide_mul])
+            i16x16 {
+              a: i16x8 { neon: low_wide_mul },
+              b: i16x8 { neon: high_wide_mul },
+            }
           }
         } else {
           let self_array = self.to_array();
@@ -1136,8 +1135,8 @@ impl_simd_int! {
           let low_high = vuzpq_s8(low_wide_mul, high_wide_mul);
 
           (
-            Self { neon: low_high.0 },
-            Self { neon: low_high.1 },
+            u8x16 { neon: vreinterpretq_u8_s8(low_high.0) },
+            i8x16 { neon: low_high.1 },
           )
         }
       } else {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -246,6 +246,8 @@ impl_simd_int! {
     N = 32,
     Simd = i8x32,
     UnsignedSimd = u8x32,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
     [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
@@ -465,23 +467,49 @@ impl_simd_int! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [i8x16; 2] = cast(self);
-    let [rhs_a, rhs_b]: [i8x16; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u8x32, i8x32>(low);
+
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> i16x32 {
+      // x86 has no `_mm256_mul_epi8` intrinsic so there is no `avx2`
+      // optimization.
+
+      let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
+      let [rhs_a, rhs_b] = cast::<i8x32, [i8x16; 2]>(rhs);
+
+      cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+    }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u8x32, i8x32) {
     // x86 has no `_mm256_mul_epi8` intrinsic so there is no `avx2`
     // optimization.
 
     let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
     let [rhs_a, rhs_b] = cast::<i8x32, [i8x16; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm256_mul_epi8` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i8x32, [i8x16; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 
   #[inline]

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -11,6 +11,8 @@ macro_rules! impl_simd_int {
       N = $N:literal,
       Simd = $Simd:ident,
       UnsignedSimd = $UnsignedSimd:ident,
+      T_BITS = $T_BITS:literal,
+      T_BITS_MUL_2 = $T_BITS_MUL_2:literal,
       [$($index:literal),* $(,)?],
     }
 
@@ -33,8 +35,10 @@ macro_rules! impl_simd_int {
     $fn_reduce_min:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
-    $fn_saturating_mul:item
     $fn_overflowing_mul:item
+    optional_fn_widening_mul { $($fn_widening_mul:item)? }
+    $fn_mul_keep_low_high:item
+    $fn_mul_keep_high:item
     $fn_abs:item
     $fn_is_positive:item
     $fn_is_negative:item
@@ -294,8 +298,13 @@ macro_rules! impl_simd_int {
       $fn_saturating_sub
 
       /// Lanewise saturating multiply.
+      #[inline]
       #[must_use]
-      $fn_saturating_mul
+      pub fn saturating_mul(self, rhs: Self) -> Self {
+        let (result, overflow) = self.overflowing_mul(rhs);
+        let limit = Self::MAX ^ (self ^ rhs).is_negative();
+        overflow.select(limit, result)
+      }
 
       /// Lanewise saturating divide.
       ///
@@ -389,6 +398,53 @@ macro_rules! impl_simd_int {
         // `self.simd_eq(Self::MIN) & rhs.simd_eq(-1)` but may be cheaper.
         (self % rhs, ((self ^ Self::MAX) & rhs).simd_eq(!Self::ZERO))
       }
+
+      $(
+        /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+        /// vector of a larger integer type.
+        ///
+        /// The returned value is always exact and can never overflow.
+        ///
+        /// This function is different from [`mul_keep_low_high`], which returns
+        /// two seperate SIMD vectors for low and high parts, instead of a
+        /// single SIMD vector of a larger integer type. Also note that while
+        /// [`mul_keep_low_high`] exists for all types, `widening_mul` does not
+        /// exist for types with no wider variant (e.g., for `i32x16` because
+        /// there is no `i64x16`).
+        ///
+        /// [`mul_keep_low_high`]: Self::mul_keep_low_high
+        #[must_use]
+        $fn_widening_mul
+      )?
+
+      #[doc = concat!(
+        "Computes `self * rhs`, producing intermediate ",
+        $T_BITS_MUL_2,
+        "-bit integers, then returns their low ",
+        $T_BITS,
+        "-bit parts and high ",
+        $T_BITS,
+        "-bit parts in two seperate SIMD vectors."
+      )]
+      ///
+      /// This function is different from `widening_mul`, which returns a single
+      /// SIMD vector of a larger integer type, instead of two seperate SIMD
+      /// vectors for low and high parts. Also note that while
+      /// `mul_keep_low_high` exists for all types, `widening_mul` does not
+      /// exist for types with no wider variant (e.g., for `i32x16` because
+      /// there is no `i64x16`).
+      #[must_use]
+      $fn_mul_keep_low_high
+
+      #[doc = concat!(
+        "Computes `self * rhs`, producing intermediate ",
+        $T_BITS_MUL_2,
+        "-bit integers, then returns their high ",
+        $T_BITS,
+        "-bit parts."
+      )]
+      #[must_use]
+      $fn_mul_keep_high
 
       #[must_use]
       $fn_abs

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -10,6 +10,8 @@ macro_rules! impl_simd_uint {
       T = $T:ident,
       N = $N:literal,
       Simd = $Simd:ident,
+      T_BITS = $T_BITS:literal,
+      T_BITS_MUL_2 = $T_BITS_MUL_2:literal,
       [$($index:literal),* $(,)?],
     }
 
@@ -32,8 +34,10 @@ macro_rules! impl_simd_uint {
     $fn_reduce_min:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
-    $fn_saturating_mul:item
     $fn_overflowing_mul:item
+    optional_fn_widening_mul { $($fn_widening_mul:item)? }
+    $fn_mul_keep_low_high:item
+    $fn_mul_keep_high:item
   ) => {
     impl_unary_operator!(
       $Simd,
@@ -290,8 +294,12 @@ macro_rules! impl_simd_uint {
       $fn_saturating_sub
 
       /// Lanewise saturating multiply.
+      #[inline]
       #[must_use]
-      $fn_saturating_mul
+      pub fn saturating_mul(self, rhs: Self) -> Self {
+        let (low, high) = self.mul_keep_low_high(rhs);
+        low | high.simd_ne(Self::ZERO)
+      }
 
       /// Lanewise saturating divide.
       ///
@@ -382,6 +390,53 @@ macro_rules! impl_simd_uint {
       pub fn overflowing_rem(self, rhs: Self) -> (Self, Self) {
         (self % rhs, Self::ZERO)
       }
+
+      $(
+        /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+        /// vector of a larger integer type.
+        ///
+        /// The returned value is always exact and can never overflow.
+        ///
+        /// This function is different from [`mul_keep_low_high`], which returns
+        /// two seperate SIMD vectors for low and high parts, instead of a
+        /// single SIMD vector of a larger integer type. Also note that while
+        /// [`mul_keep_low_high`] exists for all types, `widening_mul` does not
+        /// exist for types with no wider variant (e.g., for `i32x16` because
+        /// there is no `i64x16`).
+        ///
+        /// [`mul_keep_low_high`]: Self::mul_keep_low_high
+        #[must_use]
+        $fn_widening_mul
+      )?
+
+      #[doc = concat!(
+        "Computes `self * rhs`, producing intermediate ",
+        $T_BITS_MUL_2,
+        "-bit integers, then returns their low ",
+        $T_BITS,
+        "-bit parts and high ",
+        $T_BITS,
+        "-bit parts in two seperate SIMD vectors."
+      )]
+      ///
+      /// This function is different from `widening_mul`, which returns a single
+      /// SIMD vector of a larger integer type, instead of two seperate SIMD
+      /// vectors for low and high parts. Also note that while
+      /// `mul_keep_low_high` exists for all types, `widening_mul` does not
+      /// exist for types with no wider variant (e.g., for `i32x16` because
+      /// there is no `i64x16`).
+      #[must_use]
+      $fn_mul_keep_low_high
+
+      #[doc = concat!(
+        "Computes `self * rhs`, producing intermediate ",
+        $T_BITS_MUL_2,
+        "-bit integers, then returns their high ",
+        $T_BITS,
+        "-bit parts."
+      )]
+      #[must_use]
+      $fn_mul_keep_high
     }
   };
 }

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -160,6 +160,8 @@ impl_simd_uint! {
     T = u16,
     N = 16,
     Simd = u16x16,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -420,23 +422,47 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [u16x8; 2] = cast(self);
-    let [rhs_a, rhs_b]: [u16x8; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u32x16 {
+      // x86 has no `_mm256_mul_epu16` intrinsic so there is no `avx2`
+      // optimization.
+
+      let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
+      let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+      cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+    }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     // x86 has no `_mm256_mul_epu16` intrinsic so there is no `avx2`
     // optimization.
 
     let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
     let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm256_mul_epu16` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 }
 

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -163,6 +163,8 @@ impl_simd_uint! {
     T = u16,
     N = 32,
     Simd = u16x32,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
@@ -410,22 +412,37 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [u16x16; 2] = cast(self);
-    let [rhs_a, rhs_b]: [u16x16; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `u32x32` type.
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     // x86 has no `_mm512_mul_epu16` intrinsic so there is no `avx512`
     // optimization.
 
     let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
     let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm512_mul_epu16` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -263,6 +263,8 @@ impl_simd_uint! {
     T = u16,
     N = 8,
     Simd = u16x8,
+    T_BITS = 16,
+    T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -757,61 +759,66 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="simd128")] {
-        let low_wide_mul = u32x4_extmul_low_u16x8(self.simd, rhs.simd);
-        let high_wide_mul = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
-        let low = Self { simd: u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
 
-        let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.select(low, Self::MAX)
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        unsafe {
-          let low_wide_mul = vreinterpretq_u16_u32(
-            vmull_u16(vget_low_u16(self.neon), vget_low_u16(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_u16_u32(
-            vmull_u16(vget_high_u16(self.neon), vget_high_u16(rhs.neon)),
-          );
-          let low_high = vuzpq_u16(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u32x8 {
+      pick! {
+        if #[cfg(target_feature="avx2")] {
+          let a = convert_to_i32_m256i_from_u16_m128i(self.sse);
+          let b = convert_to_i32_m256i_from_u16_m128i(rhs.sse);
+          u32x8 { avx2: mul_i32_keep_low_m256i(a,b) }
+        } else if #[cfg(target_feature="sse2")] {
+          let low = mul_i16_keep_low_m128i(self.sse, rhs.sse);
+          let high = mul_u16_keep_high_m128i(self.sse, rhs.sse);
+          u32x8 {
+            a: u32x4 { sse:unpack_low_i16_m128i(low, high) },
+            b: u32x4 { sse:unpack_high_i16_m128i(low, high) }
+          }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+          let lhs_low = unsafe { vget_low_u16(self.neon) };
+          let rhs_low = unsafe { vget_low_u16(rhs.neon) };
 
-          let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.select(low, Self::MAX)
+          let lhs_high = unsafe { vget_high_u16(self.neon) };
+          let rhs_high = unsafe { vget_high_u16(rhs.neon) };
+
+          let low = unsafe { vmull_u16(lhs_low, rhs_low) };
+          let high = unsafe { vmull_u16(lhs_high, rhs_high) };
+
+          u32x8 { a: u32x4 { neon: low }, b: u32x4 {neon: high } }
+        } else {
+          let a = self.as_array();
+          let b = rhs.as_array();
+          u32x8::new([
+            u32::from(a[0]) * u32::from(b[0]),
+            u32::from(a[1]) * u32::from(b[1]),
+            u32::from(a[2]) * u32::from(b[2]),
+            u32::from(a[3]) * u32::from(b[3]),
+            u32::from(a[4]) * u32::from(b[4]),
+            u32::from(a[5]) * u32::from(b[5]),
+            u32::from(a[6]) * u32::from(b[6]),
+            u32::from(a[7]) * u32::from(b[7]),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-          self_array[4].saturating_mul(rhs_array[4]),
-          self_array[5].saturating_mul(rhs_array[5]),
-          self_array[6].saturating_mul(rhs_array[6]),
-          self_array[7].saturating_mul(rhs_array[7]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     pick! {
       if #[cfg(target_feature="simd128")] {
         let low_wide_mul = u32x4_extmul_low_u16x8(self.simd, rhs.simd);
         let high_wide_mul = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
-        let low = Self { simd: u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) };
-
-        let overflow = high.simd_ne(Self::ZERO);
-
-        (low, overflow)
+        (
+          Self { simd: u16x8_shuffle::<0, 2, 4, 6, 8, 10, 12, 14>(low_wide_mul, high_wide_mul) },
+          Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low_wide_mul, high_wide_mul) },
+        )
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_u16_u32(
@@ -821,12 +828,10 @@ impl_simd_uint! {
             vmull_u16(vget_high_u16(self.neon), vget_high_u16(rhs.neon)),
           );
           let low_high = vuzpq_u16(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
-
-          let overflow = high.simd_ne(Self::ZERO);
-
-          (low, overflow)
+          (
+            Self { neon: low_high.0 },
+            Self { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -835,7 +840,7 @@ impl_simd_uint! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[u32; 8], [[u16; 2]; 8]>([
+        let widening_mul = [
           (self_array[0] as u32).wrapping_mul(rhs_array[0] as u32),
           (self_array[1] as u32).wrapping_mul(rhs_array[1] as u32),
           (self_array[2] as u32).wrapping_mul(rhs_array[2] as u32),
@@ -844,31 +849,66 @@ impl_simd_uint! {
           (self_array[5] as u32).wrapping_mul(rhs_array[5] as u32),
           (self_array[6] as u32).wrapping_mul(rhs_array[6] as u32),
           (self_array[7] as u32).wrapping_mul(rhs_array[7] as u32),
-        ]);
-        let low = Self::new([
-          widening_mul[0][0],
-          widening_mul[1][0],
-          widening_mul[2][0],
-          widening_mul[3][0],
-          widening_mul[4][0],
-          widening_mul[5][0],
-          widening_mul[6][0],
-          widening_mul[7][0],
-        ]);
-        let high = Self::new([
-          widening_mul[0][1],
-          widening_mul[1][1],
-          widening_mul[2][1],
-          widening_mul[3][1],
-          widening_mul[4][1],
-          widening_mul[5][1],
-          widening_mul[6][1],
-          widening_mul[7][1],
-        ]);
+        ];
 
-        let overflow = high.simd_ne(Self::ZERO);
+        (
+          Self::new([
+            widening_mul[0] as u16,
+            widening_mul[1] as u16,
+            widening_mul[2] as u16,
+            widening_mul[3] as u16,
+            widening_mul[4] as u16,
+            widening_mul[5] as u16,
+            widening_mul[6] as u16,
+            widening_mul[7] as u16,
+          ]),
+          Self::new([
+            (widening_mul[0] >> 16) as u16,
+            (widening_mul[1] >> 16) as u16,
+            (widening_mul[2] >> 16) as u16,
+            (widening_mul[3] >> 16) as u16,
+            (widening_mul[4] >> 16) as u16,
+            (widening_mul[5] >> 16) as u16,
+            (widening_mul[6] >> 16) as u16,
+            (widening_mul[7] >> 16) as u16,
+          ]),
+        )
+      }
+    }
+  }
 
-        (low, overflow)
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: mul_u16_keep_high_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        let lhs_low = unsafe { vget_low_u16(self.neon) };
+        let rhs_low = unsafe { vget_low_u16(rhs.neon) };
+
+        let lhs_high = unsafe { vget_high_u16(self.neon) };
+        let rhs_high = unsafe { vget_high_u16(rhs.neon) };
+
+        let low = unsafe { vmull_u16(lhs_low, rhs_low) };
+        let high = unsafe { vmull_u16(lhs_high, rhs_high) };
+
+        u16x8 { neon: unsafe { vuzpq_u16(vreinterpretq_u16_u32(low), vreinterpretq_u16_u32(high)).1 } }
+      } else if #[cfg(target_feature="simd128")] {
+        let low =  u32x4_extmul_low_u16x8(self.simd, rhs.simd);
+        let high = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
+
+        Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
+      } else {
+        u16x8::new([
+          ((u32::from(rhs.as_array()[0]) * u32::from(self.as_array()[0])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[1]) * u32::from(self.as_array()[1])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[2]) * u32::from(self.as_array()[2])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[3]) * u32::from(self.as_array()[3])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[4]) * u32::from(self.as_array()[4])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[5]) * u32::from(self.as_array()[5])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[6]) * u32::from(self.as_array()[6])) >> 16) as u16,
+          ((u32::from(rhs.as_array()[7]) * u32::from(self.as_array()[7])) >> 16) as u16,
+        ])
       }
     }
   }
@@ -921,85 +961,18 @@ impl u16x8 {
     }
   }
 
-  /// multiplies two u16x8 and returns the result as a widened u32x8
+  /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+  /// vector of larger integers.
+  ///
+  /// The returned value is always exact and can never overflow.
+  ///
+  /// This function has been renamed to [`widening_mul`].
+  ///
+  /// [`widening_mul`]: Self::widening_mul
   #[inline]
   #[must_use]
+  #[deprecated(since = "1.6.0", note = "renamed to `widening_mul`")]
   pub fn mul_widen(self, rhs: Self) -> u32x8 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let a = convert_to_i32_m256i_from_u16_m128i(self.sse);
-        let b = convert_to_i32_m256i_from_u16_m128i(rhs.sse);
-        u32x8 { avx2: mul_i32_keep_low_m256i(a,b) }
-      } else if #[cfg(target_feature="sse2")] {
-         let low = mul_i16_keep_low_m128i(self.sse, rhs.sse);
-         let high = mul_u16_keep_high_m128i(self.sse, rhs.sse);
-         u32x8 {
-          a: u32x4 { sse:unpack_low_i16_m128i(low, high) },
-          b: u32x4 { sse:unpack_high_i16_m128i(low, high) }
-        }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-         let lhs_low = unsafe { vget_low_u16(self.neon) };
-         let rhs_low = unsafe { vget_low_u16(rhs.neon) };
-
-         let lhs_high = unsafe { vget_high_u16(self.neon) };
-         let rhs_high = unsafe { vget_high_u16(rhs.neon) };
-
-         let low = unsafe { vmull_u16(lhs_low, rhs_low) };
-         let high = unsafe { vmull_u16(lhs_high, rhs_high) };
-
-         u32x8 { a: u32x4 { neon: low }, b: u32x4 {neon: high } }
-       } else {
-        let a = self.as_array();
-        let b = rhs.as_array();
-         u32x8::new([
-           u32::from(a[0]) * u32::from(b[0]),
-           u32::from(a[1]) * u32::from(b[1]),
-           u32::from(a[2]) * u32::from(b[2]),
-           u32::from(a[3]) * u32::from(b[3]),
-           u32::from(a[4]) * u32::from(b[4]),
-           u32::from(a[5]) * u32::from(b[5]),
-           u32::from(a[6]) * u32::from(b[6]),
-           u32::from(a[7]) * u32::from(b[7]),
-         ])
-       }
-    }
-  }
-
-  /// Multiples two `u16x8` and return the high part of intermediate `u32x8`
-  #[inline]
-  #[must_use]
-  pub fn mul_keep_high(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse2")] {
-        Self { sse: mul_u16_keep_high_m128i(self.sse, rhs.sse) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        let lhs_low = unsafe { vget_low_u16(self.neon) };
-        let rhs_low = unsafe { vget_low_u16(rhs.neon) };
-
-        let lhs_high = unsafe { vget_high_u16(self.neon) };
-        let rhs_high = unsafe { vget_high_u16(rhs.neon) };
-
-        let low = unsafe { vmull_u16(lhs_low, rhs_low) };
-        let high = unsafe { vmull_u16(lhs_high, rhs_high) };
-
-        u16x8 { neon: unsafe { vuzpq_u16(vreinterpretq_u16_u32(low), vreinterpretq_u16_u32(high)).1 } }
-      } else if #[cfg(target_feature="simd128")] {
-        let low =  u32x4_extmul_low_u16x8(self.simd, rhs.simd);
-        let high = u32x4_extmul_high_u16x8(self.simd, rhs.simd);
-
-        Self { simd: u16x8_shuffle::<1, 3, 5, 7, 9, 11, 13, 15>(low, high) }
-      } else {
-        u16x8::new([
-          ((u32::from(rhs.as_array()[0]) * u32::from(self.as_array()[0])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[1]) * u32::from(self.as_array()[1])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[2]) * u32::from(self.as_array()[2])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[3]) * u32::from(self.as_array()[3])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[4]) * u32::from(self.as_array()[4])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[5]) * u32::from(self.as_array()[5])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[6]) * u32::from(self.as_array()[6])) >> 16) as u16,
-          ((u32::from(rhs.as_array()[7]) * u32::from(self.as_array()[7])) >> 16) as u16,
-        ])
-      }
-    }
+    self.widening_mul(rhs)
   }
 }

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -163,6 +163,8 @@ impl_simd_uint! {
     T = u32,
     N = 16,
     Simd = u32x16,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -414,7 +416,18 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `u64x16` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     pick! {
       if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
         #[cfg(target_arch = "x86")]
@@ -431,62 +444,58 @@ impl_simd_uint! {
         let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
         // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
-        let low = Self {
-          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-        let high = Self {
-          avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
-        };
-
-        let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.select(low, Self::MAX)
+        (
+          Self {
+            avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
+          },
+          Self {
+            avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
+          },
+        )
       } else {
-        let [self_a, self_b]: [u32x8; 2] = cast(self);
-        let [rhs_a, rhs_b]: [u32x8; 2] = cast(rhs);
+        let [self_a, self_b] = cast::<u32x16, [u32x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u32x16, [u32x8; 2]>(rhs);
 
-        cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+        let result_a = self_a.mul_keep_low_high(rhs_a);
+        let result_b = self_b.mul_keep_low_high(rhs_b);
+        (
+          cast([result_a.0, result_b.0]),
+          cast([result_a.1, result_b.1]),
+        )
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
-      if #[cfg(all(target_feature="avx512f", target_feature="avx512dq"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::{_mm512_unpackhi_epi64, _mm512_unpacklo_epi64};
+      if #[cfg(target_feature="avx512f")] {
+        let alo = extract_m256i32_from_m512i::<0>(self.avx512);
+        let ahi = extract_m256i32_from_m512i::<1>(self.avx512);
+        let blo = extract_m256i32_from_m512i::<0>(rhs.avx512);
+        let bhi = extract_m256i32_from_m512i::<1>(rhs.avx512);
 
-        let even_wide_mul = mul_u32_wide_m512i(self.avx512, rhs.avx512);
-        let odd_wide_mul = mul_u32_wide_m512i(
-          shuffle_i32_m512i::<0b_00_11_00_01>(self.avx512),
-          shuffle_i32_m512i::<0b_00_11_00_01>(rhs.avx512),
-        );
-
-        let ll_hh_1 = unpack_low_i32_m512i(even_wide_mul, odd_wide_mul);
-        let ll_hh_2 = unpack_high_i32_m512i(even_wide_mul, odd_wide_mul);
-        // TODO(safe_arch): Add `_mm512_unpacklo_epi64` and `_mm512_unpackhi_epi64`.
-        let low = Self {
-          avx512: m512i(unsafe { _mm512_unpacklo_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        let lo_res: m256i = {
+          let a8 = u32x8 { avx2: alo };
+          let b8 = u32x8 { avx2: blo };
+          a8.mul_keep_high(b8).avx2
         };
-        let high = Self {
-          avx512: m512i(unsafe { _mm512_unpackhi_epi64(ll_hh_1.0, ll_hh_2.0) }),
+        let hi_res: m256i = {
+          let a8 = u32x8 { avx2: ahi };
+          let b8 = u32x8 { avx2: bhi };
+          a8.mul_keep_high(b8).avx2
         };
 
-        let overflow = high.simd_ne(Self::ZERO);
+        let zero = zeroed_m512i();
+        let with_lo = insert_m256i32_to_m512i::<0>(zero, lo_res);
+        let combined = insert_m256i32_to_m512i::<1>(with_lo, hi_res);
 
-        (low, overflow)
+        Self { avx512: combined }
       } else {
-        let [self_a, self_b] = cast::<u32x16, [u32x8; 2]>(self);
-        let [rhs_a, rhs_b] = cast::<u32x16, [u32x8; 2]>(rhs);
-
-        let result_a = self_a.overflowing_mul(rhs_a);
-        let result_b = self_b.overflowing_mul(rhs_b);
-        (
-          cast([result_a.0, result_b.0]),
-          cast([result_a.1, result_b.1]),
-        )
+        Self {
+          a: self.a.mul_keep_high(rhs.a),
+          b: self.b.mul_keep_high(rhs.b),
+        }
       }
     }
   }
@@ -536,43 +545,6 @@ impl From<u16x16> for u32x16 {
           arr[8] as u32,  arr[9] as u32,  arr[10] as u32, arr[11] as u32,
           arr[12] as u32, arr[13] as u32, arr[14] as u32, arr[15] as u32,
         ])
-      }
-    }
-  }
-}
-
-impl u32x16 {
-  #[inline]
-  #[must_use]
-  pub fn mul_keep_high(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="avx512f")] {
-        let alo = extract_m256i32_from_m512i::<0>(self.avx512);
-        let ahi = extract_m256i32_from_m512i::<1>(self.avx512);
-        let blo = extract_m256i32_from_m512i::<0>(rhs.avx512);
-        let bhi = extract_m256i32_from_m512i::<1>(rhs.avx512);
-
-        let lo_res: m256i = {
-          let a8 = u32x8 { avx2: alo };
-          let b8 = u32x8 { avx2: blo };
-          a8.mul_keep_high(b8).avx2
-        };
-        let hi_res: m256i = {
-          let a8 = u32x8 { avx2: ahi };
-          let b8 = u32x8 { avx2: bhi };
-          a8.mul_keep_high(b8).avx2
-        };
-
-        let zero = zeroed_m512i();
-        let with_lo = insert_m256i32_to_m512i::<0>(zero, lo_res);
-        let combined = insert_m256i32_to_m512i::<1>(with_lo, hi_res);
-
-        Self { avx512: combined }
-      } else {
-        Self {
-          a: self.a.mul_keep_high(rhs.a),
-          b: self.b.mul_keep_high(rhs.b),
-        }
       }
     }
   }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -248,6 +248,8 @@ impl_simd_uint! {
     T = u32,
     N = 4,
     Simd = u32x4,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3],
   }
 
@@ -621,61 +623,58 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse2")] {
-        let even_wide_mul = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
-        let odd_wide_mul = mul_widen_u32_odd_m128i(
-          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(self.sse),
-          shuffle_ai_f32_all_m128i::<0b_00_11_00_01>(rhs.sse),
-        );
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
 
-        let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
-        let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
-        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
-        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u64x4 {
+      pick! {
+        if #[cfg(target_feature="avx2")] {
+          // ok to sign extend since we are throwing away the high half of the result anyway
+          let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
+          let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
+          cast(mul_u64_low_bits_m256i(a, b))
+        } else if #[cfg(target_feature="sse2")] {
+          let evenp = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
 
-        let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.select(low, Self::MAX)
-      } else if #[cfg(target_feature="simd128")] {
-        let low_wide_mul = u64x2_extmul_low_u32x4(self.simd, rhs.simd);
-        let high_wide_mul = u64x2_extmul_high_u32x4(self.simd, rhs.simd);
-        let low = Self { simd: u32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: u32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
+          let oddp = mul_widen_u32_odd_m128i(
+            shr_imm_u64_m128i::<32>(self.sse),
+            shr_imm_u64_m128i::<32>(rhs.sse));
 
-        let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.select(low, Self::MAX)
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+          u64x4 {
+            a: u64x2 { sse: unpack_low_i64_m128i(evenp, oddp)},
+            b: u64x2 { sse: unpack_high_i64_m128i(evenp, oddp)}
+          }
+        } else if #[cfg(target_feature="simd128")] {
+          u64x4 {
+            a: u64x2 { simd: u64x2_extmul_low_u32x4(self.simd, rhs.simd) },
+            b: u64x2 { simd: u64x2_extmul_high_u32x4(self.simd, rhs.simd) },
+          }
+        } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
-          let low_wide_mul = vreinterpretq_u32_u64(
-            vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_u32_u64(
-            vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon)),
-          );
-          let low_high = vuzpq_u32(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
-
-          let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.select(low, Self::MAX)
+          u64x4 { a: u64x2 { neon: vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)) },
+                  b: u64x2 { neon: vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon)) } }
+          }
+        } else {
+          let a: [u32; 4] = cast(self);
+          let b: [u32; 4] = cast(rhs);
+          cast([
+            u64::from(a[0]) * u64::from(b[0]),
+            u64::from(a[1]) * u64::from(b[1]),
+            u64::from(a[2]) * u64::from(b[2]),
+            u64::from(a[3]) * u64::from(b[3]),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     pick! {
       if #[cfg(target_feature="sse4.1")] {
         let even_wide_mul = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
@@ -686,21 +685,17 @@ impl_simd_uint! {
 
         let ll_hh_1 = unpack_low_i32_m128i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m128i(even_wide_mul, odd_wide_mul);
-        let low = Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) };
-        let high = Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) };
-
-        let overflow = high.simd_ne(Self::ZERO);
-
-        (low, overflow)
+        (
+          Self { sse: unpack_low_i64_m128i(ll_hh_1, ll_hh_2) },
+          Self { sse: unpack_high_i64_m128i(ll_hh_1, ll_hh_2) },
+        )
       } else if #[cfg(target_feature="simd128")] {
         let low_wide_mul = u64x2_extmul_low_u32x4(self.simd, rhs.simd);
         let high_wide_mul = u64x2_extmul_high_u32x4(self.simd, rhs.simd);
-        let low = Self { simd: u32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) };
-        let high = Self { simd: u32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) };
-
-        let overflow = high.simd_ne(Self::ZERO);
-
-        (low, overflow)
+        (
+          Self { simd: u32x4_shuffle::<0, 2, 4, 6>(low_wide_mul, high_wide_mul) },
+          Self { simd: u32x4_shuffle::<1, 3, 5, 7>(low_wide_mul, high_wide_mul) },
+        )
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           let low_wide_mul = vreinterpretq_u32_u64(
@@ -710,12 +705,10 @@ impl_simd_uint! {
             vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon)),
           );
           let low_high = vuzpq_u32(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
-
-          let overflow = high.simd_ne(Self::ZERO);
-
-          (low, overflow)
+          (
+            Self { neon: low_high.0 },
+            Self { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -724,29 +717,32 @@ impl_simd_uint! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[u64; 4], [[u32; 2]; 4]>([
+        let widening_mul = [
           (self_array[0] as u64).wrapping_mul(rhs_array[0] as u64),
           (self_array[1] as u64).wrapping_mul(rhs_array[1] as u64),
           (self_array[2] as u64).wrapping_mul(rhs_array[2] as u64),
           (self_array[3] as u64).wrapping_mul(rhs_array[3] as u64),
-        ]);
-        let low = Self::new([widening_mul[0][0], widening_mul[1][0], widening_mul[2][0], widening_mul[3][0]]);
-        let high = Self::new([widening_mul[0][1], widening_mul[1][1], widening_mul[2][1], widening_mul[3][1]]);
+        ];
 
-        let overflow = high.simd_ne(Self::ZERO);
-
-        (low, overflow)
+        (
+          Self::new([
+            widening_mul[0] as u32,
+            widening_mul[1] as u32,
+            widening_mul[2] as u32,
+            widening_mul[3] as u32,
+          ]),
+          Self::new([
+            (widening_mul[0] >> 32) as u32,
+            (widening_mul[1] >> 32) as u32,
+            (widening_mul[2] >> 32) as u32,
+            (widening_mul[3] >> 32) as u32,
+          ]),
+        )
       }
     }
   }
-}
 
-impl u32x4 {
-  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the
-  /// result. Useful for implementing divide constant value (see `t_usefulness`
-  /// example)
   #[inline]
-  #[must_use]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
@@ -792,52 +788,21 @@ impl u32x4 {
       }
     }
   }
+}
 
-  /// Multiplies corresponding 32 bit lanes and returns the 64 bit result
-  /// on the corresponding lanes.
+impl u32x4 {
+  /// Widening multiplication. Computes `self * rhs`, widening to a SIMD
+  /// vector of larger integers.
   ///
-  /// Effectively does two multiplies on 128 bit platforms, but is easier
-  /// to use than wrapping `mul_widen_u32_odd_m128i` individually.
+  /// The returned value is always exact and can never overflow.
+  ///
+  /// This function has been renamed to [`widening_mul`].
+  ///
+  /// [`widening_mul`]: Self::widening_mul
   #[inline]
   #[must_use]
+  #[deprecated(since = "1.6.0", note = "renamed to `widening_mul`")]
   pub fn mul_widen(self, rhs: Self) -> u64x4 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        // ok to sign extend since we are throwing away the high half of the result anyway
-        let a = convert_to_i64_m256i_from_i32_m128i(self.sse);
-        let b = convert_to_i64_m256i_from_i32_m128i(rhs.sse);
-        cast(mul_u64_low_bits_m256i(a, b))
-      } else if #[cfg(target_feature="sse2")] {
-        let evenp = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
-
-        let oddp = mul_widen_u32_odd_m128i(
-          shr_imm_u64_m128i::<32>(self.sse),
-          shr_imm_u64_m128i::<32>(rhs.sse));
-
-        u64x4 {
-          a: u64x2 { sse: unpack_low_i64_m128i(evenp, oddp)},
-          b: u64x2 { sse: unpack_high_i64_m128i(evenp, oddp)}
-        }
-      } else if #[cfg(target_feature="simd128")] {
-        u64x4 {
-          a: u64x2 { simd: u64x2_extmul_low_u32x4(self.simd, rhs.simd) },
-          b: u64x2 { simd: u64x2_extmul_high_u32x4(self.simd, rhs.simd) },
-        }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-      unsafe {
-        u64x4 { a: u64x2 { neon: vmull_u32(vget_low_u32(self.neon), vget_low_u32(rhs.neon)) },
-                b: u64x2 { neon: vmull_u32(vget_high_u32(self.neon), vget_high_u32(rhs.neon)) } }
-        }
-      } else {
-        let a: [u32; 4] = cast(self);
-        let b: [u32; 4] = cast(rhs);
-        cast([
-          u64::from(a[0]) * u64::from(b[0]),
-          u64::from(a[1]) * u64::from(b[1]),
-          u64::from(a[2]) * u64::from(b[2]),
-          u64::from(a[3]) * u64::from(b[3]),
-        ])
-      }
-    }
+    self.widening_mul(rhs)
   }
 }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -142,6 +142,8 @@ impl_simd_uint! {
     T = u32,
     N = 8,
     Simd = u32x8,
+    T_BITS = 32,
+    T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -395,33 +397,40 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let even_wide_mul = mul_u64_low_bits_m256i(self.avx2, rhs.avx2);
-        let odd_wide_mul = mul_u64_low_bits_m256i(
-          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
-          shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
-        );
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
 
-        let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
-        let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
-        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
-        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u64x8 {
+      pick! {
+        if #[cfg(target_feature="avx2")] {
+          const SHUFFLE_INDICES: __m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]);
 
-        let no_overflow = high.simd_eq(Self::ZERO);
-        no_overflow.select(low, Self::MAX)
-      } else {
-        let [self_a, self_b]: [u32x4; 2] = cast(self);
-        let [rhs_a, rhs_b]: [u32x4; 2] = cast(rhs);
+          let even_wide_mul = mul_u64_low_bits_m256i(self.avx2, rhs.avx2);
+          let odd_wide_mul = mul_u64_low_bits_m256i(
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(self.avx2),
+            shuffle_ai_i32_half_m256i::<0b_00_11_00_01>(rhs.avx2),
+          );
+          let even_then_odd = cast::<[m256i; 2], m512i>([even_wide_mul, odd_wide_mul]);
+          u64x8 {
+            avx512: permute_i64_m512i(SHUFFLE_INDICES, even_then_odd),
+          }
+        } else {
+          let [self_a, self_b] = cast::<u32x8, [u32x4; 2]>(self);
+          let [rhs_a, rhs_b] = cast::<u32x8, [u32x4; 2]>(rhs);
 
-        cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+          cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+        }
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     pick! {
       if #[cfg(target_feature="avx2")] {
         let even_wide_mul = mul_u64_low_bits_m256i(self.avx2, rhs.avx2);
@@ -431,22 +440,41 @@ impl_simd_uint! {
         );
         let ll_hh_1 = unpack_low_i32_m256i(even_wide_mul, odd_wide_mul);
         let ll_hh_2 = unpack_high_i32_m256i(even_wide_mul, odd_wide_mul);
-        let low = Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) };
-        let high = Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) };
-
-        let overflow = high.simd_ne(Self::ZERO);
-
-        (low, overflow)
+        (
+          Self { avx2: unpack_low_i64_m256i(ll_hh_1, ll_hh_2) },
+          Self { avx2: unpack_high_i64_m256i(ll_hh_1, ll_hh_2) },
+        )
       } else {
         let [self_a, self_b] = cast::<u32x8, [u32x4; 2]>(self);
         let [rhs_a, rhs_b] = cast::<u32x8, [u32x4; 2]>(rhs);
 
-        let result_a = self_a.overflowing_mul(rhs_a);
-        let result_b = self_b.overflowing_mul(rhs_b);
+        let result_a = self_a.mul_keep_low_high(rhs_a);
+        let result_b = self_b.mul_keep_low_high(rhs_b);
         (
           cast([result_a.0, result_b.0]),
           cast([result_a.1, result_b.1]),
         )
+      }
+    }
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: u32x8) -> u32x8 {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let a : [u32;8]= cast(self);
+        let b : [u32;8]= cast(rhs);
+
+        // let the compiler shuffle the values around, it does the right thing
+        let r1 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[0], 0, a[1], 0, a[2], 0, a[3], 0]), cast([b[0], 0, b[1], 0, b[2], 0, b[3], 0])));
+        let r2 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[4], 0, a[5], 0, a[6], 0, a[7], 0]), cast([b[4], 0, b[5], 0, b[6], 0, b[7], 0])));
+
+        cast([r1[1], r1[3], r1[5], r1[7], r2[1], r2[3], r2[5], r2[7]])
+      } else {
+        Self {
+          a : self.a.mul_keep_high(rhs.a),
+          b : self.b.mul_keep_high(rhs.b),
+        }
       }
     }
   }
@@ -475,33 +503,6 @@ impl From<u16x8> for u32x8 {
           u32::from(v.as_array()[6]),
           u32::from(v.as_array()[7]),
         ])
-      }
-    }
-  }
-}
-
-impl u32x8 {
-  /// Multiplies 32x32 bit to 64 bit and then only keeps the high 32 bits of the
-  /// result. Useful for implementing divide constant value (see `t_usefulness`
-  /// example)
-  #[inline]
-  #[must_use]
-  pub fn mul_keep_high(self, rhs: u32x8) -> u32x8 {
-    pick! {
-      if #[cfg(target_feature="avx2")] {
-        let a : [u32;8]= cast(self);
-        let b : [u32;8]= cast(rhs);
-
-        // let the compiler shuffle the values around, it does the right thing
-        let r1 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[0], 0, a[1], 0, a[2], 0, a[3], 0]), cast([b[0], 0, b[1], 0, b[2], 0, b[3], 0])));
-        let r2 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[4], 0, a[5], 0, a[6], 0, a[7], 0]), cast([b[4], 0, b[5], 0, b[6], 0, b[7], 0])));
-
-        cast([r1[1], r1[3], r1[5], r1[7], r2[1], r2[3], r2[5], r2[7]])
-      } else {
-        Self {
-          a : self.a.mul_keep_high(rhs.a),
-          b : self.b.mul_keep_high(rhs.b),
-        }
       }
     }
   }

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -407,8 +407,8 @@ impl_simd_uint! {
     #[inline]
     pub fn widening_mul(self, rhs: Self) -> u64x8 {
       pick! {
-        if #[cfg(target_feature="avx2")] {
-          const SHUFFLE_INDICES: __m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]);
+        if #[cfg(all(target_feature="avx512f", target_feature="avx2"))] {
+          const SHUFFLE_INDICES: m512i = i64x8::new([0, 4, 1, 5, 2, 6, 3, 7]).avx512;
 
           let even_wide_mul = mul_u64_low_bits_m256i(self.avx2, rhs.avx2);
           let odd_wide_mul = mul_u64_low_bits_m256i(

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -228,6 +228,8 @@ impl_simd_uint! {
     T = u64,
     N = 2,
     Simd = u64x2,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1],
   }
 
@@ -539,20 +541,10 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -566,11 +558,37 @@ impl_simd_uint! {
       Self::new([-(result[0].1 as i64) as u64, -(result[1].1 as i64) as u64]),
     )
   }
-}
 
-impl u64x2 {
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `u128x2` type.
+  }
+
   #[inline]
-  #[must_use]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as u128).wrapping_mul(rhs_array[0] as u128),
+      (self_array[1] as u128).wrapping_mul(rhs_array[1] as u128),
+    ];
+
+    (
+      Self::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+      ]),
+      Self::new([
+        (widening_mul[0] >> 64) as u64,
+        (widening_mul[1] >> 64) as u64,
+      ]),
+    )
+  }
+
+  #[inline]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
     let arr1: [u64; 2] = cast(self);
     let arr2: [u64; 2] = cast(rhs);

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -157,6 +157,8 @@ impl_simd_uint! {
     T = u64,
     N = 4,
     Simd = u64x4,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1, 2, 3],
   }
 
@@ -400,22 +402,10 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-      self_array[2].saturating_mul(rhs_array[2]),
-      self_array[3].saturating_mul(rhs_array[3]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -436,11 +426,43 @@ impl_simd_uint! {
       ]),
     )
   }
-}
 
-impl u64x4 {
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `u128x4` type.
+  }
+
   #[inline]
-  #[must_use]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as u128).wrapping_mul(rhs_array[0] as u128),
+      (self_array[1] as u128).wrapping_mul(rhs_array[1] as u128),
+      (self_array[2] as u128).wrapping_mul(rhs_array[2] as u128),
+      (self_array[3] as u128).wrapping_mul(rhs_array[3] as u128),
+    ];
+
+    (
+      Self::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+        widening_mul[2] as u64,
+        widening_mul[3] as u64,
+      ]),
+      Self::new([
+        (widening_mul[0] >> 64) as u64,
+        (widening_mul[1] >> 64) as u64,
+        (widening_mul[2] >> 64) as u64,
+        (widening_mul[3] >> 64) as u64,
+      ]),
+    )
+  }
+
+  #[inline]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -163,6 +163,8 @@ impl_simd_uint! {
     T = u64,
     N = 8,
     Simd = u64x8,
+    T_BITS = 64,
+    T_BITS_MUL_2 = 128,
     [0, 1, 2, 3, 4, 5, 6, 7],
   }
 
@@ -426,26 +428,10 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let self_array = self.to_array();
-    let rhs_array = rhs.to_array();
-
-    Self::new([
-      self_array[0].saturating_mul(rhs_array[0]),
-      self_array[1].saturating_mul(rhs_array[1]),
-      self_array[2].saturating_mul(rhs_array[2]),
-      self_array[3].saturating_mul(rhs_array[3]),
-      self_array[4].saturating_mul(rhs_array[4]),
-      self_array[5].saturating_mul(rhs_array[5]),
-      self_array[6].saturating_mul(rhs_array[6]),
-      self_array[7].saturating_mul(rhs_array[7]),
-    ])
-  }
-
-  #[inline]
   pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
     // TODO(perf): This implementation looks quite bad. Is there a better
-    // one?
+    // one? This intentionally avoids `mul_keep_low_high` because getting the
+    // high bits of 64-bit multiplication could be slow.
 
     let self_array = self.to_array();
     let rhs_array = rhs.to_array();
@@ -483,11 +469,55 @@ impl_simd_uint! {
       ]),
     )
   }
-}
 
-impl u64x8 {
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `u128x8` type.
+  }
+
   #[inline]
-  #[must_use]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
+    // TODO(perf): This implementation looks quite bad. Is there a better
+    // one?
+
+    let self_array = self.to_array();
+    let rhs_array = rhs.to_array();
+
+    let widening_mul = [
+      (self_array[0] as u128).wrapping_mul(rhs_array[0] as u128),
+      (self_array[1] as u128).wrapping_mul(rhs_array[1] as u128),
+      (self_array[2] as u128).wrapping_mul(rhs_array[2] as u128),
+      (self_array[3] as u128).wrapping_mul(rhs_array[3] as u128),
+      (self_array[4] as u128).wrapping_mul(rhs_array[4] as u128),
+      (self_array[5] as u128).wrapping_mul(rhs_array[5] as u128),
+      (self_array[6] as u128).wrapping_mul(rhs_array[6] as u128),
+      (self_array[7] as u128).wrapping_mul(rhs_array[7] as u128),
+    ];
+
+    (
+      Self::new([
+        widening_mul[0] as u64,
+        widening_mul[1] as u64,
+        widening_mul[2] as u64,
+        widening_mul[3] as u64,
+        widening_mul[4] as u64,
+        widening_mul[5] as u64,
+        widening_mul[6] as u64,
+        widening_mul[7] as u64,
+      ]),
+      Self::new([
+        (widening_mul[0] >> 64) as u64,
+        (widening_mul[1] >> 64) as u64,
+        (widening_mul[2] >> 64) as u64,
+        (widening_mul[3] >> 64) as u64,
+        (widening_mul[4] >> 64) as u64,
+        (widening_mul[5] >> 64) as u64,
+        (widening_mul[6] >> 64) as u64,
+        (widening_mul[7] >> 64) as u64,
+      ]),
+    )
+  }
+
+  #[inline]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -334,6 +334,8 @@ impl_simd_uint! {
     T = u8,
     N = 16,
     Simd = u8x16,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
   }
 
@@ -964,51 +966,56 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        unsafe {
-          let low_wide_mul = vreinterpretq_u8_u16(
-            vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon)),
-          );
-          let high_wide_mul = vreinterpretq_u8_u16(
-            vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
-          );
-          let low_high = vuzpq_u8(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
 
-          let no_overflow = high.simd_eq(Self::ZERO);
-          no_overflow.select(low, Self::MAX)
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u16x16 {
+      pick! {
+        if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+          unsafe {
+            let low_wide_mul = vreinterpretq_u8_u16(
+              vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon)),
+            );
+            let high_wide_mul = vreinterpretq_u8_u16(
+              vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
+            );
+
+            cast([low_wide_mul, high_wide_mul])
+          }
+        } else {
+          let self_array = self.to_array();
+          let rhs_array = rhs.to_array();
+
+          u16x16::new([
+            (self_array[0] as u16).wrapping_mul(rhs_array[0] as u16),
+            (self_array[1] as u16).wrapping_mul(rhs_array[1] as u16),
+            (self_array[2] as u16).wrapping_mul(rhs_array[2] as u16),
+            (self_array[3] as u16).wrapping_mul(rhs_array[3] as u16),
+            (self_array[4] as u16).wrapping_mul(rhs_array[4] as u16),
+            (self_array[5] as u16).wrapping_mul(rhs_array[5] as u16),
+            (self_array[6] as u16).wrapping_mul(rhs_array[6] as u16),
+            (self_array[7] as u16).wrapping_mul(rhs_array[7] as u16),
+            (self_array[8] as u16).wrapping_mul(rhs_array[8] as u16),
+            (self_array[9] as u16).wrapping_mul(rhs_array[9] as u16),
+            (self_array[10] as u16).wrapping_mul(rhs_array[10] as u16),
+            (self_array[11] as u16).wrapping_mul(rhs_array[11] as u16),
+            (self_array[12] as u16).wrapping_mul(rhs_array[12] as u16),
+            (self_array[13] as u16).wrapping_mul(rhs_array[13] as u16),
+            (self_array[14] as u16).wrapping_mul(rhs_array[14] as u16),
+            (self_array[15] as u16).wrapping_mul(rhs_array[15] as u16),
+          ])
         }
-      } else {
-        let self_array = self.to_array();
-        let rhs_array = rhs.to_array();
-
-        Self::new([
-          self_array[0].saturating_mul(rhs_array[0]),
-          self_array[1].saturating_mul(rhs_array[1]),
-          self_array[2].saturating_mul(rhs_array[2]),
-          self_array[3].saturating_mul(rhs_array[3]),
-          self_array[4].saturating_mul(rhs_array[4]),
-          self_array[5].saturating_mul(rhs_array[5]),
-          self_array[6].saturating_mul(rhs_array[6]),
-          self_array[7].saturating_mul(rhs_array[7]),
-          self_array[8].saturating_mul(rhs_array[8]),
-          self_array[9].saturating_mul(rhs_array[9]),
-          self_array[10].saturating_mul(rhs_array[10]),
-          self_array[11].saturating_mul(rhs_array[11]),
-          self_array[12].saturating_mul(rhs_array[12]),
-          self_array[13].saturating_mul(rhs_array[13]),
-          self_array[14].saturating_mul(rhs_array[14]),
-          self_array[15].saturating_mul(rhs_array[15]),
-        ])
       }
     }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     pick! {
       if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
@@ -1019,12 +1026,10 @@ impl_simd_uint! {
             vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
           );
           let low_high = vuzpq_u8(low_wide_mul, high_wide_mul);
-          let low = Self { neon: low_high.0 };
-          let high = Self { neon: low_high.1 };
-
-          let overflow = high.simd_ne(Self::ZERO);
-
-          (low, overflow)
+          (
+            Self { neon: low_high.0 },
+            Self { neon: low_high.1 },
+          )
         }
       } else {
         // TODO(perf): This implementation looks quite bad. Is there a better
@@ -1033,7 +1038,7 @@ impl_simd_uint! {
         let self_array = self.to_array();
         let rhs_array = rhs.to_array();
 
-        let widening_mul = cast::<[u16; 16], [[u8; 2]; 16]>([
+        let widening_mul = [
           (self_array[0] as u16).wrapping_mul(rhs_array[0] as u16),
           (self_array[1] as u16).wrapping_mul(rhs_array[1] as u16),
           (self_array[2] as u16).wrapping_mul(rhs_array[2] as u16),
@@ -1050,47 +1055,85 @@ impl_simd_uint! {
           (self_array[13] as u16).wrapping_mul(rhs_array[13] as u16),
           (self_array[14] as u16).wrapping_mul(rhs_array[14] as u16),
           (self_array[15] as u16).wrapping_mul(rhs_array[15] as u16),
-        ]);
-        let low = Self::new([
-          widening_mul[0][0],
-          widening_mul[1][0],
-          widening_mul[2][0],
-          widening_mul[3][0],
-          widening_mul[4][0],
-          widening_mul[5][0],
-          widening_mul[6][0],
-          widening_mul[7][0],
-          widening_mul[8][0],
-          widening_mul[9][0],
-          widening_mul[10][0],
-          widening_mul[11][0],
-          widening_mul[12][0],
-          widening_mul[13][0],
-          widening_mul[14][0],
-          widening_mul[15][0],
-        ]);
-        let high = Self::new([
-          widening_mul[0][1],
-          widening_mul[1][1],
-          widening_mul[2][1],
-          widening_mul[3][1],
-          widening_mul[4][1],
-          widening_mul[5][1],
-          widening_mul[6][1],
-          widening_mul[7][1],
-          widening_mul[8][1],
-          widening_mul[9][1],
-          widening_mul[10][1],
-          widening_mul[11][1],
-          widening_mul[12][1],
-          widening_mul[13][1],
-          widening_mul[14][1],
-          widening_mul[15][1],
-        ]);
+        ];
 
-        let overflow = high.simd_ne(Self::ZERO);
+        (
+          Self::new([
+            widening_mul[0] as u8,
+            widening_mul[1] as u8,
+            widening_mul[2] as u8,
+            widening_mul[3] as u8,
+            widening_mul[4] as u8,
+            widening_mul[5] as u8,
+            widening_mul[6] as u8,
+            widening_mul[7] as u8,
+            widening_mul[8] as u8,
+            widening_mul[9] as u8,
+            widening_mul[10] as u8,
+            widening_mul[11] as u8,
+            widening_mul[12] as u8,
+            widening_mul[13] as u8,
+            widening_mul[14] as u8,
+            widening_mul[15] as u8,
+          ]),
+          Self::new([
+            (widening_mul[0] >> 8) as u8,
+            (widening_mul[1] >> 8) as u8,
+            (widening_mul[2] >> 8) as u8,
+            (widening_mul[3] >> 8) as u8,
+            (widening_mul[4] >> 8) as u8,
+            (widening_mul[5] >> 8) as u8,
+            (widening_mul[6] >> 8) as u8,
+            (widening_mul[7] >> 8) as u8,
+            (widening_mul[8] >> 8) as u8,
+            (widening_mul[9] >> 8) as u8,
+            (widening_mul[10] >> 8) as u8,
+            (widening_mul[11] >> 8) as u8,
+            (widening_mul[12] >> 8) as u8,
+            (widening_mul[13] >> 8) as u8,
+            (widening_mul[14] >> 8) as u8,
+            (widening_mul[15] >> 8) as u8,
+          ]),
+        )
+      }
+    }
+  }
 
-        (low, overflow)
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          let low_wide_mul = vreinterpretq_u8_u16(
+            vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon)),
+          );
+          let high_wide_mul = vreinterpretq_u8_u16(
+            vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
+          );
+          Self { neon: vuzpq_u8(low_wide_mul, high_wide_mul).1 }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          ((self_array[0] as u16).wrapping_mul(rhs_array[0] as u16) >> 8) as u8,
+          ((self_array[1] as u16).wrapping_mul(rhs_array[1] as u16) >> 8) as u8,
+          ((self_array[2] as u16).wrapping_mul(rhs_array[2] as u16) >> 8) as u8,
+          ((self_array[3] as u16).wrapping_mul(rhs_array[3] as u16) >> 8) as u8,
+          ((self_array[4] as u16).wrapping_mul(rhs_array[4] as u16) >> 8) as u8,
+          ((self_array[5] as u16).wrapping_mul(rhs_array[5] as u16) >> 8) as u8,
+          ((self_array[6] as u16).wrapping_mul(rhs_array[6] as u16) >> 8) as u8,
+          ((self_array[7] as u16).wrapping_mul(rhs_array[7] as u16) >> 8) as u8,
+          ((self_array[8] as u16).wrapping_mul(rhs_array[8] as u16) >> 8) as u8,
+          ((self_array[9] as u16).wrapping_mul(rhs_array[9] as u16) >> 8) as u8,
+          ((self_array[10] as u16).wrapping_mul(rhs_array[10] as u16) >> 8) as u8,
+          ((self_array[11] as u16).wrapping_mul(rhs_array[11] as u16) >> 8) as u8,
+          ((self_array[12] as u16).wrapping_mul(rhs_array[12] as u16) >> 8) as u8,
+          ((self_array[13] as u16).wrapping_mul(rhs_array[13] as u16) >> 8) as u8,
+          ((self_array[14] as u16).wrapping_mul(rhs_array[14] as u16) >> 8) as u8,
+          ((self_array[15] as u16).wrapping_mul(rhs_array[15] as u16) >> 8) as u8,
+        ])
       }
     }
   }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -978,14 +978,13 @@ impl_simd_uint! {
       pick! {
         if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
           unsafe {
-            let low_wide_mul = vreinterpretq_u8_u16(
-              vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon)),
-            );
-            let high_wide_mul = vreinterpretq_u8_u16(
-              vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon)),
-            );
+            let low_wide_mul = vmull_u8(vget_low_u8(self.neon), vget_low_u8(rhs.neon));
+            let high_wide_mul = vmull_u8(vget_high_u8(self.neon), vget_high_u8(rhs.neon));
 
-            cast([low_wide_mul, high_wide_mul])
+            u16x16 {
+              a: u16x8 { neon: low_wide_mul },
+              b: u16x8 { neon: high_wide_mul },
+            }
           }
         } else {
           let self_array = self.to_array();

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -169,6 +169,8 @@ impl_simd_uint! {
     T = u8,
     N = 32,
     Simd = u8x32,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
     [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
@@ -387,23 +389,47 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn saturating_mul(self, rhs: Self) -> Self {
-    let [self_a, self_b]: [u8x16; 2] = cast(self);
-    let [rhs_a, rhs_b]: [u8x16; 2] = cast(rhs);
-    cast([self_a.saturating_mul(rhs_a), self_b.saturating_mul(rhs_b)])
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let overflow = high.simd_ne(Self::ZERO);
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    #[inline]
+    pub fn widening_mul(self, rhs: Self) -> u16x32 {
+      // x86 has no `_mm256_mul_epu8` intrinsic so there is no `avx2`
+      // optimization.
+
+      let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+      let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+
+      cast([self_a.widening_mul(rhs_a), self_b.widening_mul(rhs_b)])
+    }
   }
 
   #[inline]
-  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+  pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
     // x86 has no `_mm256_mul_epu8` intrinsic so there is no `avx2`
     // optimization.
 
     let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
     let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
 
-    let result_a = self_a.overflowing_mul(rhs_a);
-    let result_b = self_b.overflowing_mul(rhs_b);
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
     (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm256_mul_epu8` intrinsic so there is no `avx2`
+    // optimization.
+
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }
 }
 

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -1,8 +1,6 @@
-use std::iter::once;
-
 use wide::{
   f32x4, f32x8, f32x16, i8x16, i8x32, i16x8, i16x16, i32x4, i32x8, i32x16,
-  i64x4, u8x16, u16x8, u32x4, u32x8, u32x16, u64x4,
+  u8x16, u16x8,
 };
 
 use crate::utils::{for_simd_types, random_iter, simd_chunks};
@@ -502,6 +500,288 @@ fn test_overflowing_rem() {
 }
 
 #[test]
+fn test_widening_mul() {
+  for_simd_types!(|T: Signed, N, DoubleSizedSimd| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MIN + 1,
+        T::MIN,
+        2,
+        3,
+        4,
+        5,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        T::MAX / 2,
+        T::MIN / 2,
+      ],
+      [17, -18, 1, 1, -1, -2, -6, 3, 3, 2, 1, 3, 3],
+    )
+    .chain(random_iter())
+    {
+      let expected = DoubleSizedSimd::new(std::array::from_fn(|i| {
+        (left[i] as DoubleSizedT) * (right[i] as DoubleSizedT)
+      }));
+      let actual = Simd::new(left).widening_mul(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N, DoubleSizedSimd| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        3,
+        4,
+        5,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+      ],
+      [
+        17,
+        18,
+        9,
+        1,
+        0,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+      ],
+    )
+    .chain(random_iter())
+    {
+      let expected = DoubleSizedSimd::new(std::array::from_fn(|i| {
+        (left[i] as DoubleSizedT) * (right[i] as DoubleSizedT)
+      }));
+      let actual = Simd::new(left).widening_mul(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
+fn test_mul_keep_low_high() {
+  for_simd_types!(|T: Signed, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MIN + 1,
+        T::MIN,
+        2,
+        3,
+        4,
+        5,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        T::MAX / 2,
+        T::MIN / 2,
+      ],
+      [17, -18, 1, 1, -1, -2, -6, 3, 3, 2, 1, 3, 3],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        SimdUnsigned::new(std::array::from_fn(|i| {
+          left[i].wrapping_mul(right[i]).cast_unsigned()
+        })),
+        Simd::new(std::array::from_fn(|i| {
+          ((left[i] as DoubleSizedT).wrapping_mul(right[i] as DoubleSizedT)
+            >> T::BITS) as T
+        })),
+      );
+      let actual = Simd::new(left).mul_keep_low_high(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        3,
+        4,
+        5,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+      ],
+      [
+        17,
+        18,
+        9,
+        1,
+        0,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+      ],
+    )
+    .chain(random_iter())
+    {
+      let expected = (
+        Simd::new(std::array::from_fn(|i| left[i].wrapping_mul(right[i]))),
+        Simd::new(std::array::from_fn(|i| {
+          ((left[i] as DoubleSizedT).wrapping_mul(right[i] as DoubleSizedT)
+            >> T::BITS) as T
+        })),
+      );
+      let actual = Simd::new(left).mul_keep_low_high(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
+fn test_mul_keep_high() {
+  for_simd_types!(|T: Signed, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MIN + 1,
+        T::MIN,
+        2,
+        3,
+        4,
+        5,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        T::MAX / 2,
+        T::MIN / 2,
+      ],
+      [17, -18, 1, 1, -1, -2, -6, 3, 3, 2, 1, 3, 3],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        ((left[i] as DoubleSizedT).wrapping_mul(right[i] as DoubleSizedT)
+          >> T::BITS) as T
+      }));
+      let actual = Simd::new(left).mul_keep_high(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        3,
+        4,
+        5,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+      ],
+      [
+        17,
+        18,
+        9,
+        1,
+        0,
+        3,
+        4,
+        3,
+        2,
+        2,
+        1,
+        T::MAX / 4,
+        T::MAX / 3,
+        T::MAX / 2,
+        T::MAX - 1,
+        T::MAX,
+        T::MAX,
+      ],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        ((left[i] as DoubleSizedT).wrapping_mul(right[i] as DoubleSizedT)
+          >> T::BITS) as T
+      }));
+      let actual = Simd::new(left).mul_keep_high(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "expected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}"
+      );
+    }
+  });
+}
+
+#[test]
 fn test_from_big_truncate() {
   // `from_{big}_truncate` is inconsistently missing from types.
 
@@ -539,177 +819,6 @@ fn test_from_big_saturate() {
   let expected = i16x8::new([10000, 1001, 2, 3, 4, 5, -32768, 32767]);
   let actual = i16x8::from_i32x8_saturate(value);
   assert_eq!(actual, expected);
-}
-
-#[test]
-fn test_mul_keep_high() {
-  // `mul_keep_high` is inconsistently missing from types.
-
-  for [left, right] in once([
-    [i16::MAX, 200, 300, 4568, -1, -2, -3, -4],
-    [i16::MIN, 600, 700, 8910, -15, -26, -37, 48],
-  ])
-  .chain(random_iter())
-  {
-    let expected = i16x8::new(std::array::from_fn(|i| {
-      ((left[i] as i32 * right[i] as i32) >> 16) as i16
-    }));
-    let actual = i16x8::mul_keep_high(i16x8::new(left), i16x8::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in once([
-    [u16::MAX, 200, 300, 4568, 1, 2, 3, 200],
-    [u16::MAX, 600, 700, 8910, 15, 26, 37, 600],
-  ])
-  .chain(random_iter())
-  {
-    let expected = u16x8::new(std::array::from_fn(|i| {
-      ((left[i] as u32 * right[i] as u32) >> 16) as u16
-    }));
-    let actual = u16x8::mul_keep_high(u16x8::new(left), u16x8::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in once([
-    [1, 2 * 10000000, 3 * 1000000, u32::MAX],
-    [5, 6 * 100, 7 * 1000000, u32::MAX],
-  ])
-  .chain(random_iter())
-  {
-    let expected = u32x4::new(std::array::from_fn(|i| {
-      ((left[i] as u64 * right[i] as u64) >> 32) as u32
-    }));
-    let actual = u32x4::mul_keep_high(u32x4::new(left), u32x4::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in once([
-    [
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-    ],
-    [5, 6 * 100, 7 * 1000000, u32::MAX, 5, 6 * 100, 7 * 1000000, u32::MAX],
-  ])
-  .chain(random_iter())
-  {
-    let expected = u32x8::new(std::array::from_fn(|i| {
-      ((left[i] as u64 * right[i] as u64) >> 32) as u32
-    }));
-    let actual = u32x8::mul_keep_high(u32x8::new(left), u32x8::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in once([
-    [
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-      1,
-      2 * 10000000,
-      3 * 1000000,
-      u32::MAX,
-    ],
-    [
-      5,
-      6 * 100,
-      7 * 1000000,
-      u32::MAX,
-      5,
-      6 * 100,
-      7 * 1000000,
-      u32::MAX,
-      5,
-      6 * 100,
-      7 * 1000000,
-      u32::MAX,
-      5,
-      6 * 100,
-      7 * 1000000,
-      u32::MAX,
-    ],
-  ])
-  .chain(random_iter())
-  {
-    let expected = u32x16::new(std::array::from_fn(|i| {
-      ((left[i] as u64 * right[i] as u64) >> 32) as u32
-    }));
-    let actual = u32x16::mul_keep_high(u32x16::new(left), u32x16::new(right));
-
-    assert_eq!(actual, expected);
-  }
-}
-
-#[test]
-fn test_mul_widen() {
-  // `mul_widen` is inconsistently missing from types.
-
-  for [left, right] in once([
-    [1, 2, 3, 4, 5, 6, i16::MIN, i16::MAX],
-    [17, -18, 190, -20, 21, -22, i16::MAX, i16::MAX],
-  ])
-  .chain(random_iter())
-  {
-    let expected =
-      i32x8::new(std::array::from_fn(|i| left[i] as i32 * right[i] as i32));
-    let actual = i16x8::new(left).mul_widen(i16x8::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in
-    once([[1, 2, 3 * -1000000, i32::MAX], [5, 6, 7 * -1000000, i32::MIN]])
-      .chain(random_iter())
-  {
-    let expected =
-      i64x4::new(std::array::from_fn(|i| left[i] as i64 * right[i] as i64));
-    let actual = i32x4::new(left).mul_widen(i32x4::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in once([
-    [1, 2, 3, 4, 5, 6, i16::MAX as u16, u16::MAX],
-    [17, 18, 190, 20, 21, 22, i16::MAX as u16, u16::MAX],
-  ])
-  .chain(random_iter())
-  {
-    let expected =
-      u32x8::new(std::array::from_fn(|i| left[i] as u32 * right[i] as u32));
-    let actual = u16x8::new(left).mul_widen(u16x8::new(right));
-
-    assert_eq!(actual, expected);
-  }
-
-  for [left, right] in
-    once([[1, 2, 3 * 1000000, u32::MAX], [5, 6, 7 * 1000000, u32::MAX]])
-      .chain(random_iter())
-  {
-    let expected =
-      u64x4::new(std::array::from_fn(|i| left[i] as u64 * right[i] as u64));
-    let actual = u32x4::new(left).mul_widen(u32x4::new(right));
-
-    assert_eq!(actual, expected);
-  }
 }
 
 #[test]

--- a/tests/utils/for_simd_types.rs
+++ b/tests/utils/for_simd_types.rs
@@ -59,30 +59,56 @@ macro_rules! for_simd_types {
     for_simd_types!(|T: Unsigned, N| $expr);
   };
   (|T: Signed, N| $expr:expr) => {
-    for_simd_types!(signed!(i8, 16, i8x16, u8, u8x16, $expr));
-    for_simd_types!(signed!(i8, 32, i8x32, u8, u8x32, $expr));
-    for_simd_types!(signed!(i16, 8, i16x8, u16, u16x8, $expr));
-    for_simd_types!(signed!(i16, 16, i16x16, u16, u16x16, $expr));
-    for_simd_types!(signed!(i16, 32, i16x32, u16, u16x32, $expr));
-    for_simd_types!(signed!(i32, 4, i32x4, u32, u32x4, $expr));
-    for_simd_types!(signed!(i32, 8, i32x8, u32, u32x8, $expr));
-    for_simd_types!(signed!(i32, 16, i32x16, u32, u32x16, $expr));
-    for_simd_types!(signed!(i64, 2, i64x2, u64, u64x2, $expr));
-    for_simd_types!(signed!(i64, 4, i64x4, u64, u64x4, $expr));
-    for_simd_types!(signed!(i64, 8, i64x8, u64, u64x8, $expr));
+    for_simd_types!(signed!(i8, 16, i8x16, u8, u8x16, i16, (), $expr));
+    for_simd_types!(signed!(i8, 32, i8x32, u8, u8x32, i16, (), $expr));
+    for_simd_types!(signed!(i16, 8, i16x8, u16, u16x8, i32, (), $expr));
+    for_simd_types!(signed!(i16, 16, i16x16, u16, u16x16, i32, (), $expr));
+    for_simd_types!(signed!(i16, 32, i16x32, u16, u16x32, i32, (), $expr));
+    for_simd_types!(signed!(i32, 4, i32x4, u32, u32x4, i64, (), $expr));
+    for_simd_types!(signed!(i32, 8, i32x8, u32, u32x8, i64, (), $expr));
+    for_simd_types!(signed!(i32, 16, i32x16, u32, u32x16, i64, (), $expr));
+    for_simd_types!(signed!(i64, 2, i64x2, u64, u64x2, i128, (), $expr));
+    for_simd_types!(signed!(i64, 4, i64x4, u64, u64x4, i128, (), $expr));
+    for_simd_types!(signed!(i64, 8, i64x8, u64, u64x8, i128, (), $expr));
+  };
+  (|T: Signed, N, DoubleSizedSimd| $expr:expr) => {
+    for_simd_types!(signed!(i8, 16, i8x16, u8, u8x16, i16, (i16x16), $expr));
+    for_simd_types!(signed!(i8, 32, i8x32, u8, u8x32, i16, (i16x32), $expr));
+    for_simd_types!(signed!(i16, 8, i16x8, u16, u16x8, i32, (i32x8), $expr));
+    for_simd_types!(signed!(i16, 16, i16x16, u16, u16x16, i32, (i32x16), $expr));
+    // for_simd_types!(signed!(i16, 32, i16x32, u16, u16x32, i32, (i32x32), $expr));
+    for_simd_types!(signed!(i32, 4, i32x4, u32, u32x4, i64, (i64x4), $expr));
+    for_simd_types!(signed!(i32, 8, i32x8, u32, u32x8, i64, (i64x8), $expr));
+    // for_simd_types!(signed!(i32, 16, i32x16, u32, u32x16, i64, (i64x16), $expr));
+    // for_simd_types!(signed!(i64, 2, i64x2, u64, u64x2, i128, (i128x2), $expr));
+    // for_simd_types!(signed!(i64, 4, i64x4, u64, u64x4, i128, (i128x4), $expr));
+    // for_simd_types!(signed!(i64, 8, i64x8, u64, u64x8, i128, (i128x8), $expr));
   };
   (|T: Unsigned, N| $expr:expr) => {
-    for_simd_types!(unsigned!(u8, 16, u8x16, $expr));
-    for_simd_types!(unsigned!(u8, 32, u8x32, $expr));
-    for_simd_types!(unsigned!(u16, 8, u16x8, $expr));
-    for_simd_types!(unsigned!(u16, 16, u16x16, $expr));
-    for_simd_types!(unsigned!(u16, 32, u16x32, $expr));
-    for_simd_types!(unsigned!(u32, 4, u32x4, $expr));
-    for_simd_types!(unsigned!(u32, 8, u32x8, $expr));
-    for_simd_types!(unsigned!(u32, 16, u32x16, $expr));
-    for_simd_types!(unsigned!(u64, 2, u64x2, $expr));
-    for_simd_types!(unsigned!(u64, 4, u64x4, $expr));
-    for_simd_types!(unsigned!(u64, 8, u64x8, $expr));
+    for_simd_types!(unsigned!(u8, 16, u8x16, u16, (), $expr));
+    for_simd_types!(unsigned!(u8, 32, u8x32, u16, (), $expr));
+    for_simd_types!(unsigned!(u16, 8, u16x8, u32, (), $expr));
+    for_simd_types!(unsigned!(u16, 16, u16x16, u32, (), $expr));
+    for_simd_types!(unsigned!(u16, 32, u16x32, u32, (), $expr));
+    for_simd_types!(unsigned!(u32, 4, u32x4, u64, (), $expr));
+    for_simd_types!(unsigned!(u32, 8, u32x8, u64, (), $expr));
+    for_simd_types!(unsigned!(u32, 16, u32x16, u64, (), $expr));
+    for_simd_types!(unsigned!(u64, 2, u64x2, u128, (), $expr));
+    for_simd_types!(unsigned!(u64, 4, u64x4, u128, (), $expr));
+    for_simd_types!(unsigned!(u64, 8, u64x8, u128, (), $expr));
+  };
+  (|T: Unsigned, N, DoubleSizedSimd| $expr:expr) => {
+    for_simd_types!(unsigned!(u8, 16, u8x16, u16, (u16x16), $expr));
+    for_simd_types!(unsigned!(u8, 32, u8x32, u16, (u16x32), $expr));
+    for_simd_types!(unsigned!(u16, 8, u16x8, u32, (u32x8), $expr));
+    for_simd_types!(unsigned!(u16, 16, u16x16, u32, (u32x16), $expr));
+    // for_simd_types!(unsigned!(u16, 32, u16x32, u32, (u32x32), $expr));
+    for_simd_types!(unsigned!(u32, 4, u32x4, u64, (u64x4), $expr));
+    for_simd_types!(unsigned!(u32, 8, u32x8, u64, (u64x8), $expr));
+    // for_simd_types!(unsigned!(u32, 16, u32x16, u64, (u64x16), $expr));
+    // for_simd_types!(unsigned!(u64, 2, u64x2, u128, (u128x2), $expr));
+    // for_simd_types!(unsigned!(u64, 4, u64x4, u128, (u128x4), $expr));
+    // for_simd_types!(unsigned!(u64, 8, u64x8, u128, (u128x8), $expr));
   };
   (float!($T:ident, $N:literal, $Simd:ident, $Signed:ident, $SimdSigned:ident, $pow_simd:ident, $expr:expr)) => {{
     type Simd = wide::$Simd;
@@ -100,7 +126,16 @@ macro_rules! for_simd_types {
     const pow_simd: fn(Simd, Simd) -> Simd = Simd::$pow_simd;
     $crate::utils::for_simd_types_helper(|| $expr, stringify!($T), $N);
   }};
-  (signed!($T:ident, $N:literal, $Simd:ident, $Unsigned:ident, $SimdUnsigned:ident, $expr:expr)) => {{
+  (signed!(
+    $T:ident,
+    $N:literal,
+    $Simd:ident,
+    $Unsigned:ident,
+    $SimdUnsigned:ident,
+    $DoubleSizedT:ident,
+    ($($DoubleSizedSimd:ident)?),
+    $expr:expr
+  )) => {{
     type Simd = wide::$Simd;
     #[allow(dead_code)]
     type T = $T;
@@ -110,14 +145,33 @@ macro_rules! for_simd_types {
     type Unsigned = $Unsigned;
     #[allow(dead_code)]
     type SimdUnsigned = wide::$SimdUnsigned;
+    #[allow(dead_code)]
+    type DoubleSizedT = $DoubleSizedT;
+    $(
+      #[allow(dead_code)]
+      type DoubleSizedSimd = wide::$DoubleSizedSimd;
+    )?
     $crate::utils::for_simd_types_helper(|| $expr, stringify!($T), $N);
   }};
-  (unsigned!($T:ident, $N:literal, $Simd:ident, $expr:expr)) => {{
+  (unsigned!(
+    $T:ident,
+    $N:literal,
+    $Simd:ident,
+    $DoubleSizedT:ident,
+    ($($DoubleSizedSimd:ident)?),
+    $expr:expr
+  )) => {{
     type Simd = wide::$Simd;
     #[allow(dead_code)]
     type T = $T;
     #[allow(dead_code)]
     const N: usize = $N;
+    #[allow(dead_code)]
+    type DoubleSizedT = $DoubleSizedT;
+    $(
+      #[allow(dead_code)]
+      type DoubleSizedSimd = wide::$DoubleSizedSimd;
+    )?
     $crate::utils::for_simd_types_helper(|| $expr, stringify!($T), $N);
   }};
 }


### PR DESCRIPTION
Changes:

- Renames `mul_widen` to `widening_mul`, deprecates the original functions and adds the new one to remaining types (excluding types that don't have a wider variant).
- Adds `mul_keep_high` to remaining integers (and moves it to the new macros).
- Adds `mul_keep_low_high`.
- Recycles `mul_keep_low_high` for `saturating_mul` and `overflowing_mul`

Currently std's nightly `widening_mul` function is actually equivalent to the added `mul_keep_low_high` function because it returns a tuple `(low, high)`, but based on the tracking issue it looks like its going to change to returning a wider integer type instead, like the `widening_mul` function added in this PR.

`mul_keep_low_high` returns a tuple of two SIMD vectors, one for the low bits and one for the high bits. I am not sure if its current name is great, it could be `mul_low_high` instead, but then `mul_keep_high` may need to be renamed too.