### PR TITLE
refactor: Rename `powf` functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Renamed float function `pow_{simd-type-name}` to `powf_simd` and deprecated `powf`.
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.
 * Added integer functions `reduce_mul` and `mul_keep_low_high`.

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -235,6 +235,7 @@ impl_simd_float! {
     Simd = f32x16,
     UnsignedT = u32,
   }
+  old_powf_simd_fn_name = pow_f32x16,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -905,7 +906,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f32x16(self, y: Self) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f32_as_f32x16!(ln2f_hi, 0.693359375);
     const_f32_as_f32x16!(ln2f_lo, -2.12194440e-4);
     const_f32_as_f32x16!(P0logf, 3.3333331174E-1);
@@ -939,17 +940,17 @@ impl_simd_float! {
 
     let ef = x1.exponent();
     let ef = mask.select(ef + f32x16::ONE, ef);
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f32x16::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x16::HALF * x).mul_sub(x, f32x16::HALF * x2);
     let lg_err = f32x16::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x16::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2f_hi);
+    let e2 = (lg * n * f32x16::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
-    let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x16::LN_2);
+    let v = v - (lg_err + x2_err).mul_sub(n, yr * f32x16::LN_2);
 
     let x = v;
     let e3 = (x * f32x16::LOG2_E).round_ties_even();
@@ -978,9 +979,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f32x16::ZERO).select(
+      n.simd_lt(f32x16::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x16::ZERO).select(f32x16::ONE, f32x16::ZERO),
+        n.simd_eq(f32x16::ZERO).select(f32x16::ONE, f32x16::ZERO),
       ),
       z,
     );
@@ -988,10 +989,10 @@ impl_simd_float! {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
 
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i32x16, f32x16>(y.round_int() << 31);
+      let y_odd = cast::<i32x16, f32x16>(n.round_int() << 31);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -1002,18 +1003,13 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f32) -> Self {
-    Self::pow_f32x16(self, f32x16::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -328,6 +328,7 @@ impl_simd_float! {
     Simd = f32x4,
     UnsignedT = u32,
   }
+  old_powf_simd_fn_name = pow_f32x4,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -1213,7 +1214,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f32x4(self, y: f32x4) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f32_as_f32x4!(ln2f_hi, 0.693359375);
     const_f32_as_f32x4!(ln2f_lo, -2.12194440e-4);
     const_f32_as_f32x4!(P0logf, 3.3333331174E-1);
@@ -1249,17 +1250,17 @@ impl_simd_float! {
     let ef = x1.exponent();
     let ef = mask.select(ef + f32x4::ONE, ef);
 
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f32x4::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x4::HALF * x).mul_sub(x, f32x4::HALF * x2);
     let lg_err = f32x4::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x4::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2f_hi);
+    let e2 = (lg * n * f32x4::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
-    let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x4::LN_2);
+    let v = v - (lg_err + x2_err).mul_sub(n, yr * f32x4::LN_2);
 
     let x = v;
     let e3 = (x * f32x4::LOG2_E).round_ties_even();
@@ -1293,9 +1294,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f32x4::ZERO).select(
+      n.simd_lt(f32x4::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x4::ZERO).select(f32x4::ONE, f32x4::ZERO),
+        n.simd_eq(f32x4::ZERO).select(f32x4::ONE, f32x4::ZERO),
       ),
       z,
     );
