### PR TITLE
feat: full-width u8x32/i8x32 swizzle (vpermb / vqtbl2 / AVX2 emulation)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Set RUSTFLAGS for AVX512
         if: always()
         run: |
-          echo "RUSTFLAGS=-C target-feature=+avx512f,+avx512dq,+avx512cd,+avx512bw,+avx512vl" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-C target-feature=+avx512f,+avx512dq,+avx512cd,+avx512bw,+avx512vl,+avx512vbmi" >> $GITHUB_ENV
         shell: bash
 
       - name: Build tests with AVX512

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `u8x32`/`i8x32` `swizzle` and `swizzle_relaxed`: a full-width 32-entry
+  byte table lookup (`vpermb` on AVX-512-VBMI, `vqtbl2` on NEON, emulated on
+  AVX2/SSSE3).
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.
 * Added integer functions `reduce_mul` and `mul_keep_low_high`.

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -605,4 +605,61 @@ impl i8x32 {
       }
     }
   }
+
+  /// Full 32-entry byte table lookup.
+  ///
+  /// * An index (interpreted as unsigned) in `[0, 31]` selects `self[index]`.
+  /// * Any index `>= 32` (including negative `i8` values) yields `0`.
+  ///
+  /// Unlike [`swizzle_half`](Self::swizzle_half), indices address the entire
+  /// 32-byte vector, not just their own 16-byte half.
+  #[inline]
+  pub fn swizzle(self, rhs: i8x32) -> i8x32 {
+    pick! {
+      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi8;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi8;
+        // vpermb takes the index mod 32 and never zeroes, so zero the
+        // out-of-range lanes ourselves: (rhs & 0xE0) == 0  <=>  rhs < 32.
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
+        let permuted = m256i(unsafe { _mm256_permutexvar_epi8(rhs.avx.0, self.avx.0) });
+        let hi_bits = bitand_m256i(rhs.avx, set_splat_i8_m256i(0xE0_u8 as i8));
+        let in_range = cmp_eq_mask_i8_m256i(hi_bits, zeroed_m256i());
+        Self { avx: bitand_m256i(permuted, in_range) }
+      } else if #[cfg(target_feature="avx2")] {
+        // Broadcast each 16-byte table half into both 128-bit lanes, pshufb
+        // each by the index, blend by index bit 4. Fold the >=32 zeroing into
+        // pshufb with an unsigned saturating add of 0x60 (0x60 + 32 = 0x80).
+        let idx = add_saturating_u8_m256i(rhs.avx, set_splat_i8_m256i(0x60));
+        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
+        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
+        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, idx);
+        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, idx);
+        // move index bit 4 into the sign bit (bit 7) for blendv.
+        let sel = shl_imm_u16_m256i::<3>(rhs.avx);
+        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        use core::arch::aarch64::{int8x16x2_t, vqtbl2q_s8, vreinterpretq_u8_s8};
+        unsafe {
+          let table = int8x16x2_t(self.a.neon, self.b.neon);
+          Self {
+            a: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.a.neon)) },
+            b: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.b.neon)) },
+          }
+        }
+      } else {
+        // Generic {a,b}: each output half pulls from either table half.
+        // a.swizzle / b.swizzle are STRICT (zero index >= 16), and their
+        // nonzero domains are disjoint, so a bitwise OR selects correctly and
+        // out-of-range (>=32) falls out as 0 with no extra mask.
+        let sixteen = i8x16::splat(16);
+        Self {
+          a: self.a.swizzle(rhs.a) | self.b.swizzle(rhs.a - sixteen),
+          b: self.a.swizzle(rhs.b) | self.b.swizzle(rhs.b - sixteen),
+        }
+      }
+    }
+  }
 }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -662,4 +662,46 @@ impl i8x32 {
       }
     }
   }
