### PR TITLE
feat: Add unbounded shift functions for integers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added four unbounded-shift functions for integers.
 * Renamed float function `pow_{simd-type-name}` to `powf_simd` and deprecated `powf`.
 * Added conversions between `wide` types and native intrinsics SIMD types.
 * Added `reduce_mul` for integers.

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -464,6 +464,26 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u16x16) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_srav_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_srav_epi16;
+
+        // TODO(safe_arch): Add `_mm256_srav_epi16`.
+        cast(unsafe { _mm256_srav_epi16(self.avx2.0, rhs.avx2.0) })
+      } else {
+        let [self_a, self_b] = cast::<i16x16, [i16x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+        cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -484,6 +484,20 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_all_i16_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -507,6 +507,22 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        // `u32 as u16` truncates the higher half so we need to manually
+        // saturate.
+        Self { avx512: shr_all_i16_m512i(self.avx512, rhs.min(u16::MAX as u32) as u16) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -487,6 +487,26 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u16x32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_srav_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_srav_epi16;
+
+        // TODO(safe_arch): Add `_mm512_srav_epi16`.
+        Self { avx512: m512i(unsafe { _mm512_srav_epi16(self.avx512.0, rhs.avx512.0) }) }
+      } else {
+        let [self_a, self_b] = cast::<i16x32, [i16x16; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+
+        cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -938,6 +938,36 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shr_all_i16_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        if rhs < 16 { Self { simd: i16x8_shr(self.simd, rhs) } } else { self.is_negative() }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed())) }
+        }
+      } else {
+        Self {
+          arr: [
+            self.arr[0].unbounded_shr(rhs),
+            self.arr[1].unbounded_shr(rhs),
+            self.arr[2].unbounded_shr(rhs),
+            self.arr[3].unbounded_shr(rhs),
+            self.arr[4].unbounded_shr(rhs),
+            self.arr[5].unbounded_shr(rhs),
+            self.arr[6].unbounded_shr(rhs),
+            self.arr[7].unbounded_shr(rhs),
+          ]
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -903,6 +903,41 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u16x8) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm_srav_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm_srav_epi16;
+
+        // TODO(safe_arch): Add `_mm_srav_epi16`.
+        cast(unsafe { _mm_srav_epi16(self.sse.0, rhs.sse.0) })
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s16(self.neon, vnegq_s16(cast(rhs.min(u16x8::splat(16))))) }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0] as u32),
+          self_array[1].unbounded_shr(rhs_array[1] as u32),
+          self_array[2].unbounded_shr(rhs_array[2] as u32),
+          self_array[3].unbounded_shr(rhs_array[3] as u32),
+          self_array[4].unbounded_shr(rhs_array[4] as u32),
+          self_array[5].unbounded_shr(rhs_array[5] as u32),
+          self_array[6].unbounded_shr(rhs_array[6] as u32),
+          self_array[7].unbounded_shr(rhs_array[7] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -917,7 +917,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_s16(self.neon, vnegq_s16(cast(rhs.min(u16x8::splat(16))))) }
+          Self { neon: vshlq_s16(self.neon, vnegq_s16(vreinterpretq_s16_u16(rhs.min(u16x8::splat(16)).neon))) }
         }
       } else {
         let self_array = self.to_array();
@@ -948,7 +948,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_s16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed())) }
+          Self { neon: vshlq_s16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed() as i16)) }
         }
       } else {
         Self {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -473,6 +473,20 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_all_i32_m512i(self.avx512, rhs) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -453,6 +453,26 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u32x16) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_srav_epi32;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_srav_epi32;
+
+        // TODO(safe_arch): Add `_mm512_srav_epi32`.
+        Self { avx512: m512i(unsafe { _mm512_srav_epi32(self.avx512.0, rhs.avx512.0) }) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -667,7 +667,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_s32(self.neon, vnegq_s32(cast(rhs.min(u32x4::splat(32))))) }
+          Self { neon: vshlq_s32(self.neon, vnegq_s32(vreinterpretq_s32_u32(rhs.min(u32x4::splat(32)).neon))) }
         }
       } else {
         let self_array = self.to_array();

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -659,6 +659,31 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u32x4) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse: shr_each_i32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s32(self.neon, vnegq_s32(cast(rhs.min(u32x4::splat(32))))) }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0]),
+          self_array[1].unbounded_shr(rhs_array[1]),
+          self_array[2].unbounded_shr(rhs_array[2]),
+          self_array[3].unbounded_shr(rhs_array[3]),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -684,6 +684,32 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shr_all_i32_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        if rhs < 32 { Self { simd: i32x4_shr(self.simd, rhs) } } else { self.is_negative() }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s32(self.neon, vmovq_n_s32(-rhs.min(32).cast_signed())) }
+        }
+      } else {
+        Self {
+          arr: [
+            self.arr[0].unbounded_shr(rhs),
+            self.arr[1].unbounded_shr(rhs),
+            self.arr[2].unbounded_shr(rhs),
+            self.arr[3].unbounded_shr(rhs),
+          ]
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -475,6 +475,20 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u32x8) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_each_i32_m256i(self.avx2, rhs.avx2) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -489,6 +489,20 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_all_i32_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -582,6 +582,22 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        if rhs < 64 { Self { simd: i64x2_shr(self.simd, rhs) } } else { self.is_negative() }
+      } else {
+        let self_array = self.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs),
+          self_array[1].unbounded_shr(rhs),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -562,6 +562,26 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u64x2) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s64(self.neon, vnegq_s64(cast(rhs.min(u64x2::splat(64))))) }
+        }
+      } else {
+        // Cannot use scalar `unbounded_shl` because it takes `u32`, which is
+        // smaller than `u64`.
+        cast::<u64x2, i64x2>(rhs.simd_lt(64)).select(
+          self >> cast::<u64x2, i64x2>(rhs),
+          self.is_negative(),
+        )
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -568,7 +568,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_s64(self.neon, vnegq_s64(cast(rhs.min(u64x2::splat(64))))) }
+          Self { neon: vshlq_s64(self.neon, vnegq_s64(vreinterpretq_s64_u64(rhs.min(u64x2::splat(64)).neon))) }
         }
       } else {
         // Cannot use scalar `unbounded_shl` because it takes `u32`, which is

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -448,6 +448,13 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    // there is no signed right shift in AVX2
+    let [self_a, self_b] = cast::<i64x4, [i64x2; 2]>(self);
+    cast([self_a.unbounded_shr_scalar(rhs), self_b.unbounded_shr_scalar(rhs)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -440,6 +440,14 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u64x4) -> Self {
+    Self {
+      a: self.a.unbounded_shr(rhs.a),
+      b: self.b.unbounded_shr(rhs.b),
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -441,10 +441,10 @@ impl_simd_int! {
 
   #[inline]
   pub fn unbounded_shr(self, rhs: u64x4) -> Self {
-    Self {
-      a: self.a.unbounded_shr(rhs.a),
-      b: self.b.unbounded_shr(rhs.b),
-    }
+    let [self_a, self_b] = cast::<i64x4, [i64x2; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u64x4, [u64x2; 2]>(rhs);
+
+    cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
   }
 
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -485,6 +485,20 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_all_i64_m512i(self.avx512, rhs as u64) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -473,6 +473,18 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u64x8) -> Self {
+    // TODO(safe_arch): add shr_each_i64_m512i (arithmetic right shift)
+    // Self { avx512: shr_each_i64_m512i(self.avx512, rhs.avx512) }
+    // Fallback for now:
+
+    let [self_a, self_b] = cast::<i64x8, [i64x4; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u64x8, [u64x4; 2]>(rhs);
+
+    cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1020,7 +1020,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          let neg_rhs = vnegq_s8(cast(rhs.min(u8x16::splat(8))));
+          let neg_rhs = vnegq_s8(vreinterpretq_s8_u8(rhs.min(u8x16::splat(8)).neon));
           Self { neon: vshlq_s8(self.neon, neg_rhs) }
         }
       } else {
@@ -1061,7 +1061,7 @@ impl_simd_int! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_s8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed())) }
+          Self { neon: vshlq_s8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed() as i8)) }
         }
       } else {
         let self_array = self.to_array();

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1050,6 +1050,45 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `i16` or `i32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        if rhs < 8 { Self { simd: i8x16_shr(self.simd, rhs) } } else { self.is_negative() }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_s8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed())) }
+        }
+      } else {
+        let self_array = self.to_array();
+
+        cast([
+          self_array[0].unbounded_shr(rhs),
+          self_array[1].unbounded_shr(rhs),
+          self_array[2].unbounded_shr(rhs),
+          self_array[3].unbounded_shr(rhs),
+          self_array[4].unbounded_shr(rhs),
+          self_array[5].unbounded_shr(rhs),
+          self_array[6].unbounded_shr(rhs),
+          self_array[7].unbounded_shr(rhs),
+          self_array[8].unbounded_shr(rhs),
+          self_array[9].unbounded_shr(rhs),
+          self_array[10].unbounded_shr(rhs),
+          self_array[11].unbounded_shr(rhs),
+          self_array[12].unbounded_shr(rhs),
+          self_array[13].unbounded_shr(rhs),
+          self_array[14].unbounded_shr(rhs),
+          self_array[15].unbounded_shr(rhs),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1011,6 +1011,45 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u8x16) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `i16` or `i32` then converting back after multiplication, but that may
+    // not actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          let neg_rhs = vnegq_s8(cast(rhs.min(u8x16::splat(8))));
+          Self { neon: vshlq_s8(self.neon, neg_rhs) }
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0] as u32),
+          self_array[1].unbounded_shr(rhs_array[1] as u32),
+          self_array[2].unbounded_shr(rhs_array[2] as u32),
+          self_array[3].unbounded_shr(rhs_array[3] as u32),
+          self_array[4].unbounded_shr(rhs_array[4] as u32),
+          self_array[5].unbounded_shr(rhs_array[5] as u32),
+          self_array[6].unbounded_shr(rhs_array[6] as u32),
+          self_array[7].unbounded_shr(rhs_array[7] as u32),
+          self_array[8].unbounded_shr(rhs_array[8] as u32),
+          self_array[9].unbounded_shr(rhs_array[9] as u32),
+          self_array[10].unbounded_shr(rhs_array[10] as u32),
+          self_array[11].unbounded_shr(rhs_array[11] as u32),
+          self_array[12].unbounded_shr(rhs_array[12] as u32),
+          self_array[13].unbounded_shr(rhs_array[13] as u32),
+          self_array[14].unbounded_shr(rhs_array[14] as u32),
+          self_array[15].unbounded_shr(rhs_array[15] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -442,6 +442,16 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: u8x32) -> Self {
+    // For x86, this technically can be done explicitly by converting to `i16`
+    // or `i32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+    cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -452,6 +452,15 @@ impl_simd_int! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `i16` or `i32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<i8x32, [i8x16; 2]>(self);
+    cast([self_a.unbounded_shr_scalar(rhs), self_b.unbounded_shr_scalar(rhs)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -137,11 +137,15 @@ macro_rules! impl_simd_int {
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
       #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
       ,
-      /// Shifts all lanes by the value given.
+      /// Shifts left each element of `self` by the uniform scalar `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl_scalar`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl_scalar`]: ", stringify!($Simd), "::unbounded_shl_scalar")]
       ,
       /// Shifts left the scalar `self` by each element of `rhs`.
       ///