@@ -1303,9 +1304,9 @@ impl_simd_float! {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i32x4, f32x4>(y.round_int() << 31);
+      let y_odd = cast::<i32x4, f32x4>(n.round_int() << 31);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -1315,18 +1316,13 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f32) -> Self {
-    Self::pow_f32x4(self, f32x4::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -260,6 +260,7 @@ impl_simd_float! {
     Simd = f32x8,
     UnsignedT = u32,
   }
+  old_powf_simd_fn_name = pow_f32x8,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -927,7 +928,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f32x8(self, y: Self) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f32_as_f32x8!(ln2f_hi, 0.693359375);
     const_f32_as_f32x8!(ln2f_lo, -2.12194440e-4);
     const_f32_as_f32x8!(P0logf, 3.3333331174E-1);
@@ -961,17 +962,17 @@ impl_simd_float! {
 
     let ef = x1.exponent();
     let ef = mask.select(ef + f32x8::ONE, ef);
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f32x8::HALF.mul_neg_add(x2, x) + lg1;
     let x2_err = (f32x8::HALF * x).mul_sub(x, f32x8::HALF * x2);
     let lg_err = f32x8::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f32x8::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2f_hi);
+    let e2 = (lg * n * f32x8::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2f_hi);
     let v = e2.mul_neg_add(ln2f_lo, v);
-    let v = v - (lg_err + x2_err).mul_sub(y, yr * f32x8::LN_2);
+    let v = v - (lg_err + x2_err).mul_sub(n, yr * f32x8::LN_2);
 
     let x = v;
     let e3 = (x * f32x8::LOG2_E).round_ties_even();
@@ -1000,9 +1001,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f32x8::ZERO).select(
+      n.simd_lt(f32x8::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f32x8::ZERO).select(f32x8::ONE, f32x8::ZERO),
+        n.simd_eq(f32x8::ZERO).select(f32x8::ONE, f32x8::ZERO),
       ),
       z,
     );
@@ -1010,10 +1011,10 @@ impl_simd_float! {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
 
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i32x8, f32x8>(y.round_int() << 31);
+      let y_odd = cast::<i32x8, f32x8>(n.round_int() << 31);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -1024,18 +1025,13 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f32) -> Self {
-    Self::pow_f32x8(self, f32x8::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -284,6 +284,7 @@ impl_simd_float! {
     Simd = f64x2,
     UnsignedT = u64,
   }
+  old_powf_simd_fn_name = pow_f64x2,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -1101,7 +1102,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f64x2(self, y: Self) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f64_as_f64x2!(ln2d_hi, 0.693145751953125);
     const_f64_as_f64x2!(ln2d_lo, 1.42860682030941723212E-6);
     const_f64_as_f64x2!(P0log, 2.0039553499201281259648E1);
@@ -1145,17 +1146,17 @@ impl_simd_float! {
 
     let ef = x1.exponent();
     let ef = mask.select(ef + f64x2::ONE, ef);
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f64x2::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x2::HALF * x).mul_sub(x, f64x2::HALF * x2);
     let lg_err = f64x2::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x2::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2d_hi);
+    let e2 = (lg * n * f64x2::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
-    let v = v - (lg_err + x2err).mul_sub(y, yr * f64x2::LN_2);
+    let v = v - (lg_err + x2err).mul_sub(n, yr * f64x2::LN_2);
 
     let x = v;
     let e3 = (x * f64x2::LOG2_E).round_ties_even();
@@ -1186,9 +1187,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f64x2::ZERO).select(
+      n.simd_lt(f64x2::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x2::ZERO).select(f64x2::ONE, f64x2::ZERO),
+        n.simd_eq(f64x2::ZERO).select(f64x2::ONE, f64x2::ZERO),
       ),
       z,
     );