+
+  /// Like [`swizzle`](Self::swizzle), but out-of-range indices (unsigned
+  /// `>= 32`) yield an implementation-defined result (`0` or `self[index % 32]`).
+  /// Prefer this when you know all indices are in range; it can be cheaper.
+  #[inline]
+  pub fn swizzle_relaxed(self, rhs: i8x32) -> i8x32 {
+    pick! {
+      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi8;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi8;
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
+        Self { avx: m256i(unsafe { _mm256_permutexvar_epi8(rhs.avx.0, self.avx.0) }) }
+      } else if #[cfg(target_feature="avx2")] {
+        // Same broadcast+blend as strict, but skip the 0x60 zeroing fold.
+        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
+        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
+        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, rhs.avx);
+        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, rhs.avx);
+        let sel = shl_imm_u16_m256i::<3>(rhs.avx);
+        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // vqtbl2 zeroes out-of-range anyway; identical to strict.
+        use core::arch::aarch64::{int8x16x2_t, vqtbl2q_s8, vreinterpretq_u8_s8};
+        unsafe {
+          let table = int8x16x2_t(self.a.neon, self.b.neon);
+          Self {
+            a: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.a.neon)) },
+            b: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.b.neon)) },
+          }
+        }
+      } else {
+        // Strict fallback is a valid relaxed implementation (it zeroes OOR).
+        let sixteen = i8x16::splat(16);
+        Self {
+          a: self.a.swizzle(rhs.a) | self.b.swizzle(rhs.a - sixteen),
+          b: self.a.swizzle(rhs.b) | self.b.swizzle(rhs.b - sixteen),
+        }
+      }
+    }
+  }
 }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -463,4 +463,18 @@ impl u8x32 {
   pub fn swizzle_half_relaxed(self, rhs: u8x32) -> u8x32 {
     cast(i8x32::swizzle_half_relaxed(cast(self), cast(rhs)))
   }
+
+  /// Full 32-entry byte table lookup. An index in `[0, 31]` selects
+  /// `self[index]`; any index `>= 32` yields `0`.
+  #[inline]
+  pub fn swizzle(self, rhs: u8x32) -> u8x32 {
+    cast(i8x32::swizzle(cast(self), cast(rhs)))
+  }
+
+  /// Like [`swizzle`](Self::swizzle), but out-of-range indices yield an
+  /// implementation-defined result (`0` or `self[index % 32]`).
+  #[inline]
+  pub fn swizzle_relaxed(self, rhs: u8x32) -> u8x32 {
+    cast(i8x32::swizzle_relaxed(cast(self), cast(rhs)))
+  }
 }

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -922,6 +922,39 @@ fn test_swizzle_half() {
   assert_eq!(actual, expected);
 }
 