@@ -162,23 +166,36 @@ macro_rules! impl_simd_int {
       shr_assign,
       $fn_shr,
       $fn_shr_u32,
-      /// Shifts each lane individually.
+      /// Shifts right each element of `self` by the corresponding element of
+      /// `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr`]: ", stringify!($Simd), "::unbounded_shr")]
       ,
-      /// Shifts all lanes by the value given.
+      /// Shifts right each element of `self` by the uniform scalar `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr_scalar`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr_scalar`]: ", stringify!($Simd), "::unbounded_shr_scalar")]
       ,
-      /// Shifts the same value by each lane, returning a SIMD type.
+      /// Shifts right the scalar `self` by each element of `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr`]: ", stringify!($Simd), "::unbounded_shr")]
     );
     impl_binary_operator!(
       $T,
@@ -312,7 +329,11 @@ macro_rules! impl_simd_int {
       /// [`wrapping_shl`]. For most targets, `unbounded_shl` is faster than the
       /// standard operator.
       ///
+      /// If you intend to shift all elements by the same value, consider using
+      /// [`unbounded_shl_scalar`] which is faster.
+      ///
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      /// [`unbounded_shl_scalar`]: Self::unbounded_shl_scalar
       #[inline]
       #[must_use]
       pub fn unbounded_shl(self, rhs: $UnsignedSimd) -> Self {
@@ -320,8 +341,8 @@ macro_rules! impl_simd_int {
         cast(cast::<$Simd, $UnsignedSimd>(self).unbounded_shl(rhs))
       }
 
-      /// Shifts left each element of `self` by the same scalar `rhs`, without
-      /// bounding `rhs`.
+      /// Shifts left each element of `self` by the uniform scalar `rhs`,
+      /// without bounding `rhs`.
       ///
       #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
       /// the entire value is shifted out, and `0` is returned.
@@ -352,12 +373,16 @@ macro_rules! impl_simd_int {
       /// [`wrapping_shr`]. For most targets, `unbounded_shr` is faster than the
       /// standard operator.
       ///
+      /// If you intend to shift all elements by the same value, consider using
+      /// [`unbounded_shr_scalar`] which is faster.
+      ///
       #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      /// [`unbounded_shr_scalar`]: Self::unbounded_shr_scalar
       #[must_use]
       $fn_unbounded_shr
 
-      /// Shifts right each element of `self` by the same scalar `rhs`, without
-      /// bounding `rhs`.
+      /// Shifts right each element of `self` by the uniform scalar `rhs`,
+      /// without bounding `rhs`.
       ///
       #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
       /// the entire value is shifted out, which yields `0` for a positive

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -34,6 +34,7 @@ macro_rules! impl_simd_int {
     $fn_reduce_max:item
     $fn_reduce_min:item
     $fn_unbounded_shr:item
+    $fn_unbounded_shr_scalar:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -354,6 +355,24 @@ macro_rules! impl_simd_int {
       #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
       #[must_use]
       $fn_unbounded_shr
+
+      /// Shifts right each element of `self` by the same scalar `rhs`, without
+      /// bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, which yields `0` for a positive
+      /// number, and `-1` for a negative number.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shr`]. For most targets, `unbounded_shr_scalar` is faster
+      /// than the standard operator.
+      ///
+      /// This function is faster than `self.unbounded_shr(splat(rhs))` because
+      /// it has special hardware support.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[must_use]
+      $fn_unbounded_shr_scalar
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -318,6 +318,27 @@ macro_rules! impl_simd_int {
         cast(cast::<$Simd, $UnsignedSimd>(self).unbounded_shl(rhs))
       }
 
+      /// Shifts left each element of `self` by the same scalar `rhs`, without
+      /// bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shl`]. For most targets, `unbounded_shl_scalar` is faster
+      /// than the standard operator.
+      ///
+      /// This function is faster than `self.unbounded_shl(splat(rhs))` because
+      /// it has special hardware support.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[inline]
+      #[must_use]
+      pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+        // Shift left is the same for unsigned and signed integers.
+        cast(cast::<$Simd, $UnsignedSimd>(self).unbounded_shl_scalar(rhs))
+      }
+
       #[must_use]
       $fn_saturating_add
 

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -33,6 +33,7 @@ macro_rules! impl_simd_int {
     $fn_reduce_mul:item
     $fn_reduce_max:item
     $fn_reduce_min:item
+    $fn_unbounded_shr:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -338,6 +339,21 @@ macro_rules! impl_simd_int {
         // Shift left is the same for unsigned and signed integers.
         cast(cast::<$Simd, $UnsignedSimd>(self).unbounded_shl_scalar(rhs))
       }
+
+      /// Shifts right each element of `self` by the corresponding element of
+      /// `rhs`, without bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, which yields `0` for a positive
+      /// number, and `-1` for a negative number.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shr`]. For most targets, `unbounded_shr` is faster than the
+      /// standard operator.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[must_use]
+      $fn_unbounded_shr
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_int.rs
+++ b/src/simd_int.rs
@@ -124,11 +124,16 @@ macro_rules! impl_simd_int {
       shl_assign,
       $fn_shl,
       $fn_shl_u32,
-      /// Shifts lanes by the corresponding lane.
+      /// Shifts left each element of `self` by the corresponding element of
+      /// `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
       ,
       /// Shifts all lanes by the value given.
       ///
@@ -136,11 +141,15 @@ macro_rules! impl_simd_int {
       /// high-order bits of `rhs` that would cause the shift to exceed the
       /// bitwidth of the type. (same as `wrapping_shl`)
       ,
-      /// Shifts the same value by each lane, returning a SIMD type.
+      /// Shifts left the scalar `self` by each element of `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
     );
     impl_shift_operator!(
       $T,
@@ -290,6 +299,24 @@ macro_rules! impl_simd_int {
       /// horizontal min of all the elements of the vector
       #[must_use]
       $fn_reduce_min
+
+      /// Shifts left each element of `self` by the corresponding element of
+      /// `rhs`, without bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shl`]. For most targets, `unbounded_shl` is faster than the
+      /// standard operator.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[inline]
+      #[must_use]
+      pub fn unbounded_shl(self, rhs: $UnsignedSimd) -> Self {
+        // Shift left is the same for unsigned and signed integers.
+        cast(cast::<$Simd, $UnsignedSimd>(self).unbounded_shl(rhs))
+      }
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -35,6 +35,7 @@ macro_rules! impl_simd_uint {
     $fn_unbounded_shl:item
     $fn_unbounded_shl_scalar:item
     $fn_unbounded_shr:item
+    $fn_unbounded_shr_scalar:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -343,6 +344,23 @@ macro_rules! impl_simd_uint {
       #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
       #[must_use]
       $fn_unbounded_shr
+
+      /// Shifts right each element of `self` by the same scalar `rhs`, without
+      /// bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shr`]. For most targets, `unbounded_shr_scalar` is faster
+      /// than the standard operator.
+      ///
+      /// This function is faster than `self.unbounded_shr(splat(rhs))` because
+      /// it has special hardware support.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[must_use]
+      $fn_unbounded_shr_scalar
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -33,6 +33,7 @@ macro_rules! impl_simd_uint {
     $fn_reduce_max:item
     $fn_reduce_min:item
     $fn_unbounded_shl:item
+    $fn_unbounded_shl_scalar:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -310,6 +311,23 @@ macro_rules! impl_simd_uint {
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
       #[must_use]
       $fn_unbounded_shl
+
+      /// Shifts left each element of `self` by the same scalar `rhs`, without
+      /// bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shl`]. For most targets, `unbounded_shl_scalar` is faster
+      /// than the standard operator.
+      ///
+      /// This function is faster than `self.unbounded_shl(splat(rhs))` because
+      /// it has special hardware support.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[must_use]
+      $fn_unbounded_shl_scalar
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -34,6 +34,7 @@ macro_rules! impl_simd_uint {
     $fn_reduce_min:item
     $fn_unbounded_shl:item
     $fn_unbounded_shl_scalar:item
+    $fn_unbounded_shr:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -328,6 +329,20 @@ macro_rules! impl_simd_uint {
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
       #[must_use]
       $fn_unbounded_shl_scalar
+
+      /// Shifts right each element of `self` by the corresponding element of
+      /// `rhs`, without bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shr`]. For most targets, `unbounded_shr` is faster than the
+      /// standard operator.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[must_use]
+      $fn_unbounded_shr
 
       #[must_use]
       $fn_saturating_add

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -135,11 +135,15 @@ macro_rules! impl_simd_uint {
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
       #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
       ,
-      /// Shifts all lanes by the value given.
+      /// Shifts left each element of `self` by the uniform scalar `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl_scalar`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl_scalar`]: ", stringify!($Simd), "::unbounded_shl_scalar")]
       ,
       /// Shifts left the scalar `self` by each element of `rhs`.
       ///
@@ -160,23 +164,36 @@ macro_rules! impl_simd_uint {
       shr_assign,
       $fn_shr,
       $fn_shr_u32,
-      /// Shifts each lane individually.
+      /// Shifts right each element of `self` by the corresponding element of
+      /// `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr`]: ", stringify!($Simd), "::unbounded_shr")]
       ,
-      /// Shifts all lanes by the value given.
+      /// Shifts right each element of `self` by the uniform scalar `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr_scalar`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr_scalar`]: ", stringify!($Simd), "::unbounded_shr_scalar")]
       ,
-      /// Shifts the same value by each lane, returning a SIMD type.
+      /// Shifts right the scalar `self` by each element of `rhs`.
       ///
-      /// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes
-      /// any high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shr`)
+      /// This operator behaves like [`wrapping_shr`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shr`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      #[doc = concat!("[`unbounded_shr`]: ", stringify!($Simd), "::unbounded_shr")]
     );
     impl_binary_operator!(
       $T,
@@ -310,12 +327,16 @@ macro_rules! impl_simd_uint {
       /// [`wrapping_shl`]. For most targets, `unbounded_shl` is faster than the
       /// standard operator.
       ///
+      /// If you intend to shift all elements by the same value, consider using
+      /// [`unbounded_shl_scalar`] which is faster.
+      ///
       #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      /// [`unbounded_shl_scalar`]: Self::unbounded_shl_scalar
       #[must_use]
       $fn_unbounded_shl
 
-      /// Shifts left each element of `self` by the same scalar `rhs`, without
-      /// bounding `rhs`.
+      /// Shifts left each element of `self` by the uniform scalar `rhs`,
+      /// without bounding `rhs`.
       ///
       #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
       /// the entire value is shifted out, and `0` is returned.
@@ -341,12 +362,16 @@ macro_rules! impl_simd_uint {
       /// [`wrapping_shr`]. For most targets, `unbounded_shr` is faster than the
       /// standard operator.
       ///
+      /// If you intend to shift all elements by the same value, consider using
+      /// [`unbounded_shr_scalar`] which is faster.
+      ///
       #[doc = concat!("[`wrapping_shr`]: ", stringify!($T), "::wrapping_shr")]
+      /// [`unbounded_shr_scalar`]: Self::unbounded_shr_scalar
       #[must_use]
       $fn_unbounded_shr
 
-      /// Shifts right each element of `self` by the same scalar `rhs`, without
-      /// bounding `rhs`.
+      /// Shifts right each element of `self` by the uniform scalar `rhs`,
+      /// without bounding `rhs`.
       ///
       #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
       /// the entire value is shifted out, and `0` is returned.

--- a/src/simd_uint.rs
+++ b/src/simd_uint.rs
@@ -32,6 +32,7 @@ macro_rules! impl_simd_uint {
     $fn_reduce_mul:item
     $fn_reduce_max:item
     $fn_reduce_min:item
+    $fn_unbounded_shl:item
     $fn_saturating_add:item
     $fn_saturating_sub:item
     $fn_overflowing_mul:item
@@ -120,11 +121,16 @@ macro_rules! impl_simd_uint {
       shl_assign,
       $fn_shl,
       $fn_shl_u32,
-      /// Shifts lanes by the corresponding lane.
+      /// Shifts left each element of `self` by the corresponding element of
+      /// `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
       ,
       /// Shifts all lanes by the value given.
       ///
@@ -132,11 +138,15 @@ macro_rules! impl_simd_uint {
       /// high-order bits of `rhs` that would cause the shift to exceed the
       /// bitwidth of the type. (same as `wrapping_shl`)
       ,
-      /// Shifts the same value by each lane, returning a SIMD type.
+      /// Shifts left the scalar `self` by each element of `rhs`.
       ///
-      /// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
-      /// high-order bits of `rhs` that would cause the shift to exceed the
-      /// bitwidth of the type. (same as `wrapping_shl`)
+      /// This operator behaves like [`wrapping_shl`].
+      ///
+      /// Note that for most targets, this operator is slower than
+      /// [`unbounded_shl`], so consider using that instead.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[doc = concat!("[`unbounded_shl`]: ", stringify!($Simd), "::unbounded_shl")]
     );
     impl_shift_operator!(
       $T,
@@ -286,6 +296,20 @@ macro_rules! impl_simd_uint {
       /// horizontal min of all the elements of the vector
       #[must_use]
       $fn_reduce_min
+
+      /// Shifts left each element of `self` by the corresponding element of
+      /// `rhs`, without bounding `rhs`.
+      ///
+      #[doc = concat!("If `rhs` is larger than or equal to the number of bits in [`", stringify!($T), "`],")]
+      /// the entire value is shifted out, and `0` is returned.
+      ///
+      /// This is different from the standard operator, which behaves like
+      /// [`wrapping_shl`]. For most targets, `unbounded_shl` is faster than the
+      /// standard operator.
+      ///
+      #[doc = concat!("[`wrapping_shl`]: ", stringify!($T), "::wrapping_shl")]
+      #[must_use]
+      $fn_unbounded_shl
 
       #[must_use]
       $fn_saturating_add

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -451,6 +451,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_all_u16_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -397,6 +397,26 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_sllv_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_sllv_epi16;
+
+        // TODO(safe_arch): Add `_mm256_sllv_epi16`.
+        cast(unsafe { _mm256_sllv_epi16(self.avx2.0, rhs.0) })
+      } else {
+        let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+        cast([self_a.unbounded_shl(rhs_a), self_b.unbounded_shl(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -431,6 +431,26 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_srlv_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_srlv_epi16;
+
+        // TODO(safe_arch): Add `_mm256_srlv_epi16`.
+        cast(unsafe { _mm256_srlv_epi16(self.avx2.0, rhs.avx2.0) })
+      } else {
+        let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
+
+        cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -417,6 +417,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shl_all_u16_m256i(self.avx2, [rhs as u64, 0]) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -406,7 +406,7 @@ impl_simd_uint! {
         use core::arch::x86_64::_mm256_sllv_epi16;
 
         // TODO(safe_arch): Add `_mm256_sllv_epi16`.
-        cast(unsafe { _mm256_sllv_epi16(self.avx2.0, rhs.0) })
+        cast(unsafe { _mm256_sllv_epi16(self.avx2.0, rhs.avx2.0) })
       } else {
         let [self_a, self_b] = cast::<u16x16, [u16x8; 2]>(self);
         let [rhs_a, rhs_b] = cast::<u16x16, [u16x8; 2]>(rhs);
@@ -420,7 +420,7 @@ impl_simd_uint! {
   pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx2: shl_all_u16_m256i(self.avx2, [rhs as u64, 0]) }
+        Self { avx2: shl_all_u16_m256i(self.avx2, cast([rhs as u64, 0])) }
       } else {
         Self {
           a: self.a.unbounded_shl_scalar(rhs),

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -431,6 +431,22 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        // `u32 as u16` truncates the higher half so we need to manually
+        // saturate.
+        Self { avx512: shr_all_u16_m512i(self.avx512, rhs.min(u16::MAX as u32) as u16) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -387,6 +387,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: shl_each_u16_m512i(self.avx512, rhs.avx512) }
+      } else {
+        let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+
+        cast([self_a.unbounded_shl(rhs_a), self_b.unbounded_shl(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -401,6 +401,22 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        // `u32 as u16` truncates the higher half so we need to manually
+        // saturate.
+        Self { avx512: shl_all_u16_m512i(self.avx512, rhs.min(u16::MAX as u32) as u16) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -417,6 +417,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512bw")] {
+        Self { avx512: shr_each_u16_m512i(self.avx512, rhs.avx512) }
+      } else {
+        let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
+        let [rhs_a, rhs_b] = cast::<u16x32, [u16x16; 2]>(rhs);
+
+        cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512bw")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -774,6 +774,41 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm_srlv_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm_srlv_epi16;
+
+        // TODO(safe_arch): Add `_mm_srlv_epi16`.
+        cast(unsafe { _mm_srlv_epi16(self.sse.0, rhs.sse.0) })
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // mask to hide `rhs` overflow.
+          Self { neon: vshlq_u16(self.neon, vnegq_s16(cast(rhs))) } & rhs.simd_lt(16)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0] as u32),
+          self_array[1].unbounded_shr(rhs_array[1] as u32),
+          self_array[2].unbounded_shr(rhs_array[2] as u32),
+          self_array[3].unbounded_shr(rhs_array[3] as u32),
+          self_array[4].unbounded_shr(rhs_array[4] as u32),
+          self_array[5].unbounded_shr(rhs_array[5] as u32),
+          self_array[6].unbounded_shr(rhs_array[6] as u32),
+          self_array[7].unbounded_shr(rhs_array[7] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -714,6 +714,40 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm_sllv_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm_sllv_epi16;
+
+        // TODO(safe_arch): Add `_mm_sllv_epi16`.
+        cast(unsafe { _mm_sllv_epi16(self.sse.0, rhs.sse.0) })
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe {
+          // The intrinsic has different semantics so we need to mask ourselves.
+          Self { neon: vshlq_u16(self.neon, cast(rhs.neon)) } & rhs.simd_lt(16)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shl(rhs_array[0] as u32),
+          self_array[1].unbounded_shl(rhs_array[1] as u32),
+          self_array[2].unbounded_shl(rhs_array[2] as u32),
+          self_array[3].unbounded_shl(rhs_array[3] as u32),
+          self_array[4].unbounded_shl(rhs_array[4] as u32),
+          self_array[5].unbounded_shl(rhs_array[5] as u32),
+          self_array[6].unbounded_shl(rhs_array[6] as u32),
+          self_array[7].unbounded_shl(rhs_array[7] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -748,6 +748,32 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shl_all_u16_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        // The intrinsic performs wrapping shift so we need to mask the result.
+        if rhs >= 16 { Self::ZERO } else { Self { simd: u16x8_shl(self.simd, rhs) } }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        // The intrinsic has different semantics so we need to saturate `rhs`.
+        unsafe { Self { neon: vshlq_u16(self.neon, vmovq_n_s16(rhs.min(i16::MAX as u32) as i16)) } }
+      } else {
+        Self { arr: [
+          self.arr[0].unbounded_shl(rhs),
+          self.arr[1].unbounded_shl(rhs),
+          self.arr[2].unbounded_shl(rhs),
+          self.arr[3].unbounded_shl(rhs),
+          self.arr[4].unbounded_shl(rhs),
+          self.arr[5].unbounded_shl(rhs),
+          self.arr[6].unbounded_shl(rhs),
+          self.arr[7].unbounded_shl(rhs),
+        ]}
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -809,6 +809,36 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shr_all_u16_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        if rhs < 16 { Self { simd: u16x8_shr(self.simd, rhs) } } else { Self::ZERO }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_u16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed())) }
+        }
+      } else {
+        Self {
+          arr: [
+            self.arr[0].unbounded_shr(rhs),
+            self.arr[1].unbounded_shr(rhs),
+            self.arr[2].unbounded_shr(rhs),
+            self.arr[3].unbounded_shr(rhs),
+            self.arr[4].unbounded_shr(rhs),
+            self.arr[5].unbounded_shr(rhs),
+            self.arr[6].unbounded_shr(rhs),
+            self.arr[7].unbounded_shr(rhs),
+          ],
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -727,7 +727,7 @@ impl_simd_uint! {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
         unsafe {
           // The intrinsic has different semantics so we need to mask ourselves.
-          Self { neon: vshlq_u16(self.neon, cast(rhs.neon)) } & rhs.simd_lt(16)
+          Self { neon: vshlq_u16(self.neon, vreinterpretq_s16_u16(rhs.neon)) } & rhs.simd_lt(16)
         }
       } else {
         let self_array = self.to_array();
@@ -788,7 +788,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // mask to hide `rhs` overflow.
-          Self { neon: vshlq_u16(self.neon, vnegq_s16(cast(rhs))) } & rhs.simd_lt(16)
+          Self { neon: vshlq_u16(self.neon, vnegq_s16(vreinterpretq_s16_u16(rhs.neon))) } & rhs.simd_lt(16)
         }
       } else {
         let self_array = self.to_array();
@@ -819,7 +819,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_u16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed())) }
+          Self { neon: vshlq_u16(self.neon, vmovq_n_s16(-rhs.min(16).cast_signed() as i16)) }
         }
       } else {
         Self {

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -757,7 +757,7 @@ impl_simd_uint! {
         if rhs >= 16 { Self::ZERO } else { Self { simd: u16x8_shl(self.simd, rhs) } }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         // The intrinsic has different semantics so we need to saturate `rhs`.
-        unsafe { Self { neon: vshlq_u16(self.neon, vmovq_n_s16(rhs.min(i16::MAX as u32) as i16)) } }
+        unsafe { Self { neon: vshlq_u16(self.neon, vmovq_n_s16(rhs.min(16) as i16)) } }
       } else {
         Self { arr: [
           self.arr[0].unbounded_shl(rhs),

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -399,6 +399,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shl_all_u32_m512i(self.avx512, rhs) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -413,6 +413,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_each_u32_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -385,6 +385,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shl_each_u32_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl(rhs.a),
+          b: self.b.unbounded_shl(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -427,6 +427,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_all_u32_m512i(self.avx512, rhs) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -580,6 +580,30 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse: shl_each_u32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // The intrinsic has different semantics so we need to mask ourselves.
+          Self { neon: vshlq_u32(self.neon, cast(rhs.neon)) } & rhs.simd_lt(32)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        cast([
+          self_array[0].unbounded_shl(rhs_array[0]),
+          self_array[1].unbounded_shl(rhs_array[1]),
+          self_array[2].unbounded_shl(rhs_array[2]),
+          self_array[3].unbounded_shl(rhs_array[3]),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -613,7 +613,7 @@ impl_simd_uint! {
         Self { simd: u32x4_shl(self.simd, rhs) } & Self::splat(rhs).simd_lt(32)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         // The intrinsic has different semantics so we need to saturate `rhs`.
-        unsafe { Self { neon: vshlq_u32(self.neon, vmovq_n_s32(rhs.min(i32::MAX as u32) as i32)) } }
+        unsafe { Self { neon: vshlq_u32(self.neon, vmovq_n_s32(rhs.min(32) as i32)) } }
       } else {
         Self { arr: [
           self.arr[0].unbounded_shl(rhs),

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -626,6 +626,31 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse: shr_each_u32_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // mask to hide `rhs` overflow.
+          Self { neon: vshlq_u32(self.neon, vnegq_s32(cast(rhs))) } & rhs.simd_lt(32)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0]),
+          self_array[1].unbounded_shr(rhs_array[1]),
+          self_array[2].unbounded_shr(rhs_array[2]),
+          self_array[3].unbounded_shr(rhs_array[3]),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -651,6 +651,32 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shr_all_u32_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        if rhs < 32 { Self { simd: u32x4_shr(self.simd, rhs) } } else { Self::ZERO }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_u32(self.neon, vmovq_n_s32(-rhs.min(32).cast_signed())) }
+        }
+      } else {
+        Self {
+          arr: [
+            self.arr[0].unbounded_shr(rhs),
+            self.arr[1].unbounded_shr(rhs),
+            self.arr[2].unbounded_shr(rhs),
+            self.arr[3].unbounded_shr(rhs),
+          ],
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -587,7 +587,7 @@ impl_simd_uint! {
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         unsafe {
           // The intrinsic has different semantics so we need to mask ourselves.
-          Self { neon: vshlq_u32(self.neon, cast(rhs.neon)) } & rhs.simd_lt(32)
+          Self { neon: vshlq_u32(self.neon, vreinterpretq_s32_u32(rhs.neon)) } & rhs.simd_lt(32)
         }
       } else {
         let self_array = self.to_array();
@@ -634,7 +634,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // mask to hide `rhs` overflow.
-          Self { neon: vshlq_u32(self.neon, vnegq_s32(cast(rhs))) } & rhs.simd_lt(32)
+          Self { neon: vshlq_u32(self.neon, vnegq_s32(vreinterpretq_s32_u32(rhs.neon))) } & rhs.simd_lt(32)
         }
       } else {
         let self_array = self.to_array();

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -604,6 +604,28 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shl_all_u32_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        // The intrinsic performs wrapping shift so we need to mask the result.
+        Self { simd: u32x4_shl(self.simd, rhs) } & Self::splat(rhs).simd_lt(32)
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        // The intrinsic has different semantics so we need to saturate `rhs`.
+        unsafe { Self { neon: vshlq_u32(self.neon, vmovq_n_s32(rhs.min(i32::MAX as u32) as i32)) } }
+      } else {
+        Self { arr: [
+          self.arr[0].unbounded_shl(rhs),
+          self.arr[1].unbounded_shl(rhs),
+          self.arr[2].unbounded_shl(rhs),
+          self.arr[3].unbounded_shl(rhs),
+        ]}
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -380,6 +380,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shl_all_u32_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -408,6 +408,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_all_u32_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -366,6 +366,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shl_each_u32_m256i(self.avx2, rhs.avx2) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl(rhs.a),
+          b: self.b.unbounded_shl(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -394,6 +394,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_each_u32_m256i(self.avx2, rhs.avx2) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -502,6 +502,24 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse: shl_each_u64_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // The intrinsic has different semantics so we need to mask ourselves.
+          Self { neon: vshlq_u64(self.neon, cast(rhs.neon)) } & rhs.simd_lt(64)
+        }
+      } else {
+        // Cannot use scalar `unbounded_shl` because it takes `u32`, which is
+        // smaller than `u64`.
+        (self << rhs) & rhs.simd_lt(64)
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -509,7 +509,7 @@ impl_simd_uint! {
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
           // The intrinsic has different semantics so we need to mask ourselves.
-          Self { neon: vshlq_u64(self.neon, cast(rhs.neon)) } & rhs.simd_lt(64)
+          Self { neon: vshlq_u64(self.neon, vreinterpretq_s64_u64(rhs.neon)) } & rhs.simd_lt(64)
         }
       } else {
         // Cannot use scalar `unbounded_shl` because it takes `u32`, which is
@@ -547,7 +547,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // mask to hide `rhs` overflow.
-          Self { neon: vshlq_u64(self.neon, vnegq_s64(cast(rhs))) } & rhs.simd_lt(64)
+          Self { neon: vshlq_u64(self.neon, vnegq_s64(vreinterpretq_s64_u64(rhs.neon))) } & rhs.simd_lt(64)
         }
       } else {
         // Cannot use scalar `unbounded_shr` because it takes `u32`, which is
@@ -568,7 +568,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_u64(self.neon, vmovq_n_s64(-rhs.min(64).cast_signed())) }
+          Self { neon: vshlq_u64(self.neon, vmovq_n_s64(-rhs.min(64).cast_signed() as i64)) }
         }
       } else {
         Self {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -520,6 +520,25 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shl_all_u64_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        // The intrinsic performs wrapping shift so we need to mask the result.
+        Self { simd: u64x2_shl(self.simd, rhs) } & Self::splat(rhs as u64).simd_lt(64)
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe { Self { neon: vshlq_u64(self.neon, vmovq_n_s64(rhs as i64)) } }
+      } else {
+        Self { arr: [
+          self.arr[0].unbounded_shl(rhs),
+          self.arr[1].unbounded_shl(rhs),
+        ]}
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -558,6 +558,30 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self { sse: shr_all_u64_m128i(self.sse, cast([rhs as u64, 0])) }
+      } else if #[cfg(target_feature="simd128")] {
+        if rhs < 64 { Self { simd: u64x2_shr(self.simd, rhs) } } else { Self::ZERO }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_u64(self.neon, vmovq_n_s64(-rhs.min(64).cast_signed())) }
+        }
+      } else {
+        Self {
+          arr: [
+            self.arr[0].unbounded_shr(rhs),
+            self.arr[1].unbounded_shr(rhs),
+          ],
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -528,7 +528,7 @@ impl_simd_uint! {
         // The intrinsic performs wrapping shift so we need to mask the result.
         Self { simd: u64x2_shl(self.simd, rhs) } & Self::splat(rhs as u64).simd_lt(64)
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        unsafe { Self { neon: vshlq_u64(self.neon, vmovq_n_s64(rhs as i64)) } }
+        unsafe { Self { neon: vshlq_u64(self.neon, vmovq_n_s64(rhs.min(64) as i64)) } }
       } else {
         Self { arr: [
           self.arr[0].unbounded_shl(rhs),

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -539,6 +539,25 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { sse: shr_each_u64_m128i(self.sse, rhs.sse) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // mask to hide `rhs` overflow.
+          Self { neon: vshlq_u64(self.neon, vnegq_s64(cast(rhs))) } & rhs.simd_lt(64)
+        }
+      } else {
+        // Cannot use scalar `unbounded_shr` because it takes `u32`, which is
+        // smaller than `u64`.
+        (self >> rhs) & rhs.simd_lt(64)
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(any(target_feature="sse2", target_feature="simd128"))] {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -413,6 +413,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_all_u64_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -399,6 +399,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shr_each_u64_m256i(self.avx2, rhs.avx2) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -385,6 +385,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shl_all_u64_m256i(self.avx2, cast([rhs as u64, 0])) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -371,6 +371,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        Self { avx2: shl_each_u64_m256i(self.avx2, rhs.avx2) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl(rhs.a),
+          b: self.b.unbounded_shl(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -411,6 +411,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shl_all_u64_m512i(self.avx512, rhs as u64) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl_scalar(rhs),
+          b: self.b.unbounded_shl_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -425,6 +425,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_each_u64_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr(rhs.a),
+          b: self.b.unbounded_shr(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -397,6 +397,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shl_each_u64_m512i(self.avx512, rhs.avx512) }
+      } else {
+        Self {
+          a: self.a.unbounded_shl(rhs.a),
+          b: self.b.unbounded_shl(rhs.b),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -439,6 +439,20 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    pick! {
+      if #[cfg(target_feature="avx512f")] {
+        Self { avx512: shr_all_u64_m512i(self.avx512, rhs as u64) }
+      } else {
+        Self {
+          a: self.a.unbounded_shr_scalar(rhs),
+          b: self.b.unbounded_shr_scalar(rhs),
+        }
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx512f")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -905,6 +905,42 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    // For x86, this technically can be done explicitly by converting to `u16`
+    // or `u32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          Self { neon: vshlq_u8(self.neon, cast(rhs.neon)) } & rhs.simd_lt(8)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shl(rhs_array[0] as u32),
+          self_array[1].unbounded_shl(rhs_array[1] as u32),
+          self_array[2].unbounded_shl(rhs_array[2] as u32),
+          self_array[3].unbounded_shl(rhs_array[3] as u32),
+          self_array[4].unbounded_shl(rhs_array[4] as u32),
+          self_array[5].unbounded_shl(rhs_array[5] as u32),
+          self_array[6].unbounded_shl(rhs_array[6] as u32),
+          self_array[7].unbounded_shl(rhs_array[7] as u32),
+          self_array[8].unbounded_shl(rhs_array[8] as u32),
+          self_array[9].unbounded_shl(rhs_array[9] as u32),
+          self_array[10].unbounded_shl(rhs_array[10] as u32),
+          self_array[11].unbounded_shl(rhs_array[11] as u32),
+          self_array[12].unbounded_shl(rhs_array[12] as u32),
+          self_array[13].unbounded_shl(rhs_array[13] as u32),
+          self_array[14].unbounded_shl(rhs_array[14] as u32),
+          self_array[15].unbounded_shl(rhs_array[15] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -978,6 +978,44 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that may
+    // not actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // mask to hide `rhs` overflow.
+          Self { neon: vshlq_u8(self.neon, vnegq_s8(cast(rhs))) } & rhs.simd_lt(8)
+        }
+      } else {
+        let self_array = self.to_array();
+        let rhs_array = rhs.to_array();
+
+        Self::new([
+          self_array[0].unbounded_shr(rhs_array[0] as u32),
+          self_array[1].unbounded_shr(rhs_array[1] as u32),
+          self_array[2].unbounded_shr(rhs_array[2] as u32),
+          self_array[3].unbounded_shr(rhs_array[3] as u32),
+          self_array[4].unbounded_shr(rhs_array[4] as u32),
+          self_array[5].unbounded_shr(rhs_array[5] as u32),
+          self_array[6].unbounded_shr(rhs_array[6] as u32),
+          self_array[7].unbounded_shr(rhs_array[7] as u32),
+          self_array[8].unbounded_shr(rhs_array[8] as u32),
+          self_array[9].unbounded_shr(rhs_array[9] as u32),
+          self_array[10].unbounded_shr(rhs_array[10] as u32),
+          self_array[11].unbounded_shr(rhs_array[11] as u32),
+          self_array[12].unbounded_shr(rhs_array[12] as u32),
+          self_array[13].unbounded_shr(rhs_array[13] as u32),
+          self_array[14].unbounded_shr(rhs_array[14] as u32),
+          self_array[15].unbounded_shr(rhs_array[15] as u32),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -948,7 +948,7 @@ impl_simd_uint! {
     pick! {
       if #[cfg(target_feature="simd128")] {
         // The intrinsic performs wrapping shift so we need to mask the result.
-        if rhs >= 8 { Self::ZERO } else { Self { simd: u8x16_shl(self.simd, rhs) } };
+        if rhs >= 8 { Self::ZERO } else { Self { simd: u8x16_shl(self.simd, rhs) } }
       } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
         // The intrinsic has different semantics so we need to saturate `rhs`.
         unsafe { Self { neon: vshlq_u8(self.neon, vmovq_n_s8(rhs.min(i8::MAX as u32) as i8)) } }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -941,6 +941,43 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        // The intrinsic performs wrapping shift so we need to mask the result.
+        if rhs >= 8 { Self::ZERO } else { Self { simd: u8x16_shl(self.simd, rhs) } };
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        // The intrinsic has different semantics so we need to saturate `rhs`.
+        unsafe { Self { neon: vshlq_u8(self.neon, vmovq_n_s8(rhs.min(i8::MAX as u32) as i8)) } }
+      } else {
+        let self_array = self.to_array();
+
+        cast([
+          self_array[0].unbounded_shl(rhs),
+          self_array[1].unbounded_shl(rhs),
+          self_array[2].unbounded_shl(rhs),
+          self_array[3].unbounded_shl(rhs),
+          self_array[4].unbounded_shl(rhs),
+          self_array[5].unbounded_shl(rhs),
+          self_array[6].unbounded_shl(rhs),
+          self_array[7].unbounded_shl(rhs),
+          self_array[8].unbounded_shl(rhs),
+          self_array[9].unbounded_shl(rhs),
+          self_array[10].unbounded_shl(rhs),
+          self_array[11].unbounded_shl(rhs),
+          self_array[12].unbounded_shl(rhs),
+          self_array[13].unbounded_shl(rhs),
+          self_array[14].unbounded_shl(rhs),
+          self_array[15].unbounded_shl(rhs),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -912,7 +912,7 @@ impl_simd_uint! {
     pick! {
       if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         unsafe {
-          Self { neon: vshlq_u8(self.neon, cast(rhs.neon)) } & rhs.simd_lt(8)
+          Self { neon: vshlq_u8(self.neon, vreinterpretq_s8_u8(rhs.neon)) } & rhs.simd_lt(8)
         }
       } else {
         let self_array = self.to_array();
@@ -987,7 +987,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // mask to hide `rhs` overflow.
-          Self { neon: vshlq_u8(self.neon, vnegq_s8(cast(rhs))) } & rhs.simd_lt(8)
+          Self { neon: vshlq_u8(self.neon, vnegq_s8(vreinterpretq_s8_u8(rhs.neon))) } & rhs.simd_lt(8)
         }
       } else {
         let self_array = self.to_array();
@@ -1027,7 +1027,7 @@ impl_simd_uint! {
         unsafe {
           // Negate `rhs` because there is no direct shift-right intrinsic, and
           // restrict it to prevent overflow.
-          Self { neon: vshlq_u8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed())) }
+          Self { neon: vshlq_u8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed() as i8)) }
         }
       } else {
         let self_array = self.to_array();

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1016,6 +1016,45 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    pick! {
+      if #[cfg(target_feature="simd128")] {
+        if rhs < 8 { Self { simd: u8x16_shr(self.simd, rhs) } } else { Self::ZERO }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        unsafe {
+          // Negate `rhs` because there is no direct shift-right intrinsic, and
+          // restrict it to prevent overflow.
+          Self { neon: vshlq_u8(self.neon, vmovq_n_s8(-rhs.min(8).cast_signed())) }
+        }
+      } else {
+        let self_array = self.to_array();
+
+        cast([
+          self_array[0].unbounded_shr(rhs),
+          self_array[1].unbounded_shr(rhs),
+          self_array[2].unbounded_shr(rhs),
+          self_array[3].unbounded_shr(rhs),
+          self_array[4].unbounded_shr(rhs),
+          self_array[5].unbounded_shr(rhs),
+          self_array[6].unbounded_shr(rhs),
+          self_array[7].unbounded_shr(rhs),
+          self_array[8].unbounded_shr(rhs),
+          self_array[9].unbounded_shr(rhs),
+          self_array[10].unbounded_shr(rhs),
+          self_array[11].unbounded_shr(rhs),
+          self_array[12].unbounded_shr(rhs),
+          self_array[13].unbounded_shr(rhs),
+          self_array[14].unbounded_shr(rhs),
+          self_array[15].unbounded_shr(rhs),
+        ])
+      }
+    }
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="sse2")] {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -393,6 +393,15 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    cast([self_a.unbounded_shr_scalar(rhs), self_b.unbounded_shr_scalar(rhs)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -364,6 +364,16 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl(self, rhs: Self) -> Self {
+    // For x86, this technically can be done explicitly by converting to `u16`
+    // or `u32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+    cast([self_a.unbounded_shl(rhs_a), self_b.unbounded_shl(rhs_b)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -374,6 +374,15 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shl_scalar(self, rhs: u32) -> Self {
+    // For x86, this technically can be done explicitly by converting
+    // to `u16` or `u32` then converting back after multiplication, but that
+    // may not actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    cast([self_a.unbounded_shl_scalar(rhs), self_b.unbounded_shl_scalar(rhs)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -383,6 +383,16 @@ impl_simd_uint! {
   }
 
   #[inline]
+  pub fn unbounded_shr(self, rhs: Self) -> Self {
+    // For x86, this technically can be done explicitly by converting to `u16`
+    // or `u32` then converting back after multiplication, but that may not
+    // actually be faster than auto-vectorization.
+    let [self_a, self_b] = cast::<u8x32, [u8x16; 2]>(self);
+    let [rhs_a, rhs_b] = cast::<u8x32, [u8x16; 2]>(rhs);
+    cast([self_a.unbounded_shr(rhs_a), self_b.unbounded_shr(rhs_b)])
+  }
+
+  #[inline]
   pub fn saturating_add(self, rhs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -6,6 +6,77 @@ use wide::{
 use crate::utils::{for_simd_types, random_iter, simd_chunks};
 
 #[test]
+fn test_unbounded_shl() {
+  for_simd_types!(|T: Signed, N| {
+    for (left, right) in simd_chunks!(
+      [
+        1,
+        2,
+        T::MAX - 1,
+        -123,
+        -121,
+        53,
+        -60,
+        -49,
+        T::MAX / 2,
+        T::MIN + 1,
+        T::MIN / 2,
+        -121,
+        53,
+      ],
+      [1, 0, 3, 2, -1, 6, 100, 0, 4, 1, 3, -101, 123],
+    )
+    .chain(random_iter())
+    .map(|[left, right]| (left, right.map(T::cast_unsigned)))
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        // Cannot use `as u32` because that truncates, not saturates.
+        left[i].unbounded_shl((right[i] as u128).min(u32::MAX as u128) as u32)
+      }));
+      let actual = Simd::new(left).unbounded_shl(SimdUnsigned::new(right));
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MAX - 1,
+        T::MAX - 122,
+        T::MAX - 120,
+        53,
+        T::MAX - 59,
+        T::MAX - 48,
+        T::MAX / 4,
+        T::MAX / 2,
+        T::MAX / 4,
+        T::MAX - 120,
+        53,
+      ],
+      [1, 0, 3, 2, T::MAX, 6, 100, 0, 4, 1, 3, T::MAX - 100, 123],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        // Cannot use `as u32` because that truncates, not saturates.
+        left[i].unbounded_shl((right[i] as u128).min(u32::MAX as u128) as u32)
+      }));
+      let actual = Simd::new(left).unbounded_shl(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+}
+
+#[test]
 fn test_saturating_add() {
   for_simd_types!(|T: Integer, N| {
     for [left, right] in simd_chunks!(

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -77,6 +77,209 @@ fn test_unbounded_shl() {
 }
 
 #[test]
+fn test_unbounded_shl_scalar() {
+  for_simd_types!(|T: Signed, N| {
+    for (left, right) in simd_chunks!([
+      1,
+      2,
+      T::MAX - 1,
+      -123,
+      -121,
+      53,
+      -60,
+      -49,
+      T::MAX / 2,
+      T::MIN + 1,
+      T::MIN / 2,
+      -121,
+      53,
+    ],)
+    .flat_map(|left| {
+      [1, 0, 3, 2, 6, 100, 0, 4, 1, 3, 123].map(|right| (left, right))
+    })
+    .chain(random_iter())
+    {
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].unbounded_shl(right)));
+      let actual = Simd::new(left).unbounded_shl_scalar(right);
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for (left, right) in simd_chunks!([
+      1,
+      2,
+      T::MAX - 1,
+      T::MAX - 122,
+      T::MAX - 120,
+      53,
+      T::MAX - 59,
+      T::MAX - 48,
+      T::MAX / 4,
+      T::MAX / 2,
+      T::MAX / 4,
+      T::MAX - 120,
+      53,
+    ],)
+    .flat_map(|left| {
+      [1, 0, 3, 2, 6, 100, 0, 4, 1, 3, 123].map(|right| (left, right))
+    })
+    .chain(random_iter())
+    {
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].unbounded_shl(right)));
+      let actual = Simd::new(left).unbounded_shl_scalar(right);
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+}
+
+#[test]
+fn test_unbounded_shr() {
+  for_simd_types!(|T: Signed, N| {
+    for (left, right) in simd_chunks!(
+      [
+        1,
+        2,
+        T::MAX - 1,
+        -123,
+        -121,
+        53,
+        -60,
+        -49,
+        T::MAX / 2,
+        T::MIN + 1,
+        T::MIN / 2,
+        -121,
+        53,
+      ],
+      [1, 0, 3, 2, -1, 6, 100, 0, 4, 1, 3, -101, 123],
+    )
+    .chain(random_iter())
+    .map(|[left, right]| (left, right.map(T::cast_unsigned)))
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        // Cannot use `as u32` because that truncates, not saturates.
+        left[i].unbounded_shr((right[i] as u128).min(u32::MAX as u128) as u32)
+      }));
+      let actual = Simd::new(left).unbounded_shr(SimdUnsigned::new(right));
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for [left, right] in simd_chunks!(
+      [
+        1,
+        2,
+        T::MAX - 1,
+        T::MAX - 122,
+        T::MAX - 120,
+        53,
+        T::MAX - 59,
+        T::MAX - 48,
+        T::MAX / 4,
+        T::MAX / 2,
+        T::MAX / 4,
+        T::MAX - 120,
+        53,
+      ],
+      [1, 0, 3, 2, T::MAX, 6, 100, 0, 4, 1, 3, T::MAX - 100, 123],
+    )
+    .chain(random_iter())
+    {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        // Cannot use `as u32` because that truncates, not saturates.
+        left[i].unbounded_shr((right[i] as u128).min(u32::MAX as u128) as u32)
+      }));
+      let actual = Simd::new(left).unbounded_shr(Simd::new(right));
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+}
+
+#[test]
+fn test_unbounded_shr_scalar() {
+  for_simd_types!(|T: Signed, N| {
+    for (left, right) in simd_chunks!([
+      1,
+      2,
+      T::MAX - 1,
+      -123,
+      -121,
+      53,
+      -60,
+      -49,
+      T::MAX / 2,
+      T::MIN + 1,
+      T::MIN / 2,
+      -121,
+      53,
+    ],)
+    .flat_map(|left| {
+      [1, 0, 3, 2, 6, 100, 0, 4, 1, 3, 123].map(|right| (left, right))
+    })
+    .chain(random_iter())
+    {
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].unbounded_shr(right)));
+      let actual = Simd::new(left).unbounded_shr_scalar(right);
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+  for_simd_types!(|T: Unsigned, N| {
+    for (left, right) in simd_chunks!([
+      1,
+      2,
+      T::MAX - 1,
+      T::MAX - 122,
+      T::MAX - 120,
+      53,
+      T::MAX - 59,
+      T::MAX - 48,
+      T::MAX / 4,
+      T::MAX / 2,
+      T::MAX / 4,
+      T::MAX - 120,
+      53,
+    ],)
+    .flat_map(|left| {
+      [1, 0, 3, 2, 6, 100, 0, 4, 1, 3, 123].map(|right| (left, right))
+    })
+    .chain(random_iter())
+    {
+      let expected =
+        Simd::new(std::array::from_fn(|i| left[i].unbounded_shr(right)));
+      let actual = Simd::new(left).unbounded_shr_scalar(right);
+
+      assert!(
+        actual == expected,
+        "\nexpected: {expected:?}\n  actual: {actual:?}\n    left: {left:?}\n   right: {right:?}",
+      );
+    }
+  });
+}
+
+#[test]
 fn test_saturating_add() {
   for_simd_types!(|T: Integer, N| {
     for [left, right] in simd_chunks!(


### PR DESCRIPTION
Existing shift operators mask the shift amount by the number of bits per lane. This is done manually and has a small overhead. This PR adds `unbounded_shl`, `unbounded_shl_scalar`, `unbounded_shr` and `unbounded_shr_scalar` which don't mask the shift amount, and recommends using those over the standard operators in documentation.

For x86 these are faster, for neon they're the same since both don't have direct intrinsics, and on wasm they are slower since the intrinsics perform wrapping shift.

For SIMD x SIMD this takes an unsigned integer as `rhs` (like `i32::unbounded_shl` takes `u32`, not `i32`), and all SIMD x scalar functions take `u32` as `rhs` (like `u16::unbounded_shl` takes `u32`, not `u16`).

For 8-bit types types this keeps the broken comments from the standard operators which were pointed out by @RagnarGrootKoerkamp.