@@ -1196,9 +1197,9 @@ impl_simd_float! {
     let x_sign = self.is_sign_negative();
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i64x2, f64x2>(y.round_int() << 63);
+      let y_odd = cast::<i64x2, f64x2>(n.round_int() << 63);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -1208,19 +1209,14 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
 
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f64) -> Self {
-    Self::pow_f64x2(self, f64x2::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -224,6 +224,7 @@ impl_simd_float! {
     Simd = f64x4,
     UnsignedT = u64,
   }
+  old_powf_simd_fn_name = pow_f64x4,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -882,7 +883,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f64x4(self, y: Self) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f64_as_f64x4!(ln2d_hi, 0.693145751953125);
     const_f64_as_f64x4!(ln2d_lo, 1.42860682030941723212E-6);
     const_f64_as_f64x4!(P0log, 2.0039553499201281259648E1);
@@ -926,17 +927,17 @@ impl_simd_float! {
 
     let ef = x1.exponent();
     let ef = mask.select(ef + f64x4::ONE, ef);
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f64x4::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x4::HALF * x).mul_sub(x, f64x4::HALF * x2);
     let lg_err = f64x4::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x4::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2d_hi);
+    let e2 = (lg * n * f64x4::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
-    let v = v - (lg_err + x2err).mul_sub(y, yr * f64x4::LN_2);
+    let v = v - (lg_err + x2err).mul_sub(n, yr * f64x4::LN_2);
 
     let x = v;
     let e3 = (x * f64x4::LOG2_E).round_ties_even();
@@ -967,9 +968,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f64x4::ZERO).select(
+      n.simd_lt(f64x4::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x4::ZERO).select(f64x4::ONE, f64x4::ZERO),
+        n.simd_eq(f64x4::ZERO).select(f64x4::ONE, f64x4::ZERO),
       ),
       z,
     );