+/// Scalar reference: unsigned index in [0,31] selects table[idx], else 0.
+fn ref_swizzle32(table: [i8; 32], idx: [i8; 32]) -> [i8; 32] {
+  let mut out = [0i8; 32];
+  for i in 0..32 {
+    let ix = idx[i] as u8 as usize; // unsigned interpretation
+    out[i] = if ix < 32 { table[ix] } else { 0 };
+  }
+  out
+}
+
+#[test]
+fn test_i8x32_swizzle() {
+  let table_arr: [i8; 32] = core::array::from_fn(|i| (i as i8) + 1); // 1..=32
+  let table = i8x32::new(table_arr);
+  let cases: [[i8; 32]; 4] = [
+    core::array::from_fn(|i| i as i8), // identity
+    core::array::from_fn(|i| 31 - i as i8), // reverse
+    core::array::from_fn(|i| ((i + 16) % 32) as i8), // cross-half rotate by 16
+    {
+      let mut a = [3i8; 32];
+      a[0] = 32; // out of range -> 0
+      a[1] = 100; // out of range -> 0
+      a[2] = -1; // 255 unsigned -> 0
+      a
+    },
+  ];
+  for idx_arr in cases {
+    let expected = i8x32::new(ref_swizzle32(table_arr, idx_arr));
+    let actual = table.swizzle(i8x32::new(idx_arr));
+    assert_eq!(actual, expected, "idx={:?}", idx_arr);
+  }
+}
+
 #[test]
 fn test_from_u8x16_low() {
   // This function only exists for select types.

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -956,6 +956,22 @@ fn test_i8x32_swizzle() {
 }
 
 #[test]
+fn test_i8x32_swizzle_relaxed() {
+  let table_arr: [i8; 32] = core::array::from_fn(|i| (i as i8) + 1);
+  let table = i8x32::new(table_arr);
+  let cases: [[i8; 32]; 3] = [
+    core::array::from_fn(|i| i as i8),               // identity
+    core::array::from_fn(|i| 31 - i as i8),          // reverse
+    core::array::from_fn(|i| ((i + 16) % 32) as i8), // cross-half
+  ];
+  for idx_arr in cases {
+    let expected = i8x32::new(ref_swizzle32(table_arr, idx_arr)); // all in-range here
+    let actual = table.swizzle_relaxed(i8x32::new(idx_arr));
+    assert_eq!(actual, expected, "idx={:?}", idx_arr);
+  }
+}
+
+#[test]
 fn test_from_u8x16_low() {
   // This function only exists for select types.
 

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -1,6 +1,6 @@
 use wide::{
   f32x4, f32x8, f32x16, i8x16, i8x32, i16x8, i16x16, i32x4, i32x8, i32x16,
-  u8x16, u16x8,
+  u8x16, u8x32, u16x8,
 };
 
 use crate::utils::{for_simd_types, random_iter, simd_chunks};
@@ -969,6 +969,31 @@ fn test_i8x32_swizzle_relaxed() {
     let actual = table.swizzle_relaxed(i8x32::new(idx_arr));
     assert_eq!(actual, expected, "idx={:?}", idx_arr);
   }
+}
+
+#[test]
+fn test_u8x32_swizzle() {
+  let table_arr: [u8; 32] = core::array::from_fn(|i| (i as u8) + 1); // 1..=32
+  let table = u8x32::new(table_arr);
+  // strict: unsigned indices, out-of-range (incl. 128 and 255) -> 0
+  let mut idx_arr = [4u8; 32];
+  idx_arr[0] = 0;
+  idx_arr[1] = 31;
+  idx_arr[2] = 32; // OOR -> 0
+  idx_arr[3] = 128; // OOR -> 0 (would be negative i8 after cast)
+  idx_arr[4] = 255; // OOR -> 0
+  let mut expected = [0u8; 32];
+  for i in 0..32 {
+    let ix = idx_arr[i] as usize;
+    expected[i] = if ix < 32 { table_arr[ix] } else { 0 };
+  }
+  let actual = table.swizzle(u8x32::new(idx_arr));
+  assert_eq!(actual, u8x32::new(expected), "idx={:?}", idx_arr);
+
+  // relaxed: in-range only, must match table lookup
+  let rev: [u8; 32] = core::array::from_fn(|i| 31 - i as u8);
+  let rev_expected: [u8; 32] = core::array::from_fn(|i| table_arr[(31 - i) as usize]);
+  assert_eq!(table.swizzle_relaxed(u8x32::new(rev)), u8x32::new(rev_expected));
 }
 
 #[test]


### PR DESCRIPTION
Closes #291.

Adds `swizzle` and `swizzle_relaxed` to `u8x32` and `i8x32`: a full-width 32-entry byte table lookup where each output byte can be selected from any of the 32 input bytes (unlike the existing `swizzle_half`, whose indices only address their own 16-byte half).

Per-arch lowering:
- **AVX-512-VBMI**: `vpermb`, via the raw `_mm256_permutexvar_epi8` intrinsic with a `// TODO(safe_arch)` (matching the existing pattern in `src/u16x16_.rs`).
- **NEON**: `vqtbl2q_s8`.
- **AVX2**: broadcast each table half across both 128-bit lanes, `pshufb`, blend by index bit 4; the strict variant folds the out-of-range zeroing into the shuffle via an unsigned saturating add.
- **SSSE3 / wasm / scalar**: a generic fallback built from `i8x16::swizzle`.

`swizzle` is strict (an unsigned index `>= 32` yields `0`); `swizzle_relaxed` leaves out-of-range results implementation-defined and can be cheaper. `u8x32` delegates to `i8x32` via `cast`.

Motivation: the [`sassy`](https://github.com/RagnarGrootKoerkamp/sassy) matcher does a 32-entry IUPAC-code lookup per text block and currently hand-rolls the half-shuffle + shift + blend; on NEON that lookup is ~62% of a hot encoding routine.

Testing: NEON runtime tests pass; all arms cross-compile; `+avx512vbmi` is added to the AVX-512 CI job so the `vpermb` arm is exercised under Intel SDE.

A follow-up can add a `safe_arch` wrapper for `_mm256_permutexvar_epi8` and drop the `TODO`.
