### PR TITLE
fix: zero out-of-range indices in i8x32::swizzle_half on AVX2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed `i8x32`/`u8x32` `swizzle_half` on AVX2: out-of-range indices now
+  correctly zero their output lane (previously leaked `self[..][0]`).
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.
 * Added integer functions `reduce_mul` and `mul_keep_low_high`.

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -573,7 +573,7 @@ impl i8x32 {
   pub fn swizzle_half(self, rhs: i8x32) -> i8x32 {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: shuffle_av_i8z_half_m256i(self.avx, rhs.saturating_add(i8x32::splat(0x60)).avx) }
+        Self { avx: shuffle_av_i8z_half_m256i(self.avx, add_saturating_u8_m256i(rhs.avx, set_splat_i8_m256i(0x70))) }
       } else {
           Self {
             a : self.a.swizzle(rhs.a),

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -923,6 +923,26 @@ fn test_swizzle_half() {
 }
 
 #[test]
+fn test_swizzle_half_out_of_range_zeroes() {
+  // `swizzle_half` is strict: any index outside `[0, 15]` (per half) must zero
+  // that output lane. This previously failed on the AVX2 path, which used a
+  // signed `saturating_add(0x60)` that cannot set the high bit that makes
+  // `pshufb` zero, so out-of-range indices leaked `self[..][0]`.
+  let value = i8x32::new([
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+  ]);
+  for &bad in &[16i8, 17, 31, 100, -1, -128] {
+    let indices = i8x32::new([bad; 32]);
+    assert_eq!(
+      value.swizzle_half(indices),
+      i8x32::new([0i8; 32]),
+      "index {bad} is out of range and must zero every lane",
+    );
+  }
+}
+
+#[test]
 fn test_from_u8x16_low() {
   // This function only exists for select types.
 


### PR DESCRIPTION
The AVX2 lowering of `i8x32::swizzle_half` (and `u8x32::swizzle_half`, which delegates to it) used a **signed** `saturating_add(0x60)` on the index before `pshufb`. Signed saturation caps positive results at `0x7F` (bit 7 clear), so it can never set the high bit that makes `pshufb` zero a lane. Out-of-range indices (`>= 16` within a half) therefore leaked `self[half][0]` instead of `0`, diverging from the scalar and NEON paths and from the method's documented contract ("For indices outside of the range the resulting lane is 0").

Example (AVX2, before the fix): `value.swizzle_half([16; 32])` returned `[1, 1, …, 17, 17, …]` instead of `[0; 32]`.

Fix: use the unsigned `add_saturating_u8_m256i(rhs, 0x70)` pattern (as `i8x16::swizzle` already does). `0x70 + 16 = 0x80` sets bit 7 for any out-of-range index so `pshufb` zeroes the lane, while in-range indices `0..15` map to `0x70..0x7F` and select correctly.

Adds a regression test covering out-of-range indices. Verified on AVX2 hardware: the fix makes the AVX2 path match the scalar path, and the existing in-range `test_swizzle_half` still passes.
