### PR TITLE
feat: `cast_unsigned`, `cast_signed`, `to_bits` and `from_bits`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added cast functions `cast_unsigned`, `cast_signed`, `to_bits`, `from_bits`.
 * Renamed float function `pow_{simd-type-name}` to `powf_simd` and deprecated `powf`.
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -234,6 +234,7 @@ impl_simd_float! {
     N = 16,
     Simd = f32x16,
     UnsignedT = u32,
+    UnsignedSimd = u32x16,
   }
   old_powf_simd_fn_name = pow_f32x16,
 

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -327,6 +327,7 @@ impl_simd_float! {
     N = 4,
     Simd = f32x4,
     UnsignedT = u32,
+    UnsignedSimd = u32x4,
   }
   old_powf_simd_fn_name = pow_f32x4,
 

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -259,6 +259,7 @@ impl_simd_float! {
     N = 8,
     Simd = f32x8,
     UnsignedT = u32,
+    UnsignedSimd = u32x8,
   }
   old_powf_simd_fn_name = pow_f32x8,
 

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -283,6 +283,7 @@ impl_simd_float! {
     N = 2,
     Simd = f64x2,
     UnsignedT = u64,
+    UnsignedSimd = u64x2,
   }
   old_powf_simd_fn_name = pow_f64x2,
 

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -223,6 +223,7 @@ impl_simd_float! {
     N = 4,
     Simd = f64x4,
     UnsignedT = u64,
+    UnsignedSimd = u64x4,
   }
   old_powf_simd_fn_name = pow_f64x4,
 

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -217,6 +217,7 @@ impl_simd_float! {
     N = 8,
     Simd = f64x8,
     UnsignedT = u64,
+    UnsignedSimd = u64x8,
   }
   old_powf_simd_fn_name = pow_f64x8,
 

--- a/src/simd_float.rs
+++ b/src/simd_float.rs
@@ -11,6 +11,7 @@ macro_rules! impl_simd_float {
       N = $N:literal,
       Simd = $Simd:ident,
       UnsignedT = $UnsignedT:ident,
+      UnsignedSimd = $UnsignedSimd:ident,
     }
     old_powf_simd_fn_name = $old_powf_simd_fn_name:ident,
 