@@ -978,9 +979,9 @@ impl_simd_float! {
 
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i64x4, f64x4>(y.round_int() << 63);
+      let y_odd = cast::<i64x4, f64x4>(n.round_int() << 63);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -990,19 +991,14 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
 
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f64) -> Self {
-    Self::pow_f64x4(self, f64x4::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -218,6 +218,7 @@ impl_simd_float! {
     Simd = f64x8,
     UnsignedT = u64,
   }
+  old_powf_simd_fn_name = pow_f64x8,
 
   #[inline]
   fn neg(self) -> Self::Output {
@@ -890,7 +891,7 @@ impl_simd_float! {
   }
 
   #[inline]
-  pub fn pow_f64x8(self, y: Self) -> Self {
+  pub fn powf_simd(self, n: Self) -> Self {
     const_f64_as_f64x8!(ln2d_hi, 0.693145751953125);
     const_f64_as_f64x8!(ln2d_lo, 1.42860682030941723212E-6);
     const_f64_as_f64x8!(P0log, 2.0039553499201281259648E1);
@@ -934,17 +935,17 @@ impl_simd_float! {
 
     let ef = x1.exponent();
     let ef = mask.select(ef + f64x8::ONE, ef);
-    let e1 = (ef * y).round_ties_even();
-    let yr = ef.mul_sub(y, e1);
+    let e1 = (ef * n).round_ties_even();
+    let yr = ef.mul_sub(n, e1);
 
     let lg = f64x8::HALF.mul_neg_add(x2, x) + lg1;
     let x2err = (f64x8::HALF * x).mul_sub(x, f64x8::HALF * x2);
     let lg_err = f64x8::HALF.mul_add(x2, lg - x) - lg1;
 
-    let e2 = (lg * y * f64x8::LOG2_E).round_ties_even();
-    let v = lg.mul_sub(y, e2 * ln2d_hi);
+    let e2 = (lg * n * f64x8::LOG2_E).round_ties_even();
+    let v = lg.mul_sub(n, e2 * ln2d_hi);
     let v = e2.mul_neg_add(ln2d_lo, v);
-    let v = v - (lg_err + x2err).mul_sub(y, yr * f64x8::LN_2);
+    let v = v - (lg_err + x2err).mul_sub(n, yr * f64x8::LN_2);
 
     let x = v;
     let e3 = (x * f64x8::LOG2_E).round_ties_even();
@@ -975,9 +976,9 @@ impl_simd_float! {
     // Check for self == 0
     let x_zero = self.is_zero_or_subnormal();
     let z = x_zero.select(
-      y.simd_lt(f64x8::ZERO).select(
+      n.simd_lt(f64x8::ZERO).select(
         Self::infinity(),
-        y.simd_eq(f64x8::ZERO).select(f64x8::ONE, f64x8::ZERO),
+        n.simd_eq(f64x8::ZERO).select(f64x8::ONE, f64x8::ZERO),
       ),
       z,
     );
@@ -986,9 +987,9 @@ impl_simd_float! {
 
     let z = if x_sign.any() {
       // Y into an integer
-      let yi = y.simd_eq(y.round_ties_even());
+      let yi = n.simd_eq(n.round_ties_even());
       // Is y odd? If yes flip the sign of the result.
-      let y_odd = cast::<i64x8, f64x8>(y.round_int() << 63);
+      let y_odd = cast::<i64x8, f64x8>(n.round_int() << 63);
 
       let z1 = yi
         .select(z | y_odd, self.simd_eq(Self::ZERO).select(z, Self::nan_pow()));
@@ -998,19 +999,14 @@ impl_simd_float! {
     };
 
     let x_finite = self.is_finite();
-    let y_finite = y.is_finite();
+    let y_finite = n.is_finite();
     let e_finite = ee.is_finite();
 
     if (x_finite & y_finite & (e_finite | x_zero)).all() {
       return z;
     }
 
-    (self.is_nan() | y.is_nan()).select(self + y, z)
-  }
-
-  #[inline]
-  pub fn powf(self, y: f64) -> Self {
-    Self::pow_f64x8(self, f64x8::splat(y))
+    (self.is_nan() | n.is_nan()).select(self + n, z)
   }
 
   #[inline]

--- a/src/simd_float.rs
+++ b/src/simd_float.rs
@@ -12,6 +12,7 @@ macro_rules! impl_simd_float {
       Simd = $Simd:ident,
       UnsignedT = $UnsignedT:ident,
     }
+    old_powf_simd_fn_name = $old_powf_simd_fn_name:ident,
 
     $fn_neg:item
     $fn_not:item
@@ -52,8 +53,7 @@ macro_rules! impl_simd_float {
     $fn_mul_sub:item
     $fn_mul_neg_add:item
     $fn_mul_neg_sub:item
-    $fn_pow_simd:item
-    $fn_powf:item
+    $fn_powf_simd:item
     $fn_sqrt:item
     $fn_exp:item
     $fn_exp2:item
@@ -413,11 +413,19 @@ macro_rules! impl_simd_float {
         r.simd_lt(Self::ZERO).select(r + rhs.abs(), r)
       }
 
+      /// Raises each element of the number `self` to the corresponding element
+      /// of the floating point power `n`.
+      ///
+      /// This function cannot be named simply `powf`, because a now deprecated
+      /// function already uses that name.
+      ///
+      /// # Unspecified precision
+      ///
+      /// The precision of this function is non-deterministic. This means it
+      /// varies by platform, version, and can even differ within the same
+      /// execution from one invocation to the next.
       #[must_use]
-      $fn_pow_simd
-
-      #[must_use]
-      $fn_powf
+      $fn_powf_simd
 
       #[must_use]
       $fn_sqrt
@@ -509,6 +517,44 @@ macro_rules! impl_simd_float {
       /// Calculates hyperbolic tangent: `sinh(self)/cosh(self)`.
       #[must_use]
       $fn_tanh
+
+      /// Raises each element of the number `self` to the corresponding element
+      /// of the floating point power `n`.
+      ///
+      /// This function has been renamed to [`powf_simd`].
+      ///
+      /// # Unspecified precision
+      ///
+      /// The precision of this function is non-deterministic. This means it
+      /// varies by platform, version, and can even differ within the same
+      /// execution from one invocation to the next.
+      ///
+      /// [`powf_simd`]: Self::powf_simd
+      #[deprecated(since = "1.6.0", note = "renamed to `powf_simd`")]
+      #[inline]
+      #[must_use]
+      pub fn $old_powf_simd_fn_name(self, n: Self) -> Self {
+        self.powf_simd(n)
+      }
+
+      /// Raises each element of the number `self` to the scalar floating point
+      /// power `n`.
+      ///
+      /// This function has been deprecated because it raises all elements of
+      /// `x` to the same power, even though that brings no performance benefit.
+      #[doc = concat!("Use `x.powf_simd(", stringify!($Simd), "::splat(n))` instead.")]
+      ///
+      /// # Unspecified precision
+      ///
+      /// The precision of this function is non-deterministic. This means it
+      /// varies by platform, version, and can even differ within the same
+      /// execution from one invocation to the next.
+      #[deprecated(since = "1.6.0", note = "use `x.powf_simd(splat(n))` instead")]
+      #[inline]
+      #[must_use]
+      pub fn powf(self, n: $T) -> Self {
+        self.powf_simd(Self::splat(n))
+      }
     }
   };
 }

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -1637,10 +1637,10 @@ fn test_log10() {
 }
 
 #[test]
-fn test_pow_simd() {
+fn test_powf_simd() {
   for_simd_types!(|T: Float, N| {
     #[expect(clippy::approx_constant)]
-    for [value, n] in simd_chunks!(
+    for [x, n] in simd_chunks!(
       [
         1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
         -3.1, -3.0, -4.0, 5.1,
@@ -1649,42 +1649,30 @@ fn test_pow_simd() {
         0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
         2.7, 4.0, -3.0, 29.0,
       ],
+    )
+    .chain(
+      simd_chunks!([
+        1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
+        -3.1, -3.0, -4.0, 5.1,
+      ])
+      .flat_map(|x| {
+        [
+          0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0,
+          0.1, 2.7, 4.0, -3.0, 29.0,
+        ]
+        .into_iter()
+        .map(move |n| [x, [n; N]])
+      }),
     ) {
-      let expected = Simd::new(std::array::from_fn(|i| value[i].powf(n[i])));
-      let actual = pow_simd(Simd::new(value), Simd::new(n));
+      let expected = Simd::new(std::array::from_fn(|i| x[i].powf(n[i])));
+      let actual = Simd::new(x).powf_simd(Simd::new(n));
 
       assert!(
         ((actual - expected).abs().simd_le(expected.abs() * 1e-6)
           | actual.is_nan() & expected.is_nan())
         .all(),
-        "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}\n       n: {n:?}",
+        "expected: {expected:?}\n  actual: {actual:?}\n       x: {x:?}\n       n: {n:?}",
       );
-    }
-  });
-}
-
-#[test]
-fn test_powf() {
-  for_simd_types!(|T: Float, N| {
-    for value in simd_chunks!([
-      1.2, 2.0, 3.0, 1.5, 9.2, 6.1, 2.5, 5.3, -4.5, -5.1, -5.2, -5.3, -3.0,
-      -3.1, -3.0, -4.0, 5.1,
-    ]) {
-      #[expect(clippy::approx_constant)]
-      for n in [
-        0.1, 0.5, 1.0, 2.718282, 3.0, 4.0, 2.5, -1.0, 1.4, 2.0, 1.0, 3.0, 0.1,
-        2.7, 4.0, -3.0, 29.0,
-      ] {
-        let expected = Simd::new(std::array::from_fn(|i| value[i].powf(n)));
-        let actual = Simd::new(value).powf(n);
-
-        assert!(
-          ((actual - expected).abs().simd_le(expected.abs() * 1e-6)
-            | actual.is_nan() & expected.is_nan())
-          .all(),
-          "expected: {expected:?}\n  actual: {actual:?}\n   value: {value:?}\n       n: {n:?}",
-        );
-      }
     }
   });
 }

--- a/tests/utils/for_simd_types.rs
+++ b/tests/utils/for_simd_types.rs
@@ -18,7 +18,6 @@ use std::panic::{UnwindSafe, catch_unwind, resume_unwind};
 /// // - type Simd
 /// // - type Signed
 /// // - type SimdSigned
-/// // - fn pow_simd (because its name differs for each type)
 /// for_simd_types!(|T: Float, N| ...);
 ///
 /// // Has access to:
@@ -47,12 +46,12 @@ macro_rules! for_simd_types {
     for_simd_types!(|T: Integer, N| $expr);
   };
   (|T: Float, N| $expr:expr) => {
-    for_simd_types!(float!(f32, 4, f32x4, i32, i32x4, pow_f32x4, $expr));
-    for_simd_types!(float!(f32, 8, f32x8, i32, i32x8, pow_f32x8, $expr));
-    for_simd_types!(float!(f32, 16, f32x16, i32, i32x16, pow_f32x16, $expr));
-    for_simd_types!(float!(f64, 2, f64x2, i64, i64x2, pow_f64x2, $expr));
-    for_simd_types!(float!(f64, 4, f64x4, i64, i64x4, pow_f64x4, $expr));
-    for_simd_types!(float!(f64, 8, f64x8, i64, i64x8, pow_f64x8, $expr));
+    for_simd_types!(float!(f32, 4, f32x4, i32, i32x4, $expr));
+    for_simd_types!(float!(f32, 8, f32x8, i32, i32x8, $expr));
+    for_simd_types!(float!(f32, 16, f32x16, i32, i32x16, $expr));
+    for_simd_types!(float!(f64, 2, f64x2, i64, i64x2, $expr));
+    for_simd_types!(float!(f64, 4, f64x4, i64, i64x4, $expr));
+    for_simd_types!(float!(f64, 8, f64x8, i64, i64x8, $expr));
   };
   (|T: Integer, N| $expr:expr) => {
     for_simd_types!(|T: Signed, N| $expr);
@@ -110,7 +109,7 @@ macro_rules! for_simd_types {
     // for_simd_types!(unsigned!(u64, 4, u64x4, u128, (u128x4), $expr));
     // for_simd_types!(unsigned!(u64, 8, u64x8, u128, (u128x8), $expr));
   };
-  (float!($T:ident, $N:literal, $Simd:ident, $Signed:ident, $SimdSigned:ident, $pow_simd:ident, $expr:expr)) => {{
+  (float!($T:ident, $N:literal, $Simd:ident, $Signed:ident, $SimdSigned:ident, $expr:expr)) => {{
     type Simd = wide::$Simd;
     #[allow(dead_code)]
     type T = $T;
@@ -120,10 +119,6 @@ macro_rules! for_simd_types {
     type Signed = $Signed;
     #[allow(dead_code)]
     type SimdSigned = wide::$SimdSigned;
-    #[allow(dead_code)]
-    #[expect(non_upper_case_globals)]
-    /// Points to `Simd::pow_{Simd}` which has a different name for each type.
-    const pow_simd: fn(Simd, Simd) -> Simd = Simd::$pow_simd;
     $crate::utils::for_simd_types_helper(|| $expr, stringify!($T), $N);
   }};
   (signed!(


### PR DESCRIPTION
Currently, the powf function that that is SIMD x SIMD has a different name for each type (e.g., `f32x4::pow_f32x4`, `f64x4::pow_f64x4`), and the function name `powf` is used for the SIMD x scalar version, which internally just calls the SIMD x SIMD version with a `splat`.

When using macros for each SIMD type, its quite annoying that the SIMD x SIMD function has a different name for each type. Instead there should be one consistent name. Also since the SIMD x scalar version just calls the SIMD x SIMD version (meaning it doesn't have some sort of optimization) there is no real reason for it to exist.

Changes:

- Renames the SIMD x SIMD function to `powf_simd` for all float types. (without the `f` this could be confused with `powi`, so its important to keep it) (cannot be named `powf` because the name is taken)
- Deprecates the original functions.
- Deprecates the scalar function `powf` and recommends using `splat` at the call site instead (if in the future an actual optimization is written specifically for SIMD x scalar, a `powf_scalar` function can be added)
- Uses documentation copied from #286 next to naming explanations.