### PR TITLE
Implement `From` for `wide` types and native intrinsics SIMD types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.
 
 * Added overflowing arithmetic for integers.

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -24,6 +24,9 @@ impl_simd! {
     T = f32,
     N = 16,
     Simd = f32x16,
+    optional_type_x86_inner { X86Inner = __m512 },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -62,6 +62,9 @@ impl_simd! {
     T = f32,
     N = 4,
     Simd = f32x4,
+    optional_type_x86_inner { X86Inner = __m128 },
+    optional_type_arm_inner { ArmInner = float32x4_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -24,6 +24,9 @@ impl_simd! {
     T = f32,
     N = 8,
     Simd = f32x8,
+    optional_type_x86_inner { X86Inner = __m256 },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -65,6 +65,9 @@ impl_simd! {
     T = f64,
     N = 2,
     Simd = f64x2,
+    optional_type_x86_inner { X86Inner = __m128d },
+    optional_type_arm_inner { ArmInner = float64x2_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -24,6 +24,9 @@ impl_simd! {
     T = f64,
     N = 4,
     Simd = f64x4,
+    optional_type_x86_inner { X86Inner = __m256d },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -24,6 +24,9 @@ impl_simd! {
     T = f64,
     N = 8,
     Simd = f64x8,
+    optional_type_x86_inner { X86Inner = __m512d },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i16,
     N = 16,
     Simd = i16x16,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i16,
     N = 32,
     Simd = i16x32,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = i16,
     N = 8,
     Simd = i16x8,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = int16x8_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i32,
     N = 16,
     Simd = i32x16,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = i32,
     N = 4,
     Simd = i32x4,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = int32x4_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i32,
     N = 8,
     Simd = i32x8,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -60,6 +60,9 @@ impl_simd! {
     T = i64,
     N = 2,
     Simd = i64x2,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = int64x2_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i64,
     N = 4,
     Simd = i64x4,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i64,
     N = 8,
     Simd = i64x8,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = i8,
     N = 16,
     Simd = i8x16,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = int8x16_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = i8,
     N = 32,
     Simd = i8x32,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -6,10 +6,14 @@ macro_rules! impl_simd {
     // - `Pod` can be implemented for `Simd`
     // - `size_of::<Simd>()` is `size_of::<T>() * N`
     // - `align_of::<Simd>()` is `size_of::<Simd>()`
+    // - `Pod` can be implemented for the optional native SIMD types
     unsafe {
       T = $T:ident,
       N = $N:literal,
       Simd = $Simd:ident,
+      optional_type_x86_inner { $(X86Inner = $X86Inner:ident)? },
+      optional_type_arm_inner { $(ArmInner = $ArmInner:ident)? },
+      optional_type_wasm_inner { $(WasmInner = $WasmInner:ident)? },
     }
 
     $fn_simd_eq:item
@@ -83,6 +87,98 @@ macro_rules! impl_simd {
         result
       }
     }
+
+    $(
+      #[cfg(target_arch = "x86")]
+      impl From<core::arch::x86::$X86Inner> for $Simd {
+        /// Converts a native intrinsics SIMD type to a high-level SIMD type.
+        #[inline]
+        fn from(value: core::arch::x86::$X86Inner) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<core::arch::x86::$X86Inner, $Simd>(value) }
+        }
+      }
+
+      #[cfg(target_arch = "x86")]
+      impl From<$Simd> for core::arch::x86::$X86Inner {
+        /// Converts a high-level SIMD type to a native intrinsics SIMD type.
+        #[inline]
+        fn from(value: $Simd) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<$Simd, core::arch::x86::$X86Inner>(value) }
+        }
+      }
+
+      #[cfg(target_arch = "x86_64")]
+      impl From<core::arch::x86_64::$X86Inner> for $Simd {
+        /// Converts a native intrinsics SIMD type to a high-level SIMD type.
+        #[inline]
+        fn from(value: core::arch::x86_64::$X86Inner) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<core::arch::x86_64::$X86Inner, $Simd>(value) }
+        }
+      }
+
+      #[cfg(target_arch = "x86_64")]
+      impl From<$Simd> for core::arch::x86_64::$X86Inner {
+        /// Converts a high-level SIMD type to a native intrinsics SIMD type.
+        #[inline]
+        fn from(value: $Simd) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<$Simd, core::arch::x86_64::$X86Inner>(value) }
+        }
+      }
+    )?
+    $(
+      #[cfg(target_arch = "aarch64")]
+      impl From<core::arch::aarch64::$ArmInner> for $Simd {
+        /// Converts a native intrinsics SIMD type to a high-level SIMD type.
+        #[inline]
+        fn from(value: core::arch::aarch64::$ArmInner) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<core::arch::aarch64::$ArmInner, $Simd>(value) }
+        }
+      }
+
+      #[cfg(target_arch = "aarch64")]
+      impl From<$Simd> for core::arch::aarch64::$ArmInner {
+        /// Converts a high-level SIMD type to a native intrinsics SIMD type.
+        #[inline]
+        fn from(value: $Simd) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<$Simd, core::arch::aarch64::$ArmInner>(value) }
+        }
+      }
+    )?
+    $(
+      #[cfg(target_arch = "wasm32")]
+      impl From<core::arch::wasm32::$WasmInner> for $Simd {
+        /// Converts a native intrinsics SIMD type to a high-level SIMD type.
+        #[inline]
+        fn from(value: core::arch::wasm32::$WasmInner) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<core::arch::wasm32::$WasmInner, $Simd>(value) }
+        }
+      }
+
+      #[cfg(target_arch = "wasm32")]
+      impl From<$Simd> for core::arch::wasm32::$WasmInner {
+        /// Converts a high-level SIMD type to a native intrinsics SIMD type.
+        #[inline]
+        fn from(value: $Simd) -> Self {
+          // SAFETY: Both types are expected to accept all bit-patterns and to
+          // only contain initialized memory.
+          unsafe { core::mem::transmute::<$Simd, core::arch::wasm32::$WasmInner>(value) }
+        }
+      }
+    )?
 
     macro_rules! impl_formatting_trait {
       ($Trait:path) => {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u16,
     N = 16,
     Simd = u16x16,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u16,
     N = 32,
     Simd = u16x32,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = u16,
     N = 8,
     Simd = u16x8,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = uint16x8_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u32,
     N = 16,
     Simd = u32x16,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = u32,
     N = 4,
     Simd = u32x4,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = uint32x4_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u32,
     N = 8,
     Simd = u32x8,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -61,6 +61,9 @@ impl_simd! {
     T = u64,
     N = 2,
     Simd = u64x2,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = uint64x2_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u64,
     N = 4,
     Simd = u64x4,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u64,
     N = 8,
     Simd = u64x8,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -58,6 +58,9 @@ impl_simd! {
     T = u8,
     N = 16,
     Simd = u8x16,
+    optional_type_x86_inner { X86Inner = __m128i },
+    optional_type_arm_inner { ArmInner = uint8x16_t },
+    optional_type_wasm_inner { WasmInner = v128 },
   }
 
   #[inline]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -17,6 +17,9 @@ impl_simd! {
     T = u8,
     N = 32,
     Simd = u8x32,
+    optional_type_x86_inner { X86Inner = __m256i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
   }
 
   #[inline]


### PR DESCRIPTION
This feature also exists in `std::simd` and is useful when combining `wide` code with native SIMD code (usually code that cannot be written optimally with `wide`).

This PR gives each `wide` type one optional native type per target architecture (one for x86, one for arm, one for wasm), no `wide` type has conversions with multiple native types. Conversions are implemented even if expected target features are disabled, for example `f32x16` implements `From<__m512>` even if `avx512f` is disabled, as long as the target architecture is `x86` or `x86_64`.