@@ -265,6 +266,30 @@ macro_rules! impl_simd_float {
       #[must_use]
       pub fn midpoint(self, other: Self) -> Self {
         (self + other) * 0.5
+      }
+
+      /// Raw transmutation to unsigned integer vector.
+      ///
+      /// Note that this function preserves the *bitwise* value, and not the
+      /// numeric value.
+      #[inline]
+      #[must_use]
+      pub const fn to_bits(self) -> $UnsignedSimd {
+        // SAFETY: Both types accept all bit-patterns and only contain
+        // initialized memory.
+        unsafe { core::mem::transmute::<$Simd, $UnsignedSimd>(self) }
+      }
+
+      /// Raw transmutation from unsigned integer vector.
+      ///
+      /// Note that this function preserves the *bitwise* value, and not the
+      /// numeric value.
+      #[inline]
+      #[must_use]
+      pub const fn from_bits(bits: $UnsignedSimd) -> Self {
+        // SAFETY: Both types accept all bit-patterns and only contain
+        // initialized memory.
+        unsafe { core::mem::transmute::<$UnsignedSimd, $Simd>(bits) }
       }
 
       /// Restrict a value to a certain interval unless it is NaN.

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -291,6 +291,16 @@ macro_rules! impl_simd_int {
       #[must_use]
       $fn_reduce_min
 
+      /// Returns the bit patterns of `self` reinterpreted as unsigned integers
+      /// of the same size.
+      #[inline]
+      #[must_use]
+      pub const fn cast_unsigned(self) -> $UnsignedSimd {
+        // SAFETY: Both types accept all bit-patterns and only contain
+        // initialized memory.
+        unsafe { core::mem::transmute::<$Simd, $UnsignedSimd>(self) }
+      }
+
       #[must_use]
       $fn_saturating_add
 

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -10,6 +10,7 @@ macro_rules! impl_simd_uint {
       T = $T:ident,
       N = $N:literal,
       Simd = $Simd:ident,
+      SignedSimd = $SignedSimd:ident,
       T_BITS = $T_BITS:literal,
       T_BITS_MUL_2 = $T_BITS_MUL_2:literal,
       [$($index:literal),* $(,)?],
@@ -286,6 +287,16 @@ macro_rules! impl_simd_uint {
       /// horizontal min of all the elements of the vector
       #[must_use]
       $fn_reduce_min
+
+      /// Returns the bit patterns of `self` reinterpreted as signed integers of
+      /// the same size.
+      #[inline]
+      #[must_use]
+      pub const fn cast_signed(self) -> $SignedSimd {
+        // SAFETY: Both types accept all bit-patterns and only contain
+        // initialized memory.
+        unsafe { core::mem::transmute::<$Simd, $SignedSimd>(self) }
+      }
 
       #[must_use]
       $fn_saturating_add

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -163,6 +163,7 @@ impl_simd_uint! {
     T = u16,
     N = 16,
     Simd = u16x16,
+    SignedSimd = i16x16,
     T_BITS = 16,
     T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -166,6 +166,7 @@ impl_simd_uint! {
     T = u16,
     N = 32,
     Simd = u16x32,
+    SignedSimd = i16x32,
     T_BITS = 16,
     T_BITS_MUL_2 = 32,
     [

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -266,6 +266,7 @@ impl_simd_uint! {
     T = u16,
     N = 8,
     Simd = u16x8,
+    SignedSimd = i16x8,
     T_BITS = 16,
     T_BITS_MUL_2 = 32,
     [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -166,6 +166,7 @@ impl_simd_uint! {
     T = u32,
     N = 16,
     Simd = u32x16,
+    SignedSimd = i32x16,
     T_BITS = 32,
     T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -251,6 +251,7 @@ impl_simd_uint! {
     T = u32,
     N = 4,
     Simd = u32x4,
+    SignedSimd = i32x4,
     T_BITS = 32,
     T_BITS_MUL_2 = 64,
     [0, 1, 2, 3],

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -145,6 +145,7 @@ impl_simd_uint! {
     T = u32,
     N = 8,
     Simd = u32x8,
+    SignedSimd = i32x8,
     T_BITS = 32,
     T_BITS_MUL_2 = 64,
     [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -231,6 +231,7 @@ impl_simd_uint! {
     T = u64,
     N = 2,
     Simd = u64x2,
+    SignedSimd = i64x2,
     T_BITS = 64,
     T_BITS_MUL_2 = 128,
     [0, 1],

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -160,6 +160,7 @@ impl_simd_uint! {
     T = u64,
     N = 4,
     Simd = u64x4,
+    SignedSimd = i64x4,
     T_BITS = 64,
     T_BITS_MUL_2 = 128,
     [0, 1, 2, 3],

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -166,6 +166,7 @@ impl_simd_uint! {
     T = u64,
     N = 8,
     Simd = u64x8,
+    SignedSimd = i64x8,
     T_BITS = 64,
     T_BITS_MUL_2 = 128,
     [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -337,6 +337,7 @@ impl_simd_uint! {
     T = u8,
     N = 16,
     Simd = u8x16,
+    SignedSimd = i8x16,
     T_BITS = 8,
     T_BITS_MUL_2 = 16,
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -172,6 +172,7 @@ impl_simd_uint! {
     T = u8,
     N = 32,
     Simd = u8x32,
+    SignedSimd = i8x32,
     T_BITS = 8,
     T_BITS_MUL_2 = 16,
     [


### PR DESCRIPTION
These functions are easier to use than fully-typed bytemuck casts, and are consistent with `std`. Added functions are `const` because they are simple bitwise casts.

Since these are so simple I don't think there is a point to adding tests.