### PR TITLE
Make `to/as/as_mut_array` const functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Made `to_array`, `as_array` and `as_mut_array` available in const contexts.
 * Renamed float function `pow_{simd-type-name}` to `powf_simd` and deprecated `powf`.
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -323,20 +323,28 @@ macro_rules! impl_simd {
 
       #[inline]
       #[must_use]
-      pub fn to_array(self) -> [$T; $N] {
-        cast(self)
+      pub const fn to_array(self) -> [$T; $N] {
+        // SAFETY: Both types accept all bit-patterns and only contain
+        // initialized memory.
+        unsafe { core::mem::transmute::<$Simd, [$T; $N]>(self) }
       }
 
       #[inline]
       #[must_use]
-      pub fn as_array(&self) -> &[$T; $N] {
-        cast_ref(self)
+      pub const fn as_array(&self) -> &[$T; $N] {
+        // SAFETY: The input type has greater alignment than the output type,
+        // and both pointed-at types have the same size, accept all bit-patterns
+        // and only contain initialized memory.
+        unsafe { core::mem::transmute::<&$Simd, &[$T; $N]>(self) }
       }
 
       #[inline]
       #[must_use]
-      pub fn as_mut_array(&mut self) -> &mut [$T; $N] {
-        cast_mut(self)
+      pub const fn as_mut_array(&mut self) -> &mut [$T; $N] {
+        // SAFETY: The input type has greater alignment than the output type,
+        // and both pointed-at types have the same size, accept all bit-patterns
+        // and only contain initialized memory.
+        unsafe { core::mem::transmute::<&mut $Simd, &mut [$T; $N]>(self) }
       }
 
       /// Test if each element is equal to the corresponding element in `other`.


### PR DESCRIPTION
The lack of this was quite annoying while writing another PR.

The implementations had to be changed into unsafe transmutes because the bytemuck functions also aren't const.