### PR TITLE
Support u8x64 and i8x64 types

### DIFF
--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(64))]
-    pub struct f32x16 { pub(crate) a : f32x8, pub(crate) b : f32x8 }
+    pub struct f32x16 { pub(crate) a: f32x8, pub(crate) b: f32x8 }
   }
 }
 
@@ -36,8 +36,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(EqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -50,8 +50,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(NotEqualUnordered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -64,8 +64,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(LessThanOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -78,8 +78,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(GreaterThanOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -92,8 +92,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(LessEqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -106,8 +106,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512::<{cmp_op!(GreaterEqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -139,8 +139,8 @@ impl_simd! {
         Self { avx512: blend_varying_m512(if_false.avx512, if_true.avx512, movepi32_mask_m512(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -243,8 +243,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512(self.avx512, Self::splat(-0.0).avx512) }
       } else {
         Self {
-          a : self.a.neg(),
-          b : self.b.neg(),
+          a: self.a.neg(),
+          b: self.b.neg(),
         }
       }
     }
@@ -257,8 +257,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512(self.avx512, set_splat_m512(f32::from_bits(u32::MAX))) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -271,8 +271,8 @@ impl_simd_float! {
         Self { avx512: add_m512(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -285,8 +285,8 @@ impl_simd_float! {
         Self { avx512: sub_m512(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -343,8 +343,8 @@ impl_simd_float! {
         Self { avx512: bitand_m512(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -357,8 +357,8 @@ impl_simd_float! {
         Self { avx512: bitor_m512(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -371,8 +371,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -469,8 +469,8 @@ impl_simd_float! {
         1.0 / self
       } else {
         Self {
-          a : self.a.recip(),
-          b : self.b.recip(),
+          a: self.a.recip(),
+          b: self.b.recip(),
         }
       }
     }
@@ -486,8 +486,8 @@ impl_simd_float! {
         self.sqrt().recip()
       } else {
         Self {
-          a : self.a.recip_sqrt(),
-          b : self.b.recip_sqrt(),
+          a: self.a.recip_sqrt(),
+          b: self.b.recip_sqrt(),
         }
       }
     }
@@ -497,7 +497,7 @@ impl_simd_float! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        // max_m512 seems to do rhs < self ? self : rhs. So if there's any NaN
+        // max_m512 seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx512: max_m512(self.avx512, rhs.avx512) })
@@ -528,7 +528,7 @@ impl_simd_float! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {
-        // min_m512 seems to do rhs > self ? self : rhs. So if there's any NaN
+        // min_m512 seems to do rhs > self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx512: min_m512(self.avx512, rhs.avx512) })
@@ -595,8 +595,8 @@ impl_simd_float! {
         self & non_sign_bits
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -609,8 +609,8 @@ impl_simd_float! {
         Self { avx512: round_m512::<{round_op!(NegInf)}>(self.avx512) }
       } else {
         Self {
-          a : self.a.floor(),
-          b : self.b.floor(),
+          a: self.a.floor(),
+          b: self.b.floor(),
         }
       }
     }
@@ -623,8 +623,8 @@ impl_simd_float! {
         Self { avx512: round_m512::<{round_op!(PosInf)}>(self.avx512) }
       } else {
         Self {
-          a : self.a.ceil(),
-          b : self.b.ceil(),
+          a: self.a.ceil(),
+          b: self.b.ceil(),
         }
       }
     }
@@ -1023,8 +1023,8 @@ impl_simd_float! {
         Self { avx512: sqrt_m512(self.avx512) }
       } else {
         Self {
-          a : self.a.sqrt(),
-          b : self.b.sqrt(),
+          a: self.a.sqrt(),
+          b: self.b.sqrt(),
         }
       }
     }

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -27,7 +27,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct f32x4 { pub(crate) neon : float32x4_t }
+    pub struct f32x4 { pub(crate) neon: float32x4_t }
 
     impl Default for f32x4 {
       #[inline]
@@ -236,7 +236,7 @@ impl_simd! {
           let masked = vcltq_s32( vreinterpretq_s32_f32(self.neon), vdupq_n_s32(0));
 
           // select the right bit out of each lane
-          let selectbit : uint32x4_t = core::mem::transmute([1u32, 2, 4, 8]);
+          let selectbit: uint32x4_t = core::mem::transmute([1u32, 2, 4, 8]);
           let r = vandq_u32(masked, selectbit);
 
           // horizontally add the 16-bit lanes
@@ -625,14 +625,14 @@ impl_simd_float! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        // max_m128 seems to do rhs < self ? self : rhs. So if there's any NaN
+        // max_m128 seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { sse: max_m128(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two max intrinsics:
         // - max: This propagates NaN, that's the opposite of what we need.
-        // - pmax: This is defined as self < rhs ? rhs : self, which basically
+        // - pmax: This is defined as self < rhs ? rhs: self, which basically
         //   chooses self if either is NaN.
         //
         // pmax is what we want, but we need to specifically check self for NaN.
@@ -682,14 +682,14 @@ impl_simd_float! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse")] {
-        // min_m128 seems to do self < rhs ? self : rhs. So if there's any NaN
+        // min_m128 seems to do self < rhs ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { sse: min_m128(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two min intrinsics:
         // - min: This propagates NaN, that's the opposite of what we need.
-        // - pmin: This is defined as rhs < self ? rhs : self, which basically
+        // - pmin: This is defined as rhs < self ? rhs: self, which basically
         //   chooses self if either is NaN.
         //
         // pmin is what we want, but we need to specifically check self for NaN.

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(32))]
-    pub struct f32x8 { pub(crate) a : f32x4, pub(crate) b : f32x4 }
+    pub struct f32x8 { pub(crate) a: f32x4, pub(crate) b: f32x4 }
   }
 }
 
@@ -36,8 +36,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(EqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -50,8 +50,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(NotEqualUnordered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -64,8 +64,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(LessThanOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -78,8 +78,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(GreaterThanOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -92,8 +92,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(LessEqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -106,8 +106,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(GreaterEqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -139,8 +139,8 @@ impl_simd! {
         Self { avx: blend_varying_m256(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -197,8 +197,8 @@ impl_simd! {
           (z << 6) | (y << 4) | (x << 2) | w
         }
 
-        const SHUFF_LO : i32 = mm_shuffle(1,0,1,0);
-        const SHUFF_HI : i32 = mm_shuffle(3,2,3,2);
+        const SHUFF_LO: i32 = mm_shuffle(1,0,1,0);
+        const SHUFF_HI: i32 = mm_shuffle(3,2,3,2);
 
         // possible todo: intel performance manual suggests alternative with blend to avoid port 5 pressure
         // (since blend runs on a different port than shuffle)
@@ -268,8 +268,8 @@ impl_simd_float! {
         Self { avx: bitxor_m256(self.avx, Self::splat(-0.0).avx) }
       } else {
         Self {
-          a : self.a.neg(),
-          b : self.b.neg(),
+          a: self.a.neg(),
+          b: self.b.neg(),
         }
       }
     }
@@ -282,8 +282,8 @@ impl_simd_float! {
         Self { avx: self.avx.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -296,8 +296,8 @@ impl_simd_float! {
         Self { avx: add_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -310,8 +310,8 @@ impl_simd_float! {
         Self { avx: sub_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -324,8 +324,8 @@ impl_simd_float! {
         Self { avx: mul_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -338,8 +338,8 @@ impl_simd_float! {
         Self { avx: div_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.div(rhs.a),
-          b : self.b.div(rhs.b),
+          a: self.a.div(rhs.a),
+          b: self.b.div(rhs.b),
         }
       }
     }
@@ -366,8 +366,8 @@ impl_simd_float! {
         Self { avx: bitand_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -380,8 +380,8 @@ impl_simd_float! {
         Self { avx: bitor_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -394,8 +394,8 @@ impl_simd_float! {
         Self { avx: bitxor_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -450,8 +450,8 @@ impl_simd_float! {
         Self { avx: cmp_op_mask_m256::<{cmp_op!(Unordered)}>(self.avx, self.avx) }
       } else {
         Self {
-          a : self.a.is_nan(),
-          b : self.b.is_nan(),
+          a: self.a.is_nan(),
+          b: self.b.is_nan(),
         }
       }
     }
@@ -502,8 +502,8 @@ impl_simd_float! {
         Self { avx: reciprocal_m256(self.avx) }
       } else {
         Self {
-          a : self.a.recip(),
-          b : self.b.recip(),
+          a: self.a.recip(),
+          b: self.b.recip(),
         }
       }
     }
@@ -516,8 +516,8 @@ impl_simd_float! {
         Self { avx: reciprocal_sqrt_m256(self.avx) }
       } else {
         Self {
-          a : self.a.recip_sqrt(),
-          b : self.b.recip_sqrt(),
+          a: self.a.recip_sqrt(),
+          b: self.b.recip_sqrt(),
         }
       }
     }
@@ -527,14 +527,14 @@ impl_simd_float! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        // max_m256 seems to do rhs < self ? self : rhs. So if there's any NaN
+        // max_m256 seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx: max_m256(self.avx, rhs.avx) })
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
 
@@ -548,8 +548,8 @@ impl_simd_float! {
         Self { avx: max_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.fast_max(rhs.a),
-          b : self.b.fast_max(rhs.b),
+          a: self.a.fast_max(rhs.a),
+          b: self.b.fast_max(rhs.b),
         }
       }
     }
@@ -559,14 +559,14 @@ impl_simd_float! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        // min_m256 seems to do rhs > self ? self : rhs. So if there's any NaN
+        // min_m256 seems to do rhs > self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx: min_m256(self.avx, rhs.avx) })
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -579,8 +579,8 @@ impl_simd_float! {
         Self { avx: min_m256(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.fast_min(rhs.a),
-          b : self.b.fast_min(rhs.b),
+          a: self.a.fast_min(rhs.a),
+          b: self.b.fast_min(rhs.b),
         }
       }
     }
@@ -626,8 +626,8 @@ impl_simd_float! {
         self & non_sign_bits
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -640,8 +640,8 @@ impl_simd_float! {
         Self { avx: floor_m256(self.avx) }
       } else {
         Self {
-          a : self.a.floor(),
-          b : self.b.floor(),
+          a: self.a.floor(),
+          b: self.b.floor(),
         }
       }
     }
@@ -654,8 +654,8 @@ impl_simd_float! {
         Self { avx: ceil_m256(self.avx) }
       } else {
         Self {
-          a : self.a.ceil(),
-          b : self.b.ceil(),
+          a: self.a.ceil(),
+          b: self.b.ceil(),
         }
       }
     }
@@ -728,8 +728,8 @@ impl_simd_float! {
         Self { avx: round_m256::<{round_op!(Nearest)}>(self.avx) }
       } else {
         Self {
-          a : self.a.round_ties_even(),
-          b : self.b.round_ties_even(),
+          a: self.a.round_ties_even(),
+          b: self.b.round_ties_even(),
         }
       }
     }
@@ -742,8 +742,8 @@ impl_simd_float! {
         Self { avx: round_m256::<{round_op!(Zero)}>(self.avx) }
       } else {
         Self {
-          a : self.a.trunc(),
-          b : self.b.trunc(),
+          a: self.a.trunc(),
+          b: self.b.trunc(),
         }
       }
     }
@@ -811,8 +811,8 @@ impl_simd_float! {
         (self * m) + a
       } else {
         Self {
-          a : self.a.mul_add(m.a, a.a),
-          b : self.b.mul_add(m.b, a.b),
+          a: self.a.mul_add(m.a, a.a),
+          b: self.b.mul_add(m.b, a.b),
         }
       }
     }
@@ -847,8 +847,8 @@ impl_simd_float! {
         (self * m) - s
       } else {
         Self {
-          a : self.a.mul_sub(m.a, s.a),
-          b : self.b.mul_sub(m.b, s.b),
+          a: self.a.mul_sub(m.a, s.a),
+          b: self.b.mul_sub(m.b, s.b),
         }
       }
     }
@@ -883,8 +883,8 @@ impl_simd_float! {
         a - (self * m)
       } else {
         Self {
-          a : self.a.mul_neg_add(m.a, a.a),
-          b : self.b.mul_neg_add(m.b, a.b),
+          a: self.a.mul_neg_add(m.a, a.a),
+          b: self.b.mul_neg_add(m.b, a.b),
         }
       }
     }
@@ -919,8 +919,8 @@ impl_simd_float! {
         -(self * m) - s
       } else {
         Self {
-          a : self.a.mul_neg_sub(m.a, s.a),
-          b : self.b.mul_neg_sub(m.b, s.b),
+          a: self.a.mul_neg_sub(m.a, s.a),
+          b: self.b.mul_neg_sub(m.b, s.b),
         }
       }
     }
@@ -1045,8 +1045,8 @@ impl_simd_float! {
         Self { avx: sqrt_m256(self.avx) }
       } else {
         Self {
-          a : self.a.sqrt(),
-          b : self.b.sqrt(),
+          a: self.a.sqrt(),
+          b: self.b.sqrt(),
         }
       }
     }

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -572,14 +572,14 @@ impl_simd_float! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        // max_m128d seems to do rhs < self ? self : rhs. So if there's any NaN
+        // max_m128d seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { sse: max_m128d(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two max intrinsics:
         // - max: This propagates NaN, that's the opposite of what we need.
-        // - pmax: This is defined as self < rhs ? rhs : self, which basically
+        // - pmax: This is defined as self < rhs ? rhs: self, which basically
         //   chooses self if either is NaN.
         //
         // pmax is what we want, but we need to specifically check self for NaN.
@@ -625,14 +625,14 @@ impl_simd_float! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {
-        // min_m128d seems to do rhs < self ? rhs : self. So if there's any NaN
+        // min_m128d seems to do rhs < self ? rhs: self. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { sse: min_m128d(self.sse, rhs.sse) })
       } else if #[cfg(target_feature="simd128")] {
         // WASM has two min intrinsics:
         // - min: This propagates NaN, that's the opposite of what we need.
-        // - pmin: This is defined as rhs < self ? rhs : self, which basically
+        // - pmin: This is defined as rhs < self ? rhs: self, which basically
         //   chooses self if either is NaN.
         //
         // pmin is what we want, but we need to specifically check self for NaN.

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -36,8 +36,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(EqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -50,8 +50,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(NotEqualUnordered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -64,8 +64,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(LessThanOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -78,8 +78,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!( GreaterThanOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -92,8 +92,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(LessEqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -106,8 +106,8 @@ impl_simd! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(GreaterEqualOrdered)}>(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -139,8 +139,8 @@ impl_simd! {
         Self { avx: blend_varying_m256d(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -232,8 +232,8 @@ impl_simd_float! {
         Self { avx: bitxor_m256d(self.avx, Self::splat(-0.0).avx) }
       } else {
         Self {
-          a : self.a.neg(),
-          b : self.b.neg(),
+          a: self.a.neg(),
+          b: self.b.neg(),
         }
       }
     }
@@ -246,8 +246,8 @@ impl_simd_float! {
         Self { avx: self.avx.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -260,8 +260,8 @@ impl_simd_float! {
         Self { avx: add_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -274,8 +274,8 @@ impl_simd_float! {
         Self { avx: sub_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -288,8 +288,8 @@ impl_simd_float! {
         Self { avx: mul_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -302,8 +302,8 @@ impl_simd_float! {
         Self { avx: div_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.div(rhs.a),
-          b : self.b.div(rhs.b),
+          a: self.a.div(rhs.a),
+          b: self.b.div(rhs.b),
         }
       }
     }
@@ -326,8 +326,8 @@ impl_simd_float! {
         Self { avx: bitand_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -340,8 +340,8 @@ impl_simd_float! {
         Self { avx: bitor_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -354,8 +354,8 @@ impl_simd_float! {
         Self { avx: bitxor_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -402,8 +402,8 @@ impl_simd_float! {
         Self { avx: cmp_op_mask_m256d::<{cmp_op!(Unordered)}>(self.avx, self.avx ) }
       } else {
         Self {
-          a : self.a.is_nan(),
-          b : self.b.is_nan(),
+          a: self.a.is_nan(),
+          b: self.b.is_nan(),
         }
       }
     }
@@ -465,14 +465,14 @@ impl_simd_float! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        // max_m256d seems to do rhs < self ? self : rhs. So if there's any NaN
+        // max_m256d seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx: max_m256d(self.avx, rhs.avx) })
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -485,8 +485,8 @@ impl_simd_float! {
         Self { avx: max_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.fast_max(rhs.a),
-          b : self.b.fast_max(rhs.b),
+          a: self.a.fast_max(rhs.a),
+          b: self.b.fast_max(rhs.b),
         }
       }
     }
@@ -496,14 +496,14 @@ impl_simd_float! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx")] {
-        // min_m256d seems to do rhs < self ? self : rhs. So if there's any NaN
+        // min_m256d seems to do rhs < self ? self: rhs. So if there's any NaN
         // involved, it chooses rhs, so we need to specifically check rhs for
         // NaN.
         rhs.is_nan().select(self, Self { avx: min_m256d(self.avx, rhs.avx) })
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -516,8 +516,8 @@ impl_simd_float! {
         Self { avx: min_m256d(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.fast_min(rhs.a),
-          b : self.b.fast_min(rhs.b),
+          a: self.a.fast_min(rhs.a),
+          b: self.b.fast_min(rhs.b),
         }
       }
     }
@@ -563,8 +563,8 @@ impl_simd_float! {
         self & non_sign_bits
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -577,8 +577,8 @@ impl_simd_float! {
         Self { avx: floor_m256d(self.avx) }
       } else {
         Self {
-          a : self.a.floor(),
-          b : self.b.floor(),
+          a: self.a.floor(),
+          b: self.b.floor(),
         }
       }
     }
@@ -591,8 +591,8 @@ impl_simd_float! {
         Self { avx: ceil_m256d(self.avx) }
       } else {
         Self {
-          a : self.a.ceil(),
-          b : self.b.ceil(),
+          a: self.a.ceil(),
+          b: self.b.ceil(),
         }
       }
     }
@@ -674,8 +674,8 @@ impl_simd_float! {
         Self { avx: round_m256d::<{round_op!(Nearest)}>(self.avx) }
       } else {
         Self {
-          a : self.a.round_ties_even(),
-          b : self.b.round_ties_even(),
+          a: self.a.round_ties_even(),
+          b: self.b.round_ties_even(),
         }
       }
     }
@@ -688,8 +688,8 @@ impl_simd_float! {
         Self { avx: round_m256d::<{round_op!(Zero)}>(self.avx) }
       } else {
         Self {
-          a : self.a.trunc(),
-          b : self.b.trunc(),
+          a: self.a.trunc(),
+          b: self.b.trunc(),
         }
       }
     }
@@ -766,8 +766,8 @@ impl_simd_float! {
         (self * m) + a
       } else {
         Self {
-          a : self.a.mul_add(m.a, a.a),
-          b : self.b.mul_add(m.b, a.b),
+          a: self.a.mul_add(m.a, a.a),
+          b: self.b.mul_add(m.b, a.b),
         }
       }
     }
@@ -802,8 +802,8 @@ impl_simd_float! {
         (self * m) - s
       } else {
         Self {
-          a : self.a.mul_sub(m.a, s.a),
-          b : self.b.mul_sub(m.b, s.b),
+          a: self.a.mul_sub(m.a, s.a),
+          b: self.b.mul_sub(m.b, s.b),
         }
       }
     }
@@ -838,8 +838,8 @@ impl_simd_float! {
         a - (self * m)
       } else {
         Self {
-          a : self.a.mul_neg_add(m.a, a.a),
-          b : self.b.mul_neg_add(m.b, a.b),
+          a: self.a.mul_neg_add(m.a, a.a),
+          b: self.b.mul_neg_add(m.b, a.b),
         }
       }
     }
@@ -874,8 +874,8 @@ impl_simd_float! {
           -(self * m) - s
         } else {
          Self {
-           a : self.a.mul_neg_sub(m.a, s.a),
-           b : self.b.mul_neg_sub(m.b, s.b),
+           a: self.a.mul_neg_sub(m.a, s.a),
+           b: self.b.mul_neg_sub(m.b, s.b),
          }
        }
     }
@@ -1012,8 +1012,8 @@ impl_simd_float! {
         Self { avx: sqrt_m256d(self.avx) }
       } else {
         Self {
-          a : self.a.sqrt(),
-          b : self.b.sqrt(),
+          a: self.a.sqrt(),
+          b: self.b.sqrt(),
         }
       }
     }

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq)]
     #[repr(C, align(64))]
-    pub struct f64x8 { pub(crate) a : f64x4, pub(crate) b : f64x4 }
+    pub struct f64x8 { pub(crate) a: f64x4, pub(crate) b: f64x4 }
   }
 }
 
@@ -36,8 +36,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(EqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -50,8 +50,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(NotEqualUnordered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -64,8 +64,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(LessThanOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -78,8 +78,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(GreaterThanOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -92,8 +92,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(LessEqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -106,8 +106,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_m512d::<{cmp_op!(GreaterEqualOrdered)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -139,8 +139,8 @@ impl_simd! {
         Self { avx512: blend_varying_m512d(if_false.avx512, if_true.avx512, movepi64_mask_m512d(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -226,8 +226,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512d(self.avx512, Self::splat(-0.0).avx512) }
       } else {
         Self {
-          a : self.a.neg(),
-          b : self.b.neg(),
+          a: self.a.neg(),
+          b: self.b.neg(),
         }
       }
     }
@@ -240,8 +240,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512d(self.avx512, set_splat_m512d(f64::from_bits(u64::MAX))) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -254,8 +254,8 @@ impl_simd_float! {
         Self { avx512: add_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -268,8 +268,8 @@ impl_simd_float! {
         Self { avx512: sub_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -318,8 +318,8 @@ impl_simd_float! {
         Self { avx512: bitand_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -332,8 +332,8 @@ impl_simd_float! {
         Self { avx512: bitor_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -346,8 +346,8 @@ impl_simd_float! {
         Self { avx512: bitxor_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -479,8 +479,8 @@ impl_simd_float! {
         Self { avx512: max_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.fast_max(rhs.a),
-          b : self.b.fast_max(rhs.b),
+          a: self.a.fast_max(rhs.a),
+          b: self.b.fast_max(rhs.b),
         }
       }
     }
@@ -507,8 +507,8 @@ impl_simd_float! {
         Self { avx512: min_m512d(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.fast_min(rhs.a),
-          b : self.b.fast_min(rhs.b),
+          a: self.a.fast_min(rhs.a),
+          b: self.b.fast_min(rhs.b),
         }
       }
     }
@@ -568,8 +568,8 @@ impl_simd_float! {
         Self { avx512: round_m512d::<{round_op!(NegInf)}>(self.avx512) }
       } else {
         Self {
-          a : self.a.floor(),
-          b : self.b.floor(),
+          a: self.a.floor(),
+          b: self.b.floor(),
         }
       }
     }
@@ -582,8 +582,8 @@ impl_simd_float! {
         Self { avx512: round_m512d::<{round_op!(PosInf)}>(self.avx512) }
       } else {
         Self {
-          a : self.a.ceil(),
-          b : self.b.ceil(),
+          a: self.a.ceil(),
+          b: self.b.ceil(),
         }
       }
     }
@@ -771,8 +771,8 @@ impl_simd_float! {
         (self * m) + a
       } else {
         Self {
-          a : self.a.mul_add(m.a, a.a),
-          b : self.b.mul_add(m.b, a.b),
+          a: self.a.mul_add(m.a, a.a),
+          b: self.b.mul_add(m.b, a.b),
         }
       }
     }
@@ -808,8 +808,8 @@ impl_simd_float! {
         (self * m) - s
       } else {
         Self {
-          a : self.a.mul_sub(m.a, s.a),
-          b : self.b.mul_sub(m.b, s.b),
+          a: self.a.mul_sub(m.a, s.a),
+          b: self.b.mul_sub(m.b, s.b),
         }
       }
     }
@@ -845,8 +845,8 @@ impl_simd_float! {
         a - (self * m)
       } else {
         Self {
-          a : self.a.mul_neg_add(m.a, a.a),
-          b : self.b.mul_neg_add(m.b, a.b),
+          a: self.a.mul_neg_add(m.a, a.a),
+          b: self.b.mul_neg_add(m.b, a.b),
         }
       }
     }
@@ -882,8 +882,8 @@ impl_simd_float! {
           -(self * m) - s
         } else {
          Self {
-           a : self.a.mul_neg_sub(m.a, s.a),
-           b : self.b.mul_neg_sub(m.b, s.b),
+           a: self.a.mul_neg_sub(m.a, s.a),
+           b: self.b.mul_neg_sub(m.b, s.b),
          }
        }
     }
@@ -1020,8 +1020,8 @@ impl_simd_float! {
         Self { avx512: sqrt_m512d(self.avx512) }
       } else {
         Self {
-          a : self.a.sqrt(),
-          b : self.b.sqrt(),
+          a: self.a.sqrt(),
+          b: self.b.sqrt(),
         }
       }
     }

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i16x16 { pub(crate) a : i16x8, pub(crate) b : i16x8 }
+    pub struct i16x16 { pub(crate) a: i16x8, pub(crate) b: i16x8 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx2: !cmp_gt_mask_i16_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i16_m256i(self.avx2,rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -239,8 +239,8 @@ impl_simd_int! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -253,8 +253,8 @@ impl_simd_int! {
         Self { avx2: add_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -267,8 +267,8 @@ impl_simd_int! {
         Self { avx2: sub_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -281,8 +281,8 @@ impl_simd_int! {
         Self { avx2: mul_i16_keep_low_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -320,8 +320,8 @@ impl_simd_int! {
         Self { avx2: shl_all_u16_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -359,8 +359,8 @@ impl_simd_int! {
         Self { avx2: shr_all_i16_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -373,8 +373,8 @@ impl_simd_int! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -387,8 +387,8 @@ impl_simd_int! {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -401,8 +401,8 @@ impl_simd_int! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -415,8 +415,8 @@ impl_simd_int! {
         Self { avx2: max_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -429,8 +429,8 @@ impl_simd_int! {
         Self { avx2: min_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -470,8 +470,8 @@ impl_simd_int! {
         Self { avx2: add_saturating_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.saturating_add(rhs.a),
-          b : self.b.saturating_add(rhs.b),
+          a: self.a.saturating_add(rhs.a),
+          b: self.b.saturating_add(rhs.b),
         }
       }
     }
@@ -484,8 +484,8 @@ impl_simd_int! {
         Self { avx2: sub_saturating_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.saturating_sub(rhs.a),
-          b : self.b.saturating_sub(rhs.b),
+          a: self.a.saturating_sub(rhs.a),
+          b: self.b.saturating_sub(rhs.b),
         }
       }
     }
@@ -544,8 +544,8 @@ impl_simd_int! {
         Self { avx2: abs_i16_m256i(self.avx2) }
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -652,8 +652,8 @@ impl i16x16 {
         i32x8 { avx2:  mul_i16_horizontal_add_m256i(self.avx2, rhs.avx2) }
       } else {
         i32x8 {
-          a : self.a.dot(rhs.a),
-          b : self.b.dot(rhs.b),
+          a: self.a.dot(rhs.a),
+          b: self.b.dot(rhs.b),
         }
       }
     }
@@ -674,8 +674,8 @@ impl i16x16 {
         Self { avx2: mul_i16_scale_round_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.mul_scale_round(rhs.a),
-          b : self.b.mul_scale_round(rhs.b),
+          a: self.a.mul_scale_round(rhs.a),
+          b: self.b.mul_scale_round(rhs.b),
         }
       }
     }
@@ -696,8 +696,8 @@ impl i16x16 {
         Self { avx2: mul_i16_scale_round_m256i(self.avx2, set_splat_i16_m256i(rhs)) }
       } else {
         Self {
-          a : self.a.mul_scale_round_n(rhs),
-          b : self.b.mul_scale_round_n(rhs),
+          a: self.a.mul_scale_round_n(rhs),
+          b: self.b.mul_scale_round_n(rhs),
         }
       }
     }

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct i16x32 { pub(crate) a : i16x16, pub(crate) b : i16x16 }
+    pub struct i16x32 { pub(crate) a: i16x16, pub(crate) b: i16x16 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i16_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -274,8 +274,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i16_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -288,8 +288,8 @@ impl_simd_int! {
         Self { avx512: add_i16_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -302,8 +302,8 @@ impl_simd_int! {
         Self { avx512: sub_i16_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -346,8 +346,8 @@ impl_simd_int! {
         Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -385,8 +385,8 @@ impl_simd_int! {
         Self { avx512: shr_all_i16_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -399,8 +399,8 @@ impl_simd_int! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -413,8 +413,8 @@ impl_simd_int! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -427,8 +427,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -558,8 +558,8 @@ impl_simd_int! {
         Self { avx512: abs_i16_m512i(self.avx512) }
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -609,8 +609,8 @@ impl i16x32 {
         i32x16 { avx512: mul_i16_horizontal_add_m512i(self.avx512, rhs.avx512) }
       } else {
         i32x16 {
-          a : self.a.dot(rhs.a),
-          b : self.b.dot(rhs.b),
+          a: self.a.dot(rhs.a),
+          b: self.b.dot(rhs.b),
         }
       }
     }

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct i16x8 { pub(crate) neon : int16x8_t }
+    pub struct i16x8 { pub(crate) neon: int16x8_t }
 
     impl Default for i16x8 {
       #[inline]
@@ -256,7 +256,7 @@ impl_simd! {
           let masked = vcltq_s16(self.neon, vdupq_n_s16(0));
 
           // select the right bit out of each lane
-          let selectbit : uint16x8_t = core::mem::transmute([1u16, 2, 4, 8, 16, 32, 64, 128]);
+          let selectbit: uint16x8_t = core::mem::transmute([1u16, 2, 4, 8, 16, 32, 64, 128]);
           let r = vandq_u16(masked, selectbit);
 
           // horizontally add the 16-bit lanes
@@ -287,7 +287,7 @@ impl_simd! {
           vminvq_s16(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] | v[1]) & 0x8000800080008000) != 0
       }
     }
@@ -305,7 +305,7 @@ impl_simd! {
           vmaxvq_s16(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         (v[0] & v[1] & 0x8000800080008000) == 0x8000800080008000
       }
     }
@@ -346,7 +346,7 @@ impl_simd! {
         ]
      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
 
-          #[inline] fn vtrq32(a : int16x8_t, b : int16x8_t) -> (int16x8_t, int16x8_t)
+          #[inline] fn vtrq32(a: int16x8_t, b: int16x8_t) -> (int16x8_t, int16x8_t)
           {
               unsafe {
                 let r = vtrnq_s32(vreinterpretq_s32_s16(a),vreinterpretq_s32_s16(b));
@@ -380,12 +380,12 @@ impl_simd! {
           ]
         }
       } else if #[cfg(target_feature="simd128")] {
-        #[inline] fn lo_i16(a : v128, b : v128) -> v128 { i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a,b) }
-        #[inline] fn hi_i16(a : v128, b : v128) -> v128 { i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(a,b) }
-        #[inline] fn lo_i32(a : v128, b : v128) -> v128 { i32x4_shuffle::<0, 4, 1, 5>(a,b) }
-        #[inline] fn hi_i32(a : v128, b : v128) -> v128 { i32x4_shuffle::<2, 6, 3, 7>(a,b) }
-        #[inline] fn lo_i64(a : v128, b : v128) -> v128 { i64x2_shuffle::<0, 2>(a,b) }
-        #[inline] fn hi_i64(a : v128, b : v128) -> v128 { i64x2_shuffle::<1, 3>(a,b) }
+        #[inline] fn lo_i16(a: v128, b: v128) -> v128 { i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a,b) }
+        #[inline] fn hi_i16(a: v128, b: v128) -> v128 { i16x8_shuffle::<4, 12, 5, 13, 6, 14, 7, 15>(a,b) }
+        #[inline] fn lo_i32(a: v128, b: v128) -> v128 { i32x4_shuffle::<0, 4, 1, 5>(a,b) }
+        #[inline] fn hi_i32(a: v128, b: v128) -> v128 { i32x4_shuffle::<2, 6, 3, 7>(a,b) }
+        #[inline] fn lo_i64(a: v128, b: v128) -> v128 { i64x2_shuffle::<0, 2>(a,b) }
+        #[inline] fn hi_i64(a: v128, b: v128) -> v128 { i64x2_shuffle::<1, 3>(a,b) }
 
         let a1 = lo_i16(data[0].simd, data[1].simd);
         let a2 = hi_i16(data[0].simd, data[1].simd);
@@ -1234,7 +1234,7 @@ impl i16x8 {
           i16x8 { neon: vcombine_s16(vqmovn_s32(v.a.neon), vqmovn_s32(v.b.neon)) }
         }
       } else {
-        fn clamp(a : i32) -> i16 {
+        fn clamp(a: i32) -> i16 {
             if a < i16::MIN as i32 {
                 i16::MIN
             }

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct i32x16 { pub(crate) a : i32x8, pub(crate) b : i32x8 }
+    pub struct i32x16 { pub(crate) a: i32x8, pub(crate) b: i32x8 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i32_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -240,8 +240,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i32_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -254,8 +254,8 @@ impl_simd_int! {
         Self { avx512: add_i32_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -268,8 +268,8 @@ impl_simd_int! {
         Self { avx512: sub_i32_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -312,8 +312,8 @@ impl_simd_int! {
         Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -351,8 +351,8 @@ impl_simd_int! {
         Self { avx512: shr_all_i32_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -365,8 +365,8 @@ impl_simd_int! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -379,8 +379,8 @@ impl_simd_int! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -393,8 +393,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -578,8 +578,8 @@ impl_simd_int! {
         Self { avx512: abs_i32_m512i(self.avx512) }
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct i32x4 { pub(crate) neon : int32x4_t }
+    pub struct i32x4 { pub(crate) neon: int32x4_t }
 
     impl Default for i32x4 {
       #[inline]
@@ -233,7 +233,7 @@ impl_simd! {
           let masked = vcltq_s32(self.neon, vdupq_n_s32(0));
 
           // select the right bit out of each lane
-          let selectbit : uint32x4_t = core::mem::transmute([1u32, 2, 4, 8]);
+          let selectbit: uint32x4_t = core::mem::transmute([1u32, 2, 4, 8]);
           let r = vandq_u32(masked, selectbit);
 
           // horizontally add the 32-bit lanes
@@ -262,7 +262,7 @@ impl_simd! {
           vminvq_s32(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] | v[1]) & 0x8000000080000000) != 0
       }
     }
@@ -282,7 +282,7 @@ impl_simd! {
           vmaxvq_s32(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         (v[0] & v[1] & 0x8000000080000000) == 0x8000000080000000
       }
     }

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i32x8 { pub(crate) a : i32x4, pub(crate) b : i32x4}
+    pub struct i32x8 { pub(crate) a: i32x4, pub(crate) b: i32x4}
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i32_m256i(rhs.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b)
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b)
         }
       }
     }
@@ -191,8 +191,8 @@ impl_simd! {
           (z << 6) | (y << 4) | (x << 2) | w
         }
 
-        const SHUFF_LO : i32 = mm_shuffle(1,0,1,0);
-        const SHUFF_HI : i32 = mm_shuffle(3,2,3,2);
+        const SHUFF_LO: i32 = mm_shuffle(1,0,1,0);
+        const SHUFF_HI: i32 = mm_shuffle(3,2,3,2);
 
         // possible todo: intel performance manual suggests alternative with blend to avoid port 5 pressure
         // (since blend runs on a different port than shuffle)
@@ -265,8 +265,8 @@ impl_simd_int! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -279,8 +279,8 @@ impl_simd_int! {
         Self { avx2: add_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -293,8 +293,8 @@ impl_simd_int! {
         Self { avx2: sub_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -307,8 +307,8 @@ impl_simd_int! {
         Self { avx2: mul_i32_keep_low_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -324,8 +324,8 @@ impl_simd_int! {
         Self { avx2: shl_each_u32_m256i(self.avx2, shift_by) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -341,8 +341,8 @@ impl_simd_int! {
         Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -357,8 +357,8 @@ impl_simd_int! {
         Self { avx2: shr_each_i32_m256i(self.avx2, shift_by ) }
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -374,8 +374,8 @@ impl_simd_int! {
         Self { avx2: shr_all_i32_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -388,8 +388,8 @@ impl_simd_int! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -402,8 +402,8 @@ impl_simd_int! {
       Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
     } else {
       Self {
-        a : self.a.bitor(rhs.a),
-        b : self.b.bitor(rhs.b),
+        a: self.a.bitor(rhs.a),
+        b: self.b.bitor(rhs.b),
       }
     }    }
   }
@@ -415,8 +415,8 @@ impl_simd_int! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -429,8 +429,8 @@ impl_simd_int! {
         Self { avx2: max_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -443,8 +443,8 @@ impl_simd_int! {
         Self { avx2: min_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -619,8 +619,8 @@ impl_simd_int! {
         Self { avx2: abs_i32_m256i(self.avx2) }
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct i64x2 { pub(crate) neon : int64x2_t }
+    pub struct i64x2 { pub(crate) neon: int64x2_t }
 
     impl Default for i64x2 {
       #[inline]
@@ -249,7 +249,7 @@ impl_simd! {
       } else if #[cfg(target_feature="simd128")] {
         i64x2_bitmask(self.simd) != 0
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] | v[1]) & 0x8000000000000000) != 0
       }
     }
@@ -265,7 +265,7 @@ impl_simd! {
       }  else if #[cfg(target_feature="simd128")] {
         i64x2_bitmask(self.simd) == 0b11
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] & v[1]) & 0x8000000000000000) == 0x8000000000000000
       }
     }

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i64x4 { pub(crate) a : i64x2, pub(crate) b : i64x2 }
+    pub struct i64x4 { pub(crate) a: i64x2, pub(crate) b: i64x2 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx2: !(cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) ^ cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2)) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2,if_true.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -233,8 +233,8 @@ impl_simd_int! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -247,8 +247,8 @@ impl_simd_int! {
         Self { avx2: add_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -261,8 +261,8 @@ impl_simd_int! {
         Self { avx2: sub_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -295,8 +295,8 @@ impl_simd_int! {
         Self { avx2: shl_each_u64_m256i(self.avx2, shift_by.avx2) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -312,8 +312,8 @@ impl_simd_int! {
         Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -333,8 +333,8 @@ impl_simd_int! {
         ])
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -343,7 +343,7 @@ impl_simd_int! {
   #[inline]
   fn shr(self, rhs: u32) -> Self::Output {
     // there is no signed right shift in AVX2
-    let [a,b] : [i64x2; 2] = cast(self);
+    let [a,b]: [i64x2; 2] = cast(self);
     cast([a.shr(rhs), b.shr(rhs)])
   }
 
@@ -354,8 +354,8 @@ impl_simd_int! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -368,8 +368,8 @@ impl_simd_int! {
             Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -382,8 +382,8 @@ impl_simd_int! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -566,8 +566,8 @@ impl_simd_int! {
           ])
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct i64x8 { pub(crate) a : i64x4, pub(crate) b : i64x4 }
+    pub struct i64x8 { pub(crate) a: i64x4, pub(crate) b: i64x4 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_i64_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -118,8 +118,8 @@ impl_simd! {
         }
       } else {
         Self {
-          a : self.a.bitselect(if_one.a, if_zero.a),
-          b : self.b.bitselect(if_one.b, if_zero.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -229,8 +229,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i64_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -243,8 +243,8 @@ impl_simd_int! {
         Self { avx512: add_i64_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -257,8 +257,8 @@ impl_simd_int! {
         Self { avx512: sub_i64_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -325,8 +325,8 @@ impl_simd_int! {
         Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -371,8 +371,8 @@ impl_simd_int! {
         Self { avx512: shr_all_i64_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -385,8 +385,8 @@ impl_simd_int! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -399,8 +399,8 @@ impl_simd_int! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -413,8 +413,8 @@ impl_simd_int! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -636,8 +636,8 @@ impl_simd_int! {
           ])
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct i8x16 { pub(crate) neon : int8x16_t }
+    pub struct i8x16 { pub(crate) neon: int8x16_t }
 
     impl Default for i8x16 {
       #[inline]
@@ -304,11 +304,11 @@ impl_simd! {
           let masked = vcltq_s8(self.neon, vdupq_n_s8(0));
 
           // select the right bit out of each lane
-          let selectbit : uint8x16_t = core::mem::transmute([1u8, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128]);
+          let selectbit: uint8x16_t = core::mem::transmute([1u8, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128]);
           let out = vandq_u8(masked, selectbit);
 
           // interleave the lanes so that a 16-bit sum accumulates the bits in the right order
-          let table : uint8x16_t = core::mem::transmute([0u8, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]);
+          let table: uint8x16_t = core::mem::transmute([0u8, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]);
           let r = vqtbl1q_u8(out, table);
 
           // horizontally add the 16-bit lanes
@@ -347,7 +347,7 @@ impl_simd! {
           vminvq_s8(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] | v[1]) & 0x8080808080808080) != 0
       }
     }
@@ -365,7 +365,7 @@ impl_simd! {
           vmaxvq_s8(self.neon) < 0
         }
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         (v[0] & v[1] & 0x8080808080808080) == 0x8080808080808080
       }
     }
@@ -1327,7 +1327,7 @@ impl i8x16 {
 
         i8x16 { simd: i8x16_narrow_i16x8(v.a.simd, v.b.simd) }
       } else {
-        fn clamp(a : i16) -> i8 {
+        fn clamp(a: i16) -> i8 {
             if a < i8::MIN as i16 {
               i8::MIN
             }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct i8x32 { a : i8x16, b : i8x16 }
+    pub struct i8x32 { a: i8x16, b: i8x16 }
   }
 }
 
@@ -26,11 +26,11 @@ impl_simd! {
   fn simd_eq(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
+        Self { avx: cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -59,11 +59,11 @@ impl_simd! {
   fn simd_gt(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : cmp_gt_mask_i8_m256i(self.avx,rhs.avx) }
+        Self { avx: cmp_gt_mask_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -76,8 +76,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -90,8 +90,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -109,8 +109,8 @@ impl_simd! {
         }
       } else {
         Self {
-          a : self.a.bitselect(if_one.a, if_zero.a),
-          b : self.b.bitselect(if_one.b, if_zero.b),
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
         }
       }
     }
@@ -123,8 +123,8 @@ impl_simd! {
         Self { avx: blend_varying_i8_m256i(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -264,8 +264,8 @@ impl_simd_int! {
         Self { avx: self.avx.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -278,8 +278,8 @@ impl_simd_int! {
         Self { avx: add_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -292,8 +292,8 @@ impl_simd_int! {
         Self { avx: sub_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -351,11 +351,11 @@ impl_simd_int! {
   fn bitand(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-          Self { avx : bitand_m256i(self.avx,rhs.avx) }
+          Self { avx: bitand_m256i(self.avx,rhs.avx) }
       } else {
           Self {
-            a : self.a.bitand(rhs.a),
-            b : self.b.bitand(rhs.b),
+            a: self.a.bitand(rhs.a),
+            b: self.b.bitand(rhs.b),
           }
       }
     }
@@ -365,11 +365,11 @@ impl_simd_int! {
   fn bitor(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : bitor_m256i(self.avx,rhs.avx) }
+        Self { avx: bitor_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -379,11 +379,11 @@ impl_simd_int! {
   fn bitxor(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : bitxor_m256i(self.avx,rhs.avx) }
+        Self { avx: bitxor_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -396,8 +396,8 @@ impl_simd_int! {
         Self { avx: max_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -410,8 +410,8 @@ impl_simd_int! {
         Self { avx: min_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -448,8 +448,8 @@ impl_simd_int! {
         Self { avx: add_saturating_i8_m256i(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.saturating_add(rhs.a),
-          b : self.b.saturating_add(rhs.b),
+          a: self.a.saturating_add(rhs.a),
+          b: self.b.saturating_add(rhs.b),
         }
       }
     }
@@ -462,8 +462,8 @@ impl_simd_int! {
         Self { avx: sub_saturating_i8_m256i(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.saturating_sub(rhs.a),
-          b : self.b.saturating_sub(rhs.b),
+          a: self.a.saturating_sub(rhs.a),
+          b: self.b.saturating_sub(rhs.b),
         }
       }
     }
@@ -522,8 +522,8 @@ impl_simd_int! {
         Self { avx: abs_i8_m256i(self.avx) }
       } else {
         Self {
-          a : self.a.abs(),
-          b : self.b.abs(),
+          a: self.a.abs(),
+          b: self.b.abs(),
         }
       }
     }
@@ -576,8 +576,8 @@ impl i8x32 {
         Self { avx: shuffle_av_i8z_half_m256i(self.avx, rhs.saturating_add(i8x32::splat(0x60)).avx) }
       } else {
           Self {
-            a : self.a.swizzle(rhs.a),
-            b : self.b.swizzle(rhs.b),
+            a: self.a.swizzle(rhs.a),
+            b: self.b.swizzle(rhs.b),
           }
       }
     }
@@ -599,8 +599,8 @@ impl i8x32 {
         Self { avx: shuffle_av_i8z_half_m256i(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.swizzle_relaxed(rhs.a),
-          b : self.b.swizzle_relaxed(rhs.b),
+          a: self.a.swizzle_relaxed(rhs.a),
+          b: self.b.swizzle_relaxed(rhs.b),
         }
       }
     }

--- a/src/i8x64_.rs
+++ b/src/i8x64_.rs
@@ -1,0 +1,627 @@
+use super::*;
+
+pick! {
+  if #[cfg(target_feature="avx512bw")] {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[repr(C, align(64))]
+    pub struct i8x64 { avx512: m512i }
+  } else {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    #[repr(C, align(64))]
+    pub struct i8x64 { a: i8x32, b: i8x32 }
+  }
+}
+
+impl_simd! {
+  unsafe {
+    T = i8,
+    N = 64,
+    Simd = i8x64,
+    optional_type_x86_inner { X86Inner = __m512i },
+    optional_type_arm_inner {},
+    optional_type_wasm_inner {},
+  }
+
+  #[inline]
+  fn simd_eq(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn simd_ne(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn simd_lt(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn simd_gt(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn simd_le(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn simd_ge(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: cmp_op_mask_i8_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn bitselect(self, if_one: Self, if_zero: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self {
+          avx512: bitor_m512i(
+            bitand_m512i(if_one.avx512, self.avx512),
+            bitandnot_m512i(self.avx512, if_zero.avx512),
+          ),
+        }
+      } else {
+        Self {
+          a: self.a.bitselect(if_one.a, if_zero.a),
+          b: self.b.bitselect(if_one.b, if_zero.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn select(self, if_true: Self, if_false: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
+      } else {
+        Self {
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn to_bitmask(self) -> u64 {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        movepi8_mask_m512i(self.avx512)
+      } else {
+        (self.a.to_bitmask() as u64) | ((self.b.to_bitmask() as u64) << 32)
+      }
+    }
+  }
+
+  #[inline]
+  pub fn any(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        movepi8_mask_m512i(self.avx512) != 0
+      } else {
+        (self.a | self.b).any()
+      }
+    }
+  }
+
+  #[inline]
+  pub fn all(self) -> bool {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        movepi8_mask_m512i(self.avx512) == !0
+      } else {
+        (self.a & self.b).all()
+      }
+    }
+  }
+
+  /// Transpose matrix of 64x64 `i8` matrix. Currently not accelerated.
+  #[inline]
+  pub fn transpose(data: [i8x64; 64]) -> [i8x64; 64] {
+    // Can this be optimized?
+
+    #[inline(always)]
+    fn transpose_column(data: &[i8x64; 64], index: usize) -> i8x64 {
+      i8x64::new([
+        data[0].as_array()[index],
+        data[1].as_array()[index],
+        data[2].as_array()[index],
+        data[3].as_array()[index],
+        data[4].as_array()[index],
+        data[5].as_array()[index],
+        data[6].as_array()[index],
+        data[7].as_array()[index],
+        data[8].as_array()[index],
+        data[9].as_array()[index],
+        data[10].as_array()[index],
+        data[11].as_array()[index],
+        data[12].as_array()[index],
+        data[13].as_array()[index],
+        data[14].as_array()[index],
+        data[15].as_array()[index],
+        data[16].as_array()[index],
+        data[17].as_array()[index],
+        data[18].as_array()[index],
+        data[19].as_array()[index],
+        data[20].as_array()[index],
+        data[21].as_array()[index],
+        data[22].as_array()[index],
+        data[23].as_array()[index],
+        data[24].as_array()[index],
+        data[25].as_array()[index],
+        data[26].as_array()[index],
+        data[27].as_array()[index],
+        data[28].as_array()[index],
+        data[29].as_array()[index],
+        data[30].as_array()[index],
+        data[31].as_array()[index],
+        data[32].as_array()[index],
+        data[33].as_array()[index],
+        data[34].as_array()[index],
+        data[35].as_array()[index],
+        data[36].as_array()[index],
+        data[37].as_array()[index],
+        data[38].as_array()[index],
+        data[39].as_array()[index],
+        data[40].as_array()[index],
+        data[41].as_array()[index],
+        data[42].as_array()[index],
+        data[43].as_array()[index],
+        data[44].as_array()[index],
+        data[45].as_array()[index],
+        data[46].as_array()[index],
+        data[47].as_array()[index],
+        data[48].as_array()[index],
+        data[49].as_array()[index],
+        data[50].as_array()[index],
+        data[51].as_array()[index],
+        data[52].as_array()[index],
+        data[53].as_array()[index],
+        data[54].as_array()[index],
+        data[55].as_array()[index],
+        data[56].as_array()[index],
+        data[57].as_array()[index],
+        data[58].as_array()[index],
+        data[59].as_array()[index],
+        data[60].as_array()[index],
+        data[61].as_array()[index],
+        data[62].as_array()[index],
+        data[63].as_array()[index],
+      ])
+    }
+
+    [
+      transpose_column(&data, 0),
+      transpose_column(&data, 1),
+      transpose_column(&data, 2),
+      transpose_column(&data, 3),
+      transpose_column(&data, 4),
+      transpose_column(&data, 5),
+      transpose_column(&data, 6),
+      transpose_column(&data, 7),
+      transpose_column(&data, 8),
+      transpose_column(&data, 9),
+      transpose_column(&data, 10),
+      transpose_column(&data, 11),
+      transpose_column(&data, 12),
+      transpose_column(&data, 13),
+      transpose_column(&data, 14),
+      transpose_column(&data, 15),
+      transpose_column(&data, 16),
+      transpose_column(&data, 17),
+      transpose_column(&data, 18),
+      transpose_column(&data, 19),
+      transpose_column(&data, 20),
+      transpose_column(&data, 21),
+      transpose_column(&data, 22),
+      transpose_column(&data, 23),
+      transpose_column(&data, 24),
+      transpose_column(&data, 25),
+      transpose_column(&data, 26),
+      transpose_column(&data, 27),
+      transpose_column(&data, 28),
+      transpose_column(&data, 29),
+      transpose_column(&data, 30),
+      transpose_column(&data, 31),
+      transpose_column(&data, 32),
+      transpose_column(&data, 33),
+      transpose_column(&data, 34),
+      transpose_column(&data, 35),
+      transpose_column(&data, 36),
+      transpose_column(&data, 37),
+      transpose_column(&data, 38),
+      transpose_column(&data, 39),
+      transpose_column(&data, 40),
+      transpose_column(&data, 41),
+      transpose_column(&data, 42),
+      transpose_column(&data, 43),
+      transpose_column(&data, 44),
+      transpose_column(&data, 45),
+      transpose_column(&data, 46),
+      transpose_column(&data, 47),
+      transpose_column(&data, 48),
+      transpose_column(&data, 49),
+      transpose_column(&data, 50),
+      transpose_column(&data, 51),
+      transpose_column(&data, 52),
+      transpose_column(&data, 53),
+      transpose_column(&data, 54),
+      transpose_column(&data, 55),
+      transpose_column(&data, 56),
+      transpose_column(&data, 57),
+      transpose_column(&data, 58),
+      transpose_column(&data, 59),
+      transpose_column(&data, 60),
+      transpose_column(&data, 61),
+      transpose_column(&data, 62),
+      transpose_column(&data, 63),
+    ]
+  }
+}
+
+impl_simd_int! {
+  unsafe {
+    T = i8,
+    N = 64,
+    Simd = i8x64,
+    UnsignedSimd = u8x64,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
+    [
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+      40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+      59, 60, 61, 62, 63
+    ],
+  }
+
+  #[inline]
+  fn not(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: bitxor_m512i(self.avx512, set_splat_i8_m512i(-1)) }
+      } else {
+        Self {
+          a: self.a.not(),
+          b: self.b.not(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn add(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: add_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn sub(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: sub_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn mul(self, rhs: Self) -> Self::Output {
+    // For x86, this technically can be done explicitly by converting to `i16`
+    // then converting back after multiplication, but that may not actually be
+    // faster than auto-vectorization.
+    let [self_a, self_b]: [i8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [i8x32; 2] = cast(rhs);
+    cast([self_a * rhs_a, self_b * rhs_b])
+  }
+
+  #[inline]
+  fn shl(self, rhs: Self) -> Self::Output {
+    // For x86, this technically can be done explicitly by converting to `i16`
+    // or `i32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b]: [i8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [i8x32; 2] = cast(rhs);
+    cast([self_a << rhs_a, self_b << rhs_b])
+  }
+
+  #[inline]
+  fn shl(self, rhs: u32) -> Self::Output {
+    // For x86, this technically can be done explicitly by converting
+    // to `i16` or `i32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b]: [i8x32; 2] = cast(self);
+    cast([self_a << rhs, self_b << rhs])
+  }
+
+  #[inline]
+  fn shr(self, rhs: Self) -> Self::Output {
+    // For x86, this technically can be done explicitly by converting to `i16`
+    // or `i32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b]: [i8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [i8x32; 2] = cast(rhs);
+    cast([self_a >> rhs_a, self_b >> rhs_b])
+  }
+
+  #[inline]
+  fn shr(self, rhs: u32) -> Self::Output {
+    // For x86, this technically can be done explicitly by converting
+    // to `i16` or `i32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b]: [i8x32; 2] = cast(self);
+    cast([self_a >> rhs, self_b >> rhs])
+  }
+
+  #[inline]
+  fn bitand(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn bitor(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  fn bitxor(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn max(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: max_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn min(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: min_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn reduce_add(self) -> i8 {
+    let array: [i8x32; 2] = cast(self);
+    (array[0] + array[1]).reduce_add()
+  }
+
+  #[inline]
+  pub fn reduce_mul(self) -> i8 {
+    let array: [i8x32; 2] = cast(self);
+    (array[0] * array[1]).reduce_mul()
+  }
+
+  #[inline]
+  pub fn reduce_max(self) -> i8 {
+    let array: [i8x32; 2] = cast(self);
+    array[0].max(array[1]).reduce_max()
+  }
+
+  #[inline]
+  pub fn reduce_min(self) -> i8 {
+    let array: [i8x32; 2] = cast(self);
+    array[0].min(array[1]).reduce_min()
+  }
+
+  #[inline]
+  pub fn saturating_add(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: add_saturating_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.saturating_add(rhs.a),
+          b: self.b.saturating_add(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn saturating_sub(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: sub_saturating_i8_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.saturating_sub(rhs.a),
+          b: self.b.saturating_sub(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn overflowing_mul(self, rhs: Self) -> (Self, Self) {
+    let (low, high) = self.mul_keep_low_high(rhs);
+    let low = cast::<u8x64, i8x64>(low);
+
+    let overflow = high.simd_ne(low.is_negative());
+    (low, overflow)
+  }
+
+  optional_fn_widening_mul {
+    // Cannot have `widening_mul` because there is no `i16x64` type.
+  }
+
+  #[inline]
+  pub fn mul_keep_low_high(self, rhs: Self) -> (u8x64, i8x64) {
+    // x86 has no `_mm512_mul_epi8` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i8x64, [i8x32; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i8x64, [i8x32; 2]>(rhs);
+
+    let result_a = self_a.mul_keep_low_high(rhs_a);
+    let result_b = self_b.mul_keep_low_high(rhs_b);
+    (cast([result_a.0, result_b.0]), cast([result_a.1, result_b.1]))
+  }
+
+  #[inline]
+  pub fn mul_keep_high(self, rhs: Self) -> Self {
+    // x86 has no `_mm512_mul_epi8` intrinsic so there is no `avx512`
+    // optimization.
+
+    let [self_a, self_b] = cast::<i8x64, [i8x32; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<i8x64, [i8x32; 2]>(rhs);
+
+    cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
+  }
+
+  #[inline]
+  pub fn abs(self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: abs_i8_m512i(self.avx512) }
+      } else {
+        Self {
+          a: self.a.abs(),
+          b: self.b.abs(),
+        }
+      }
+    }
+  }
+
+  #[inline]
+  pub fn is_positive(self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // `neon` has dedicated greater-than-zero intrinsics.
+        Self {
+          a: self.a.is_positive(),
+          b: self.b.is_positive(),
+        }
+      } else {
+        self.simd_gt(Self::ZERO)
+      }
+    }
+  }
+
+  #[inline]
+  pub fn is_negative(self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // `neon` has dedicated less-than-zero intrinsics.
+        Self {
+          a: self.a.is_negative(),
+          b: self.b.is_negative(),
+        }
+      } else {
+        self.simd_lt(Self::ZERO)
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,9 @@ pub use i16x32_::*;
 mod i8x32_;
 pub use i8x32_::*;
 
+mod i8x64_;
+pub use i8x64_::*;
+
 mod i16x8_;
 pub use i16x8_::*;
 
@@ -272,6 +275,9 @@ pub use u8x16_::*;
 
 mod u8x32_;
 pub use u8x32_::*;
+
+mod u8x64_;
+pub use u8x64_::*;
 
 mod u16x8_;
 pub use u16x8_::*;

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u16x16 { pub(crate) a : u16x8, pub(crate) b : u16x8 }
+    pub struct u16x16 { pub(crate) a: u16x8, pub(crate) b: u16x8 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -82,8 +82,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -96,8 +96,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -129,8 +129,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -175,8 +175,8 @@ impl_simd_uint! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -189,8 +189,8 @@ impl_simd_uint! {
         Self { avx2: add_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -203,8 +203,8 @@ impl_simd_uint! {
         Self { avx2: sub_i16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -218,8 +218,8 @@ impl_simd_uint! {
         Self { avx2: mul_i16_keep_low_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -257,8 +257,8 @@ impl_simd_uint! {
         Self { avx2: shl_all_u16_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -296,8 +296,8 @@ impl_simd_uint! {
         Self { avx2: shr_all_u16_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -310,8 +310,8 @@ impl_simd_uint! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -324,8 +324,8 @@ impl_simd_uint! {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -338,8 +338,8 @@ impl_simd_uint! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -352,8 +352,8 @@ impl_simd_uint! {
         Self { avx2: max_u16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -366,8 +366,8 @@ impl_simd_uint! {
         Self { avx2: min_u16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -403,8 +403,8 @@ impl_simd_uint! {
         Self { avx2: add_saturating_u16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.saturating_add(rhs.a),
-          b : self.b.saturating_add(rhs.b),
+          a: self.a.saturating_add(rhs.a),
+          b: self.b.saturating_add(rhs.b),
         }
       }
     }
@@ -417,8 +417,8 @@ impl_simd_uint! {
         Self { avx2: sub_saturating_u16_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.saturating_sub(rhs.a),
-          b : self.b.saturating_sub(rhs.b),
+          a: self.a.saturating_sub(rhs.a),
+          b: self.b.saturating_sub(rhs.b),
         }
       }
     }

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct u16x32 { pub(crate) a : u16x16, pub(crate) b : u16x16 }
+    pub struct u16x32 { pub(crate) a: u16x16, pub(crate) b: u16x16 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -181,8 +181,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i16_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -195,8 +195,8 @@ impl_simd_uint! {
         Self { avx512: add_i16_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -209,8 +209,8 @@ impl_simd_uint! {
         Self { avx512: sub_i16_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -253,8 +253,8 @@ impl_simd_uint! {
         Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -286,8 +286,8 @@ impl_simd_uint! {
         Self { avx512: shr_all_u16_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -300,8 +300,8 @@ impl_simd_uint! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -314,8 +314,8 @@ impl_simd_uint! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -328,8 +328,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -29,7 +29,7 @@ pick! {
       use core::arch::aarch64::*;
       #[repr(C)]
       #[derive(Copy, Clone)]
-      pub struct u16x8 { pub(crate) neon : uint16x8_t }
+      pub struct u16x8 { pub(crate) neon: uint16x8_t }
 
       impl Default for u16x8 {
         #[inline]

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct u32x16 { pub(crate) a : u32x8, pub(crate) b : u32x8 }
+    pub struct u32x16 { pub(crate) a: u32x8, pub(crate) b: u32x8 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u32_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -178,8 +178,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i32_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -192,8 +192,8 @@ impl_simd_uint! {
         Self { avx512: add_i32_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -206,8 +206,8 @@ impl_simd_uint! {
         Self { avx512: sub_i32_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -220,8 +220,8 @@ impl_simd_uint! {
         Self { avx512: mul_i32_keep_low_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -235,8 +235,8 @@ impl_simd_uint! {
         Self { avx512: shl_each_u32_m512i(self.avx512, shift_by) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -252,8 +252,8 @@ impl_simd_uint! {
         Self { avx512: shl_all_u32_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -267,8 +267,8 @@ impl_simd_uint! {
         Self { avx512: shr_each_u32_m512i(self.avx512, shift_by ) }
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -284,8 +284,8 @@ impl_simd_uint! {
         Self { avx512: shr_all_u32_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -298,8 +298,8 @@ impl_simd_uint! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -312,8 +312,8 @@ impl_simd_uint! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -326,8 +326,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u32x4 { pub(crate) neon : uint32x4_t }
+    pub struct u32x4 { pub(crate) neon: uint32x4_t }
 
     impl Default for u32x4 {
       #[inline]
@@ -219,7 +219,7 @@ impl_simd! {
       } else if #[cfg(target_feature="simd128")] {
         u32x4_bitmask(self.simd) != 0
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         ((v[0] | v[1]) & 0x8000000080000000) != 0
       }
     }
@@ -233,7 +233,7 @@ impl_simd! {
       } else if #[cfg(target_feature="simd128")] {
         u32x4_bitmask(self.simd) == 0b1111
       } else {
-        let v : [u64;2] = cast(self);
+        let v: [u64;2] = cast(self);
         (v[0] & v[1] & 0x8000000080000000) == 0x8000000080000000
       }
     }
@@ -754,7 +754,7 @@ impl_simd_uint! {
         let r = mul_u64_low_bits_m256i(a, b);
 
         // the compiler does a good job shuffling the lanes around
-        let b : [u32;8] = cast(r);
+        let b: [u32;8] = cast(r);
         cast([b[1],b[3],b[5],b[7]])
       } else if #[cfg(target_feature="sse2")] {
         let evenp = mul_widen_u32_odd_m128i(self.sse, rhs.sse);
@@ -764,8 +764,8 @@ impl_simd_uint! {
           shr_imm_u64_m128i::<32>(rhs.sse));
 
         // the compiler does a good job shuffling the lanes around
-        let a : [u32;4]= cast(evenp);
-        let b : [u32;4]= cast(oddp);
+        let a: [u32;4]= cast(evenp);
+        let b: [u32;4]= cast(oddp);
         cast([a[1],b[1],a[3],b[3]])
 
       } else if #[cfg(target_feature="simd128")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u32x8 { pub(crate) a : u32x4, pub(crate) b : u32x4 }
+    pub struct u32x8 { pub(crate) a: u32x4, pub(crate) b: u32x4 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -56,8 +56,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i32_m256i((self ^ highbit).avx2, (rhs ^ highbit).avx2 ) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2, if_true.avx2, self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -157,8 +157,8 @@ impl_simd_uint! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -171,8 +171,8 @@ impl_simd_uint! {
         Self { avx2: add_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -185,8 +185,8 @@ impl_simd_uint! {
         Self { avx2: sub_i32_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -199,8 +199,8 @@ impl_simd_uint! {
         Self { avx2: mul_i32_keep_low_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.mul(rhs.a),
-          b : self.b.mul(rhs.b),
+          a: self.a.mul(rhs.a),
+          b: self.b.mul(rhs.b),
         }
       }
     }
@@ -215,8 +215,8 @@ impl_simd_uint! {
         Self { avx2: shl_each_u32_m256i(self.avx2, shift_by) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -232,8 +232,8 @@ impl_simd_uint! {
         Self { avx2: shl_all_u32_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -248,8 +248,8 @@ impl_simd_uint! {
         Self { avx2: shr_each_u32_m256i(self.avx2, shift_by ) }
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -265,8 +265,8 @@ impl_simd_uint! {
         Self { avx2: shr_all_u32_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -279,8 +279,8 @@ impl_simd_uint! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -293,8 +293,8 @@ impl_simd_uint! {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -307,8 +307,8 @@ impl_simd_uint! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -321,8 +321,8 @@ impl_simd_uint! {
         Self { avx2: max_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -335,8 +335,8 @@ impl_simd_uint! {
         Self { avx2: min_u32_m256i(self.avx2, rhs.avx2 ) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -465,18 +465,18 @@ impl_simd_uint! {
   pub fn mul_keep_high(self, rhs: u32x8) -> u32x8 {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        let a : [u32;8]= cast(self);
-        let b : [u32;8]= cast(rhs);
+        let a: [u32;8]= cast(self);
+        let b: [u32;8]= cast(rhs);
 
         // let the compiler shuffle the values around, it does the right thing
-        let r1 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[0], 0, a[1], 0, a[2], 0, a[3], 0]), cast([b[0], 0, b[1], 0, b[2], 0, b[3], 0])));
-        let r2 : [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[4], 0, a[5], 0, a[6], 0, a[7], 0]), cast([b[4], 0, b[5], 0, b[6], 0, b[7], 0])));
+        let r1: [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[0], 0, a[1], 0, a[2], 0, a[3], 0]), cast([b[0], 0, b[1], 0, b[2], 0, b[3], 0])));
+        let r2: [u32;8] = cast(mul_u64_low_bits_m256i(cast([a[4], 0, a[5], 0, a[6], 0, a[7], 0]), cast([b[4], 0, b[5], 0, b[6], 0, b[7], 0])));
 
         cast([r1[1], r1[3], r1[5], r1[7], r2[1], r2[3], r2[5], r2[7]])
       } else {
         Self {
-          a : self.a.mul_keep_high(rhs.a),
-          b : self.b.mul_keep_high(rhs.b),
+          a: self.a.mul_keep_high(rhs.a),
+          b: self.b.mul_keep_high(rhs.b),
         }
       }
     }

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u64x2 { pub(crate) neon : uint64x2_t }
+    pub struct u64x2 { pub(crate) neon: uint64x2_t }
 
     impl Default for u64x2 {
       #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u64x4 { pub(crate) a : u64x2, pub(crate) b : u64x2 }
+    pub struct u64x4 { pub(crate) a: u64x2, pub(crate) b: u64x2 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx2: cmp_eq_mask_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -65,8 +65,8 @@ impl_simd! {
         Self { avx2: cmp_gt_mask_i64_m256i((self ^ highbit).avx2, (rhs ^ highbit).avx2) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -79,8 +79,8 @@ impl_simd! {
         !self.simd_gt(rhs)
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -93,8 +93,8 @@ impl_simd! {
         !self.simd_lt(rhs)
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -126,8 +126,8 @@ impl_simd! {
         Self { avx2: blend_varying_i8_m256i(if_false.avx2,if_true.avx2,self.avx2) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -172,8 +172,8 @@ impl_simd_uint! {
         Self { avx2: self.avx2.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -186,8 +186,8 @@ impl_simd_uint! {
         Self { avx2: add_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -200,8 +200,8 @@ impl_simd_uint! {
         Self { avx2: sub_i64_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -234,8 +234,8 @@ impl_simd_uint! {
         Self { avx2: shl_each_u64_m256i(self.avx2, shift_by.avx2) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -251,8 +251,8 @@ impl_simd_uint! {
         Self { avx2: shl_all_u64_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -267,8 +267,8 @@ impl_simd_uint! {
         Self { avx2: shr_each_u64_m256i(self.avx2, shift_by.avx2) }
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -284,8 +284,8 @@ impl_simd_uint! {
         Self { avx2: shr_all_u64_m256i(self.avx2, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -298,8 +298,8 @@ impl_simd_uint! {
         Self { avx2: bitand_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -312,8 +312,8 @@ impl_simd_uint! {
         Self { avx2: bitor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -326,8 +326,8 @@ impl_simd_uint! {
         Self { avx2: bitxor_m256i(self.avx2, rhs.avx2) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct u64x8 { pub(crate) a : u64x4, pub(crate) b : u64x4 }
+    pub struct u64x8 { pub(crate) a: u64x4, pub(crate) b: u64x4 }
   }
 }
 
@@ -29,8 +29,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -57,8 +57,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_lt(rhs.a),
-          b : self.b.simd_lt(rhs.b),
+          a: self.a.simd_lt(rhs.a),
+          b: self.b.simd_lt(rhs.b),
         }
       }
     }
@@ -71,8 +71,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -85,8 +85,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -99,8 +99,8 @@ impl_simd! {
         Self { avx512: cmp_op_mask_u64_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,8 +132,8 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -178,8 +178,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, set_splat_i64_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -192,8 +192,8 @@ impl_simd_uint! {
         Self { avx512: add_i64_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -206,8 +206,8 @@ impl_simd_uint! {
         Self { avx512: sub_i64_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -244,8 +244,8 @@ impl_simd_uint! {
         Self { avx512: shl_each_u64_m512i(self.avx512, rhs) }
       } else {
         Self {
-          a : self.a.shl(rhs.a),
-          b : self.b.shl(rhs.b),
+          a: self.a.shl(rhs.a),
+          b: self.b.shl(rhs.b),
         }
       }
     }
@@ -261,8 +261,8 @@ impl_simd_uint! {
         Self { avx512: shl_all_u64_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
+          a: self.a.shl(rhs),
+          b: self.b.shl(rhs),
         }
       }
     }
@@ -277,8 +277,8 @@ impl_simd_uint! {
         Self { avx512: shr_each_u64_m512i(self.avx512, rhs) }
       } else {
         Self {
-          a : self.a.shr(rhs.a),
-          b : self.b.shr(rhs.b),
+          a: self.a.shr(rhs.a),
+          b: self.b.shr(rhs.b),
         }
       }
     }
@@ -294,8 +294,8 @@ impl_simd_uint! {
         Self { avx512: shr_all_u64_m512i(self.avx512, shift) }
       } else {
         Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
+          a: self.a.shr(rhs),
+          b: self.b.shr(rhs),
         }
       }
     }
@@ -308,8 +308,8 @@ impl_simd_uint! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -322,8 +322,8 @@ impl_simd_uint! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -336,8 +336,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -29,7 +29,7 @@ pick! {
     use core::arch::aarch64::*;
     #[repr(C)]
     #[derive(Copy, Clone)]
-    pub struct u8x16 { pub(crate) neon : uint8x16_t }
+    pub struct u8x16 { pub(crate) neon: uint8x16_t }
 
     impl Default for u8x16 {
       #[inline]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -8,7 +8,7 @@ pick! {
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(32))]
-    pub struct u8x32 { pub(crate) a : u8x16, pub(crate) b : u8x16 }
+    pub struct u8x32 { pub(crate) a: u8x16, pub(crate) b: u8x16 }
   }
 }
 
@@ -26,11 +26,11 @@ impl_simd! {
   fn simd_eq(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
+        Self { avx: cmp_eq_mask_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -43,8 +43,8 @@ impl_simd! {
         !self.simd_eq(rhs)
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -73,7 +73,7 @@ impl_simd! {
         let offset = Self::splat(0x80);
         let self_i8 = self.bitxor(offset).avx;
         let rhs_i8 = rhs.bitxor(offset).avx;
-        Self { avx : cmp_gt_mask_i8_m256i(self_i8,rhs_i8) }
+        Self { avx: cmp_gt_mask_i8_m256i(self_i8,rhs_i8) }
       } else {
         Self { a: self.a.simd_gt(rhs.a), b: self.b.simd_gt(rhs.b) }
       }
@@ -88,7 +88,7 @@ impl_simd! {
         let offset = Self::splat(0x80);
         let self_i8 = self.bitxor(offset).avx;
         let rhs_i8 = rhs.bitxor(offset).avx;
-        let gt_mask = Self { avx : cmp_gt_mask_i8_m256i(self_i8,rhs_i8) };
+        let gt_mask = Self { avx: cmp_gt_mask_i8_m256i(self_i8,rhs_i8) };
         Self { avx: gt_mask.bitxor(Self::splat(0xFF)).avx }
       } else {
         Self { a: self.a.simd_le(rhs.a), b: self.b.simd_le(rhs.b) }
@@ -138,8 +138,8 @@ impl_simd! {
         Self { avx: blend_varying_i8_m256i(if_false.avx, if_true.avx, self.avx) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
@@ -187,8 +187,8 @@ impl_simd_uint! {
         Self { avx: self.avx.not()  }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -201,8 +201,8 @@ impl_simd_uint! {
         Self { avx: add_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -215,8 +215,8 @@ impl_simd_uint! {
         Self { avx: sub_i8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -274,11 +274,11 @@ impl_simd_uint! {
   fn bitand(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-          Self { avx : bitand_m256i(self.avx,rhs.avx) }
+          Self { avx: bitand_m256i(self.avx,rhs.avx) }
       } else {
           Self {
-            a : self.a.bitand(rhs.a),
-            b : self.b.bitand(rhs.b),
+            a: self.a.bitand(rhs.a),
+            b: self.b.bitand(rhs.b),
           }
       }
     }
@@ -288,11 +288,11 @@ impl_simd_uint! {
   fn bitor(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : bitor_m256i(self.avx,rhs.avx) }
+        Self { avx: bitor_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -302,11 +302,11 @@ impl_simd_uint! {
   fn bitxor(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx : bitxor_m256i(self.avx,rhs.avx) }
+        Self { avx: bitxor_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -319,8 +319,8 @@ impl_simd_uint! {
         Self { avx: max_u8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.max(rhs.a),
-          b : self.b.max(rhs.b),
+          a: self.a.max(rhs.a),
+          b: self.b.max(rhs.b),
         }
       }
     }
@@ -333,8 +333,8 @@ impl_simd_uint! {
         Self { avx: min_u8_m256i(self.avx,rhs.avx) }
       } else {
         Self {
-          a : self.a.min(rhs.a),
-          b : self.b.min(rhs.b),
+          a: self.a.min(rhs.a),
+          b: self.b.min(rhs.b),
         }
       }
     }
@@ -370,8 +370,8 @@ impl_simd_uint! {
         Self { avx: add_saturating_u8_m256i(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.saturating_add(rhs.a),
-          b : self.b.saturating_add(rhs.b),
+          a: self.a.saturating_add(rhs.a),
+          b: self.b.saturating_add(rhs.b),
         }
       }
     }
@@ -384,8 +384,8 @@ impl_simd_uint! {
         Self { avx: sub_saturating_u8_m256i(self.avx, rhs.avx) }
       } else {
         Self {
-          a : self.a.saturating_sub(rhs.a),
-          b : self.b.saturating_sub(rhs.b),
+          a: self.a.saturating_sub(rhs.a),
+          b: self.b.saturating_sub(rhs.b),
         }
       }
     }

--- a/src/u8x64_.rs
+++ b/src/u8x64_.rs
@@ -4,19 +4,19 @@ pick! {
   if #[cfg(target_feature="avx512bw")] {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct u16x32 { pub(crate) avx512: m512i }
+    pub struct u8x64 { pub(crate) avx512: m512i }
   } else {
     #[derive(Default, Clone, Copy, PartialEq, Eq)]
     #[repr(C, align(64))]
-    pub struct u16x32 { pub(crate) a : u16x16, pub(crate) b : u16x16 }
+    pub struct u8x64 { pub(crate) a: u8x32, pub(crate) b: u8x32 }
   }
 }
 
 impl_simd! {
   unsafe {
-    T = u16,
-    N = 32,
-    Simd = u16x32,
+    T = u8,
+    N = 64,
+    Simd = u8x64,
     optional_type_x86_inner { X86Inner = __m512i },
     optional_type_arm_inner {},
     optional_type_wasm_inner {},
@@ -26,11 +26,11 @@ impl_simd! {
   fn simd_eq(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Eq)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_eq(rhs.a),
-          b : self.b.simd_eq(rhs.b),
+          a: self.a.simd_eq(rhs.a),
+          b: self.b.simd_eq(rhs.b),
         }
       }
     }
@@ -40,11 +40,11 @@ impl_simd! {
   fn simd_ne(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Ne)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ne(rhs.a),
-          b : self.b.simd_ne(rhs.b),
+          a: self.a.simd_ne(rhs.a),
+          b: self.b.simd_ne(rhs.b),
         }
       }
     }
@@ -54,11 +54,11 @@ impl_simd! {
   fn simd_lt(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Lt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : rhs.a.simd_gt(self.a),
-          b : rhs.b.simd_gt(self.b),
+          a: rhs.a.simd_gt(self.a),
+          b: rhs.b.simd_gt(self.b),
         }
       }
     }
@@ -68,11 +68,11 @@ impl_simd! {
   fn simd_gt(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Nle)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_gt(rhs.a),
-          b : self.b.simd_gt(rhs.b),
+          a: self.a.simd_gt(rhs.a),
+          b: self.b.simd_gt(rhs.b),
         }
       }
     }
@@ -82,11 +82,11 @@ impl_simd! {
   fn simd_le(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Le)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_le(rhs.a),
-          b : self.b.simd_le(rhs.b),
+          a: self.a.simd_le(rhs.a),
+          b: self.b.simd_le(rhs.b),
         }
       }
     }
@@ -96,11 +96,11 @@ impl_simd! {
   fn simd_ge(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: cmp_op_mask_u16_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
+        Self { avx512: cmp_op_mask_u8_m512i::<{cmp_int_op!(Nlt)}>(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.simd_ge(rhs.a),
-          b : self.b.simd_ge(rhs.b),
+          a: self.a.simd_ge(rhs.a),
+          b: self.b.simd_ge(rhs.b),
         }
       }
     }
@@ -132,57 +132,59 @@ impl_simd! {
         Self { avx512: blend_varying_i8_m512i(if_false.avx512,if_true.avx512,movepi8_mask_m512i(self.avx512)) }
       } else {
         Self {
-          a : self.a.select(if_true.a, if_false.a),
-          b : self.b.select(if_true.b, if_false.b),
+          a: self.a.select(if_true.a, if_false.a),
+          b: self.b.select(if_true.b, if_false.b),
         }
       }
     }
   }
 
   #[inline]
-  pub fn to_bitmask(self) -> u32 {
-    i16x32::to_bitmask(cast(self))
+  pub fn to_bitmask(self) -> u64 {
+    i8x64::to_bitmask(cast(self))
   }
 
   #[inline]
   pub fn any(self) -> bool {
-    i16x32::any(cast(self))
+    i8x64::any(cast(self))
   }
 
   #[inline]
   pub fn all(self) -> bool {
-    i16x32::all(cast(self))
+    i8x64::all(cast(self))
   }
 
-  /// Transpose matrix of 32x32 `u16` matrix. Currently not accelerated.
+  /// Transpose matrix of 64x64 `u8` matrix. Currently not accelerated.
   #[inline]
-  pub fn transpose(data: [u16x32; 32]) -> [u16x32; 32] {
-    cast(i16x32::transpose(cast(data)))
+  pub fn transpose(data: [u8x64; 64]) -> [u8x64; 64] {
+    cast(i8x64::transpose(cast(data)))
   }
 }
 
 impl_simd_uint! {
   unsafe {
-    T = u16,
-    N = 32,
-    Simd = u16x32,
-    T_BITS = 16,
-    T_BITS_MUL_2 = 32,
+    T = u8,
+    N = 64,
+    Simd = u8x64,
+    T_BITS = 8,
+    T_BITS_MUL_2 = 16,
     [
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+      21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+      40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+      59, 60, 61, 62, 63
     ],
   }
 
   #[inline]
-  fn not(self) -> Self::Output {
+  fn not(self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: bitxor_m512i(self.avx512, set_splat_i16_m512i(-1)) }
+        Self { avx512: bitxor_m512i(self.avx512, set_splat_i8_m512i(-1)) }
       } else {
         Self {
-          a : self.a.not(),
-          b : self.b.not(),
+          a: self.a.not(),
+          b: self.b.not(),
         }
       }
     }
@@ -192,11 +194,11 @@ impl_simd_uint! {
   fn add(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: add_i16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: add_i8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.add(rhs.a),
-          b : self.b.add(rhs.b),
+          a: self.a.add(rhs.a),
+          b: self.b.add(rhs.b),
         }
       }
     }
@@ -206,11 +208,11 @@ impl_simd_uint! {
   fn sub(self, rhs: Self) -> Self::Output {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: sub_i16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: sub_i8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.sub(rhs.a),
-          b : self.b.sub(rhs.b),
+          a: self.a.sub(rhs.a),
+          b: self.b.sub(rhs.b),
         }
       }
     }
@@ -218,79 +220,50 @@ impl_simd_uint! {
 
   #[inline]
   fn mul(self, rhs: Self) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: mul_i16_keep_low_m512i(self.avx512, rhs.avx512) }
-      } else {
-        Self { a: self.a.mul(rhs.a), b: self.b.mul(rhs.b) }
-      }
-    }
+    // For x86, this technically can be done explicitly by converting to `i16`
+    // then converting back after multiplication, but that may not actually be
+    // faster than auto-vectorization.
+    let [self_a, self_b]: [u8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [u8x32; 2] = cast(rhs);
+    cast([self_a * rhs_a, self_b * rhs_b])
   }
 
   #[inline]
   fn shl(self, rhs: Self) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="avx512bw")] {
-        // Mask `rhs` to 15 to match `wrapping_shl`.
-        let rhs = bitand_m512i(rhs.avx512, set_splat_i16_m512i(15));
-        Self { avx512: shl_each_u16_m512i(self.avx512, rhs) }
-      } else {
-        let [self_a, self_b]: [u16x16; 2] = cast(self);
-        let [rhs_a, rhs_b]: [u16x16; 2] = cast(rhs);
-
-        cast([self_a << rhs_a, self_b << rhs_b])
-      }
-    }
+    // For x86, this technically can be done explicitly by converting to `u16`
+    // or `u32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b]: [u8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [u8x32; 2] = cast(rhs);
+    cast([self_a << rhs_a, self_b << rhs_b])
   }
 
   #[inline]
   fn shl(self, rhs: u32) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="avx512bw")] {
-        // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
-        #[expect(clippy::suspicious_arithmetic_impl)]
-        let shift = rhs as u16 & 15;
-        Self { avx512: shl_all_u16_m512i(self.avx512, shift) }
-      } else {
-        Self {
-          a : self.a.shl(rhs),
-          b : self.b.shl(rhs),
-        }
-      }
-    }
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b]: [u8x32; 2] = cast(self);
+    cast([self_a << rhs, self_b << rhs])
   }
 
   #[inline]
   fn shr(self, rhs: Self) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="avx512bw")] {
-        // Mask `rhs` to 15 to match `wrapping_shr`.
-        let rhs = bitand_m512i(rhs.avx512, set_splat_i16_m512i(15));
-        Self { avx512: shr_each_u16_m512i(self.avx512, rhs) }
-      } else {
-        let [self_a, self_b]: [u16x16; 2] = cast(self);
-        let [rhs_a, rhs_b]: [u16x16; 2] = cast(rhs);
-
-        cast([self_a >> rhs_a, self_b >> rhs_b])
-      }
-    }
+    // For x86, this technically can be done explicitly by converting to `u16`
+    // or `u32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b]: [u8x32; 2] = cast(self);
+    let [rhs_a, rhs_b]: [u8x32; 2] = cast(rhs);
+    cast([self_a >> rhs_a, self_b >> rhs_b])
   }
 
   #[inline]
   fn shr(self, rhs: u32) -> Self::Output {
-    pick! {
-      if #[cfg(target_feature="avx512bw")] {
-        // Use `rhs % 16` to perform wrapping shift and not unbounded shift.
-        #[expect(clippy::suspicious_arithmetic_impl)]
-        let shift = rhs as u16 & 15;
-        Self { avx512: shr_all_u16_m512i(self.avx512, shift) }
-      } else {
-        Self {
-          a : self.a.shr(rhs),
-          b : self.b.shr(rhs),
-        }
-      }
-    }
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b]: [u8x32; 2] = cast(self);
+    cast([self_a >> rhs, self_b >> rhs])
   }
 
   #[inline]
@@ -300,8 +273,8 @@ impl_simd_uint! {
         Self { avx512: bitand_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitand(rhs.a),
-          b : self.b.bitand(rhs.b),
+          a: self.a.bitand(rhs.a),
+          b: self.b.bitand(rhs.b),
         }
       }
     }
@@ -314,8 +287,8 @@ impl_simd_uint! {
         Self { avx512: bitor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitor(rhs.a),
-          b : self.b.bitor(rhs.b),
+          a: self.a.bitor(rhs.a),
+          b: self.b.bitor(rhs.b),
         }
       }
     }
@@ -328,8 +301,8 @@ impl_simd_uint! {
         Self { avx512: bitxor_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
-          a : self.a.bitxor(rhs.a),
-          b : self.b.bitxor(rhs.b),
+          a: self.a.bitxor(rhs.a),
+          b: self.b.bitxor(rhs.b),
         }
       }
     }
@@ -339,7 +312,7 @@ impl_simd_uint! {
   pub fn max(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: max_u16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: max_u8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
           a: self.a.max(rhs.a),
@@ -353,7 +326,7 @@ impl_simd_uint! {
   pub fn min(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: min_u16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: min_u8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
           a: self.a.min(rhs.a),
@@ -364,25 +337,25 @@ impl_simd_uint! {
   }
 
   #[inline]
-  pub fn reduce_add(self) -> u16 {
-    cast(i16x32::reduce_add(cast(self)))
+  pub fn reduce_add(self) -> u8 {
+    cast(i8x64::reduce_add(cast(self)))
   }
 
   #[inline]
-  pub fn reduce_mul(self) -> u16 {
-    let array: [u16x16; 2] = cast(self);
+  pub fn reduce_mul(self) -> u8 {
+    let array: [u8x32; 2] = cast(self);
     (array[0] * array[1]).reduce_mul()
   }
 
   #[inline]
-  pub fn reduce_max(self) -> u16 {
-    let array: [u16x16; 2] = cast(self);
+  pub fn reduce_max(self) -> u8 {
+    let array: [u8x32; 2] = cast(self);
     array[0].max(array[1]).reduce_max()
   }
 
   #[inline]
-  pub fn reduce_min(self) -> u16 {
-    let array: [u16x16; 2] = cast(self);
+  pub fn reduce_min(self) -> u8 {
+    let array: [u8x32; 2] = cast(self);
     array[0].min(array[1]).reduce_min()
   }
 
@@ -390,7 +363,7 @@ impl_simd_uint! {
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: add_saturating_u16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: add_saturating_u8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
           a: self.a.saturating_add(rhs.a),
@@ -404,7 +377,7 @@ impl_simd_uint! {
   pub fn saturating_sub(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {
-        Self { avx512: sub_saturating_u16_m512i(self.avx512, rhs.avx512) }
+        Self { avx512: sub_saturating_u8_m512i(self.avx512, rhs.avx512) }
       } else {
         Self {
           a: self.a.saturating_sub(rhs.a),
@@ -422,16 +395,16 @@ impl_simd_uint! {
   }
 
   optional_fn_widening_mul {
-    // Cannot have `widening_mul` because there is no `u32x32` type.
+    // Cannot have `widening_mul` because there is no `u16x64` type.
   }
 
   #[inline]
   pub fn mul_keep_low_high(self, rhs: Self) -> (Self, Self) {
-    // x86 has no `_mm512_mul_epu16` intrinsic so there is no `avx512`
+    // x86 has no `_mm512_mul_epu8` intrinsic so there is no `avx512`
     // optimization.
 
-    let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
-    let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+    let [self_a, self_b] = cast::<u8x64, [u8x32; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x64, [u8x32; 2]>(rhs);
 
     let result_a = self_a.mul_keep_low_high(rhs_a);
     let result_b = self_b.mul_keep_low_high(rhs_b);
@@ -440,11 +413,11 @@ impl_simd_uint! {
 
   #[inline]
   pub fn mul_keep_high(self, rhs: Self) -> Self {
-    // x86 has no `_mm512_mul_epu16` intrinsic so there is no `avx512`
+    // x86 has no `_mm512_mul_epu8` intrinsic so there is no `avx512`
     // optimization.
 
-    let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
-    let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+    let [self_a, self_b] = cast::<u8x64, [u8x32; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x64, [u8x32; 2]>(rhs);
 
     cast([self_a.mul_keep_high(rhs_a), self_b.mul_keep_high(rhs_b)])
   }

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -2078,13 +2078,13 @@ fn test_to_bitmask() {
         .chain(random_iter())
     {
       let expected = (0..N)
-        .map(|i| if value[i].is_negative() { 1 << i } else { 0 })
-        .fold(0, u32::bitor);
-      let actual = Simd::new(value).to_bitmask();
+        .map(|i| if value[i].is_negative() { 1u64 << i } else { 0 })
+        .fold(0u64, u64::bitor);
+      let actual = Simd::new(value).to_bitmask() as u64;
 
       assert!(
         actual == expected,
-        "expected: {expected:0>32b}\n  actual: {actual:0>32b}\n   value: {value:?}",
+        "expected: {expected:0>64b}\n  actual: {actual:0>64b}\n   value: {value:?}",
       );
     }
   });
@@ -2094,13 +2094,13 @@ fn test_to_bitmask() {
         .chain(random_iter())
     {
       let expected = (0..N)
-        .map(|i| if value[i] > T::MAX >> 1 { 1 << i } else { 0 })
-        .fold(0, u32::bitor);
-      let actual = Simd::new(value).to_bitmask();
+        .map(|i| if value[i] > T::MAX >> 1 { 1u64 << i } else { 0 })
+        .fold(0u64, u64::bitor);
+      let actual = Simd::new(value).to_bitmask() as u64;
 
       assert!(
         actual == expected,
-        "expected: {expected:0>32b}\n  actual: {actual:0>32b}\n   value: {value:?}",
+        "expected: {expected:0>64b}\n  actual: {actual:0>64b}\n   value: {value:?}",
       );
     }
   });

--- a/tests/utils/for_simd_types.rs
+++ b/tests/utils/for_simd_types.rs
@@ -61,6 +61,7 @@ macro_rules! for_simd_types {
   (|T: Signed, N| $expr:expr) => {
     for_simd_types!(signed!(i8, 16, i8x16, u8, u8x16, i16, (), $expr));
     for_simd_types!(signed!(i8, 32, i8x32, u8, u8x32, i16, (), $expr));
+    for_simd_types!(signed!(i8, 64, i8x64, u8, u8x64, i16, (), $expr));
     for_simd_types!(signed!(i16, 8, i16x8, u16, u16x8, i32, (), $expr));
     for_simd_types!(signed!(i16, 16, i16x16, u16, u16x16, i32, (), $expr));
     for_simd_types!(signed!(i16, 32, i16x32, u16, u16x32, i32, (), $expr));
@@ -87,6 +88,7 @@ macro_rules! for_simd_types {
   (|T: Unsigned, N| $expr:expr) => {
     for_simd_types!(unsigned!(u8, 16, u8x16, u16, (), $expr));
     for_simd_types!(unsigned!(u8, 32, u8x32, u16, (), $expr));
+    for_simd_types!(unsigned!(u8, 64, u8x64, u16, (), $expr));
     for_simd_types!(unsigned!(u16, 8, u16x8, u32, (), $expr));
     for_simd_types!(unsigned!(u16, 16, u16x16, u32, (), $expr));
     for_simd_types!(unsigned!(u16, 32, u16x32, u32, (), $expr));


### PR DESCRIPTION
Just had claude add these. 

The diff between these and `u16x32` and `i16x32` is:
- `u8` multiplication always falls back to the two 256-bit halves.
- `shl` and `shr` work on the two halves like `u8` does for other widths. Would be nicer to replace this by a `u16x32` shift and mask though, at least for shifts by a constant.
- (I kept the somewhat broken comments from #264 cc @Noam2Stein.)
- I did not add the `dot` function of `i16x32` because` mul_i8_horizontal_add_m512i` does not exist in `safe_arch`.
- I did not add the `swizzle_half{_relaxed}` functions that eg `u8x32` has.