### PR TITLE
feat: Add dynamic swizzle functions for all types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
 * Fixed the `signum` documentation: the docs previously misstated the grammar
   and the set of inputs that map to `1.0`/`-1.0`. The behavior itself was
   already correct and matches [`f32::signum`].
+* Added dynamic swizzling functions `swizzle_dyn` and `zeroing_swizzle_dyn` for
+  all types, and deprecated the old 8-bit element functions `swizzle` and
+  `swizzle_relaxed`.
 
 ## 1.6.1
 

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -191,6 +191,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -193,35 +193,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm512_permutexvar_ps;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm512_permutexvar_ps;
-        // TODO(safe_arch): Add `_mm512_permutexvar_ps`.
-        Self { avx512: m512(unsafe { _mm512_permutexvar_ps(idxs.avx512.0, self.avx512.0) }) }
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        // Except for avx512, there are no float-specific intrinsics for this,
-        // so reuse integer implementation
-        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
-      } else {
-        let eight = u32x8::splat(8);
-        let [self_a, self_b] = cast::<f32x16, [f32x8; 2]>(self);
-        let [idxs_a, idxs_b] = cast::<u32x16, [u32x8; 2]>(idxs);
-        // Use zeroing swizzle to ignore overflowing subtraction.
-        cast([
-          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - eight),
-          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - eight),
-        ])
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
-    // All implementations do not have the masking behavior we want
-    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(16))
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f32x16_.rs
+++ b/src/f32x16_.rs
@@ -193,12 +193,35 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_permutexvar_ps;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_permutexvar_ps;
+        // TODO(safe_arch): Add `_mm512_permutexvar_ps`.
+        Self { avx512: m512(unsafe { _mm512_permutexvar_ps(idxs.avx512.0, self.avx512.0) }) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // Except for avx512, there are no float-specific intrinsics for this,
+        // so reuse integer implementation
+        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
+      } else {
+        let eight = u32x8::splat(8);
+        let [self_a, self_b] = cast::<f32x16, [f32x8; 2]>(self);
+        let [idxs_a, idxs_b] = cast::<u32x16, [u32x8; 2]>(idxs);
+        // Use zeroing swizzle to ignore overflowing subtraction.
+        cast([
+          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - eight),
+          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - eight),
+        ])
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    // All implementations do not have the masking behavior we want
+    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(16))
   }
 
   ///

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -301,15 +301,15 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
-    // There are no float-specific intrinsics for this, so reuse integer
-    // implementation
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
     Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
-    // There are no float-specific intrinsics for this, so reuse integer
-    // implementation
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
     Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -301,12 +301,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    // There are no float-specific intrinsics for this, so reuse integer
+    // implementation
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    // There are no float-specific intrinsics for this, so reuse integer
+    // implementation
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f32x4_.rs
+++ b/src/f32x4_.rs
@@ -299,6 +299,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `sse`.
   #[inline]

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -193,54 +193,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_ps;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_ps;
-        // TODO(safe_arch): Add `_mm256_permutexvar_ps`.
-        Self { avx: m256(unsafe { _mm256_permutexvar_ps(idxs.avx2.0, self.avx.0) }) }
-      } else if #[cfg(any(
-        target_feature = "sse2",
-        all(target_arch = "aarch64", target_feature = "neon"),
-        target_feature = "simd128",
-      ))] {
-        // Except for avx512, there are no float-specific intrinsics for this,
-        // so reuse integer implementation
-        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
-      } else {
-        let self_array = self.to_array();
-        let idxs_array = idxs.to_array();
-
-        let mut result = [0.0; 8];
-        for i in 0..8 {
-          let idx = idxs_array[i] as usize;
-          if idx < 8 {
-            result[i] = self_array[idx];
-          }
-        }
-
-        Self::new(result)
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
-    pick! {
-      if #[cfg(any(
-        target_feature = "sse2",
-        all(target_arch = "aarch64", target_feature = "neon"),
-        target_feature = "simd128",
-      ))] {
-        // All implementations except for the fallback do not have the masking
-        // behavior we want
-        self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(8))
-      } else {
-        self.swizzle_dyn(idxs)
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -193,12 +193,54 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_ps;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_ps;
+        // TODO(safe_arch): Add `_mm256_permutexvar_ps`.
+        Self { avx: m256(unsafe { _mm256_permutexvar_ps(idxs.avx2.0, self.avx.0) }) }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // Except for avx512, there are no float-specific intrinsics for this,
+        // so reuse integer implementation
+        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0.0; 8];
+        for i in 0..8 {
+          let idx = idxs_array[i] as usize;
+          if idx < 8 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(8))
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/f32x8_.rs
+++ b/src/f32x8_.rs
@@ -191,6 +191,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx`.
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -286,38 +286,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
-    pick! {
-      if #[cfg(target_feature="sse2")] {
-        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
-      } else if #[cfg(target_feature="simd128")] {
-        let e0 = Self { simd: i64x2_shuffle::<0, 0>(self.simd, self.simd) };
-        let e1 = Self { simd: i64x2_shuffle::<1, 1>(self.simd, self.simd) };
-
-        // We can assume that each index is either `0` or `1`, and negating that
-        // always gives us either all bits zero or all bits one.
-        Self::from_bits(-idxs).select(e1, e0)
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
-        let e0 = unsafe { Self { neon: vdupq_n_f64(vget_lane_f64::<0>(vget_low_f64(self.neon))) } };
-        let e1 = unsafe { Self { neon: vdupq_n_f64(vget_lane_f64::<0>(vget_high_f64(self.neon))) } };
-
-        // We can assume that each index is either `0` or `1`, and negating that
-        // always gives us either all bits zero or all bits one.
-        Self::from_bits(-idxs).select(e1, e0)
-      } else {
-        let e0 = Self::splat(self.as_array()[0]);
-        let e1 = Self::splat(self.as_array()[1]);
-
-        // We can assume that each index is either `0` or `1`, and negating that
-        // always gives us either all bits zero or all bits one.
-        Self::from_bits(-idxs).select(e1, e0)
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
-    // Since all implementations use the `select` trick, we always need to mask
-    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(2))
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -284,6 +284,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
   ///
   /// This function is accelerated on multiple target architectures.
   #[inline]

--- a/src/f64x2_.rs
+++ b/src/f64x2_.rs
@@ -286,12 +286,38 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
+      } else if #[cfg(target_feature="simd128")] {
+        let e0 = Self { simd: i64x2_shuffle::<0, 0>(self.simd, self.simd) };
+        let e1 = Self { simd: i64x2_shuffle::<1, 1>(self.simd, self.simd) };
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        Self::from_bits(-idxs).select(e1, e0)
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        let e0 = unsafe { Self { neon: vdupq_n_f64(vget_lane_f64::<0>(vget_low_f64(self.neon))) } };
+        let e1 = unsafe { Self { neon: vdupq_n_f64(vget_lane_f64::<0>(vget_high_f64(self.neon))) } };
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        Self::from_bits(-idxs).select(e1, e0)
+      } else {
+        let e0 = Self::splat(self.as_array()[0]);
+        let e1 = Self::splat(self.as_array()[1]);
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        Self::from_bits(-idxs).select(e1, e0)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    // Since all implementations use the `select` trick, we always need to mask
+    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(2))
   }
 
   ///

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -193,54 +193,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_pd;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_pd;
-        // TODO(safe_arch): Add `_mm256_permutexvar_pd`.
-        Self { avx: m256d(unsafe { _mm256_permutexvar_pd(idxs.avx2.0, self.avx.0) }) }
-      } else if #[cfg(any(
-        target_feature = "sse2",
-        all(target_arch = "aarch64", target_feature = "neon"),
-        target_feature = "simd128",
-      ))] {
-        // Except for avx512, there are no float-specific intrinsics for this,
-        // so reuse integer implementation
-        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
-      } else {
-        let self_array = self.to_array();
-        let idxs_array = idxs.to_array();
-
-        let mut result = [0.0; 4];
-        for i in 0..4 {
-          let idx = idxs_array[i] as usize;
-          if idx < 4 {
-            result[i] = self_array[idx];
-          }
-        }
-
-        Self::new(result)
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
-    pick! {
-      if #[cfg(any(
-        target_feature = "sse2",
-        all(target_arch = "aarch64", target_feature = "neon"),
-        target_feature = "simd128",
-      ))] {
-        // All implementations except for the fallback do not have the masking
-        // behavior we want
-        self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(4))
-      } else {
-        self.swizzle_dyn(idxs)
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -193,12 +193,54 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_pd;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_pd;
+        // TODO(safe_arch): Add `_mm256_permutexvar_pd`.
+        Self { avx: m256d(unsafe { _mm256_permutexvar_pd(idxs.avx2.0, self.avx.0) }) }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // Except for avx512, there are no float-specific intrinsics for this,
+        // so reuse integer implementation
+        Self::from_bits(self.to_bits().swizzle_dyn(idxs))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0.0; 4];
+        for i in 0..4 {
+          let idx = idxs_array[i] as usize;
+          if idx < 4 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(4))
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/f64x4_.rs
+++ b/src/f64x4_.rs
@@ -191,6 +191,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx`.
   #[inline]

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -193,31 +193,16 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
-    pick! {
-      if #[cfg(all(target_feature="avx512f"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm512_permutexvar_pd;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm512_permutexvar_pd;
-        // TODO(safe_arch): Add `_mm512_permutexvar_pd`.
-        Self { avx512: m512d(unsafe { _mm512_permutexvar_pd(idxs.avx512.0, self.avx512.0) }) }
-      } else {
-        let four = u64x4::splat(4);
-        let [self_a, self_b] = cast::<f64x8, [f64x4; 2]>(self);
-        let [idxs_a, idxs_b] = cast::<u64x8, [u64x4; 2]>(idxs);
-        // Use zeroing swizzle to ignore overflowing subtraction.
-        cast([
-          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - four),
-          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - four),
-        ])
-      }
-    }
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().swizzle_dyn(idxs))
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
-    // All implementations do not have the masking behavior we want
-    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(8))
+    // Reusing integer intrinsics for floats is unlikely to affect performance
+    // here
+    Self::from_bits(self.to_bits().zeroing_swizzle_dyn(idxs))
   }
 
   ///

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -193,12 +193,31 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_permutexvar_pd;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_permutexvar_pd;
+        // TODO(safe_arch): Add `_mm512_permutexvar_pd`.
+        Self { avx512: m512d(unsafe { _mm512_permutexvar_pd(idxs.avx512.0, self.avx512.0) }) }
+      } else {
+        let four = u64x4::splat(4);
+        let [self_a, self_b] = cast::<f64x8, [f64x4; 2]>(self);
+        let [idxs_a, idxs_b] = cast::<u64x8, [u64x4; 2]>(idxs);
+        // Use zeroing swizzle to ignore overflowing subtraction.
+        cast([
+          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - four),
+          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - four),
+        ])
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    // All implementations do not have the masking behavior we want
+    self.swizzle_dyn(idxs) & Self::from_bits(idxs.simd_lt(8))
   }
 
   ///

--- a/src/f64x8_.rs
+++ b/src/f64x8_.rs
@@ -191,6 +191,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -185,6 +185,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i16x16_.rs
+++ b/src/i16x16_.rs
@@ -187,12 +187,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x16) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x16) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -187,12 +187,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x32) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x32) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i16x32_.rs
+++ b/src/i16x32_.rs
@@ -185,6 +185,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x32) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x32) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -336,6 +336,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x8) -> Self {
+    todo!()
+  }
+
   ///
   /// This function is accelerated on multiple target architectures.
   #[inline]

--- a/src/i16x8_.rs
+++ b/src/i16x8_.rs
@@ -338,12 +338,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x8) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x8) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -186,6 +186,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i32x16_.rs
+++ b/src/i32x16_.rs
@@ -188,12 +188,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -313,6 +313,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `sse`.
   #[inline]

--- a/src/i32x4_.rs
+++ b/src/i32x4_.rs
@@ -315,12 +315,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -187,12 +187,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i32x8_.rs
+++ b/src/i32x8_.rs
@@ -185,6 +185,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx2`.
   #[inline]

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -298,12 +298,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -296,6 +296,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
   ///
   /// This function is accelerated on multiple target architectures.
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -189,6 +189,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx2`.
   #[inline]

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -191,12 +191,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -191,6 +191,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i64x8_.rs
+++ b/src/i64x8_.rs
@@ -193,12 +193,12 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -396,6 +396,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u8x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -396,6 +396,10 @@ impl_simd! {
     }
   }
 
+  ///
+  /// For [`i8x16`] specifically it is guaranteed that for overflows, if the high
+  /// bit of the index is set, zero is returned. Otherwise, either zero is
+  /// returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
     todo!()

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -1190,30 +1190,17 @@ impl i8x16 {
   /// * Index values in the range `[0, 15]` select the i-th element of `self`.
   /// * Index values that are out of range will cause that output lane to be
   ///   `0`.
+  ///
+  /// This function has been replaced by [`zeroing_swizzle_dyn`], which has the
+  /// same semantics and guarantees (though it takes unsigned integers as
+  /// indices instead of signed integers).
+  ///
+  /// [`zeroing_swizzle_dyn`]: Self::zeroing_swizzle_dyn
   #[inline]
-  pub fn swizzle(self, rhs: i8x16) -> i8x16 {
-    pick! {
-      if #[cfg(target_feature="ssse3")] {
-        Self { sse: shuffle_av_i8z_all_m128i(self.sse, add_saturating_u8_m128i(rhs.sse, set_splat_i8_m128i(0x70))) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd: i8x16_swizzle(self.simd, rhs.simd) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        unsafe { Self { neon: vqtbl1q_s8(self.neon, vreinterpretq_u8_s8(rhs.neon)) } }
-      } else {
-        let idxs = rhs.to_array();
-        let arr = self.to_array();
-        let mut out = [0i8;16];
-        for i in 0..16 {
-          let idx = idxs[i] as usize;
-          if idx >= 16 {
-            out[i] = 0;
-          } else {
-            out[i] = arr[idx];
-          }
-        }
-        Self::new(out)
-      }
-    }
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `zeroing_swizzle_dyn`")]
+  pub fn swizzle(self, idxs: Self) -> Self {
+    self.zeroing_swizzle_dyn(idxs.cast_unsigned())
   }
 
   /// Works like [`swizzle`](Self::swizzle) with the following additional
@@ -1224,29 +1211,16 @@ impl i8x16 {
   ///   negative), then the corresponding output lane is guaranteed to be zero.
   /// * Otherwise the output lane is either `0` or `self[rhs[i] % 16]`,
   ///   depending on the implementation.
+  ///
+  /// This function has been replaced by [`swizzle_dyn`], which has the same
+  /// semantics and guarantees (though it takes unsigned integers as
+  /// indices instead of signed integers).
+  ///
+  /// [`swizzle_dyn`]: Self::swizzle_dyn
   #[inline]
-  pub fn swizzle_relaxed(self, rhs: i8x16) -> i8x16 {
-    pick! {
-      if #[cfg(target_feature="ssse3")] {
-        Self { sse: shuffle_av_i8z_all_m128i(self.sse, rhs.sse) }
-      } else if #[cfg(target_feature="simd128")] {
-        Self { simd: i8x16_swizzle(self.simd, rhs.simd) }
-      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
-        unsafe { Self { neon: vqtbl1q_s8(self.neon, vreinterpretq_u8_s8(rhs.neon)) } }
-      } else {
-        let idxs = rhs.to_array();
-        let arr = self.to_array();
-        let mut out = [0i8;16];
-        for i in 0..16 {
-          let idx = idxs[i] as usize;
-          if idx >= 16 {
-            out[i] = 0;
-          } else {
-            out[i] = arr[idx];
-          }
-        }
-        Self::new(out)
-      }
-    }
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `swizzle_dyn`")]
+  pub fn swizzle_relaxed(self, idxs: Self) -> Self {
+    self.swizzle_dyn(idxs.cast_unsigned())
   }
 }

--- a/src/i8x16_.rs
+++ b/src/i8x16_.rs
@@ -402,12 +402,12 @@ impl_simd! {
   /// returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u8x16) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -492,14 +492,15 @@ impl i8x32 {
   /// two halves of the vector, and the indexes each refer to the
   /// corresponding half.
   #[inline]
-  pub fn swizzle_half(self, rhs: i8x32) -> i8x32 {
+  #[must_use]
+  pub fn swizzle_half(self, idxs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: shuffle_av_i8z_half_m256i(self.avx, add_saturating_u8_m256i(rhs.avx, set_splat_i8_m256i(0x70))) }
+        Self { avx: shuffle_av_i8z_half_m256i(self.avx, add_saturating_u8_m256i(idxs.avx, set_splat_i8_m256i(0x70))) }
       } else {
           Self {
-            a : self.a.swizzle(rhs.a),
-            b : self.b.swizzle(rhs.b),
+            a : self.a.zeroing_swizzle_dyn(idxs.a.cast_unsigned()),
+            b : self.b.zeroing_swizzle_dyn(idxs.b.cast_unsigned()),
           }
       }
     }
@@ -515,14 +516,15 @@ impl i8x32 {
   /// halves of the vector, and the indexes each refer to their corresponding
   /// half.
   #[inline]
-  pub fn swizzle_half_relaxed(self, rhs: i8x32) -> i8x32 {
+  #[must_use]
+  pub fn swizzle_half_relaxed(self, idxs: Self) -> Self {
     pick! {
       if #[cfg(target_feature="avx2")] {
-        Self { avx: shuffle_av_i8z_half_m256i(self.avx, rhs.avx) }
+        Self { avx: shuffle_av_i8z_half_m256i(self.avx, idxs.avx) }
       } else {
         Self {
-          a : self.a.swizzle_relaxed(rhs.a),
-          b : self.b.swizzle_relaxed(rhs.b),
+          a : self.a.swizzle_dyn(idxs.a.cast_unsigned()),
+          b : self.b.swizzle_dyn(idxs.b.cast_unsigned()),
         }
       }
     }
@@ -535,95 +537,32 @@ impl i8x32 {
   ///
   /// Unlike [`swizzle_half`](Self::swizzle_half), indices address the entire
   /// 32-byte vector, not just their own 16-byte half.
+  ///
+  /// This function has been replaced by [`zeroing_swizzle_dyn`], which has the
+  /// same semantics and guarantees (though it takes unsigned integers as
+  /// indices instead of signed integers).
+  ///
+  /// [`zeroing_swizzle_dyn`]: Self::zeroing_swizzle_dyn
   #[inline]
-  pub fn swizzle(self, rhs: i8x32) -> i8x32 {
-    pick! {
-      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_epi8;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_epi8;
-        // vpermb takes the index mod 32 and never zeroes, so zero the
-        // out-of-range lanes ourselves: (rhs & 0xE0) == 0  <=>  rhs < 32.
-        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
-        let permuted = m256i(unsafe { _mm256_permutexvar_epi8(rhs.avx.0, self.avx.0) });
-        let hi_bits = bitand_m256i(rhs.avx, set_splat_i8_m256i(0xE0_u8 as i8));
-        let in_range = cmp_eq_mask_i8_m256i(hi_bits, zeroed_m256i());
-        Self { avx: bitand_m256i(permuted, in_range) }
-      } else if #[cfg(target_feature="avx2")] {
-        // Broadcast each 16-byte table half into both 128-bit lanes, pshufb
-        // each by the index, blend by index bit 4. Fold the >=32 zeroing into
-        // pshufb with an unsigned saturating add of 0x60 (0x60 + 32 = 0x80).
-        let idx = add_saturating_u8_m256i(rhs.avx, set_splat_i8_m256i(0x60));
-        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
-        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
-        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, idx);
-        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, idx);
-        // move index bit 4 into the sign bit (bit 7) for blendv.
-        let sel = shl_imm_u16_m256i::<3>(rhs.avx);
-        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        use core::arch::aarch64::{int8x16x2_t, vqtbl2q_s8, vreinterpretq_u8_s8};
-        unsafe {
-          let table = int8x16x2_t(self.a.neon, self.b.neon);
-          Self {
-            a: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.a.neon)) },
-            b: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.b.neon)) },
-          }
-        }
-      } else {
-        // Generic {a,b}: each output half pulls from either table half.
-        // a.swizzle / b.swizzle are STRICT (zero index >= 16), and their
-        // nonzero domains are disjoint, so a bitwise OR selects correctly and
-        // out-of-range (>=32) falls out as 0 with no extra mask.
-        let sixteen = i8x16::splat(16);
-        Self {
-          a: self.a.swizzle(rhs.a) | self.b.swizzle(rhs.a - sixteen),
-          b: self.a.swizzle(rhs.b) | self.b.swizzle(rhs.b - sixteen),
-        }
-      }
-    }
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `zeroing_swizzle_dyn`")]
+  pub fn swizzle(self, idxs: Self) -> Self {
+    self.zeroing_swizzle_dyn(idxs.cast_unsigned())
   }
 
   /// Like [`swizzle`](Self::swizzle), but out-of-range indices (unsigned
   /// `>= 32`) yield an implementation-defined result (`0` or `self[index % 32]`).
   /// Prefer this when you know all indices are in range; it can be cheaper.
+  ///
+  /// This function has been replaced by [`swizzle_dyn`], which has the same
+  /// semantics and guarantees (though it takes unsigned integers as
+  /// indices instead of signed integers).
+  ///
+  /// [`swizzle_dyn`]: Self::swizzle_dyn
   #[inline]
-  pub fn swizzle_relaxed(self, rhs: i8x32) -> i8x32 {
-    pick! {
-      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_epi8;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_epi8;
-        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
-        Self { avx: m256i(unsafe { _mm256_permutexvar_epi8(rhs.avx.0, self.avx.0) }) }
-      } else if #[cfg(target_feature="avx2")] {
-        // Same broadcast+blend as strict, but skip the 0x60 zeroing fold.
-        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
-        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
-        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, rhs.avx);
-        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, rhs.avx);
-        let sel = shl_imm_u16_m256i::<3>(rhs.avx);
-        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
-      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
-        // vqtbl2 zeroes out-of-range anyway; identical to strict.
-        use core::arch::aarch64::{int8x16x2_t, vqtbl2q_s8, vreinterpretq_u8_s8};
-        unsafe {
-          let table = int8x16x2_t(self.a.neon, self.b.neon);
-          Self {
-            a: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.a.neon)) },
-            b: i8x16 { neon: vqtbl2q_s8(table, vreinterpretq_u8_s8(rhs.b.neon)) },
-          }
-        }
-      } else {
-        // Strict fallback is a valid relaxed implementation (it zeroes OOR).
-        let sixteen = i8x16::splat(16);
-        Self {
-          a: self.a.swizzle(rhs.a) | self.b.swizzle(rhs.a - sixteen),
-          b: self.a.swizzle(rhs.b) | self.b.swizzle(rhs.b - sixteen),
-        }
-      }
-    }
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `swizzle_dyn`")]
+  pub fn swizzle_relaxed(self, idxs: Self) -> Self {
+    self.swizzle_dyn(idxs.cast_unsigned())
   }
 }

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -180,12 +180,12 @@ impl_simd! {
   /// zero is returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
-    todo!()
+    self.cast_unsigned().swizzle_dyn(idxs).cast_signed()
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u8x32) -> Self {
-    todo!()
+    self.cast_unsigned().zeroing_swizzle_dyn(idxs).cast_signed()
   }
 
   ///

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -175,6 +175,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u8x32) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/i8x32_.rs
+++ b/src/i8x32_.rs
@@ -175,6 +175,9 @@ impl_simd! {
     }
   }
 
+  ///
+  /// For [`i8x32`] specifically it is guaranteed that for overflows, either
+  /// zero is returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
     todo!()

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -27,6 +27,8 @@ macro_rules! impl_simd {
     $fn_to_bitmask:item
     $fn_any:item
     $fn_all:item
+    $fn_swizzle_dyn:item
+    $fn_zeroing_swizzle_dyn:item
     $fn_transpose:item
   ) => {
     impl From<[$T; $N]> for $Simd {
@@ -512,6 +514,24 @@ macro_rules! impl_simd {
       pub fn none(self) -> bool {
         !self.any()
       }
+
+      /// Returns a SIMD vector where each element is indexed from `self` based
+      /// on the runtime indices in `idxs`.
+      ///
+      /// Returns `[self[idxs[0]], self[idxs[1]], ...]`.
+      ///
+      /// If an index is greater than the number of elements, the result is
+      /// unspecified.
+      #[must_use]
+      $fn_swizzle_dyn
+
+      /// Returns a SIMD vector where each element is indexed from `self` based
+      /// on the runtime indices in `idxs`, returning zero if an index is
+      /// greater than the number of elements.
+      ///
+      /// Returns `[self[idxs[0]], self[idxs[1]], ...]`.
+      #[must_use]
+      $fn_zeroing_swizzle_dyn
 
       /// Transposes an array of SIMD vectors interpreted as a square matrix.
       #[must_use]

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -165,12 +165,66 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512bw", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi16;
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi16`.
+        Self { avx2: m256i(unsafe { _mm256_permutexvar_epi16(idxs.avx2.0, self.avx2.0) }) }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // This trick duplicates the lowest byte index of each 16-bit element
+        // across each 2 bytes.
+        let splatted_indices = idxs * const { u16x16::splat((2 << 8) + 2) };
+
+        // Apply an offset to higher bytes of each element to target their
+        // correct bytes instead of their lowest byte.
+        #[cfg(target_endian = "little")]
+        let byte_indices = splatted_indices + const { u16x16::splat(1 << 8) };
+        #[cfg(target_endian = "big")]
+        let byte_indices = splatted_indices + u16x16::ONE;
+
+        let self_bytes = cast::<u16x16, u8x32>(self);
+        let byte_indices = cast::<u16x16, u8x32>(byte_indices);
+
+        cast::<u8x32, u16x16>(self_bytes.swizzle_dyn(byte_indices))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 16];
+        for i in 0..16 {
+          let idx = idxs_array[i] as usize;
+          if idx < 16 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(16)
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u16x16_.rs
+++ b/src/u16x16_.rs
@@ -163,6 +163,16 @@ impl_simd! {
     i16x16::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -168,12 +168,59 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x32) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512bw"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_permutexvar_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_permutexvar_epi16;
+        // TODO(safe_arch): Add `_mm512_permutexvar_epi16`.
+        Self { avx512: m512i(unsafe { _mm512_permutexvar_epi16(idxs.avx512.0, self.avx512.0) }) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // vqtbl2 zeroes out-of-range anyway; identical to strict.
+        use core::arch::aarch64::{uint8x16x4_t, vreinterpretq_u16_u8, vreinterpretq_u8_u16, vqtbl4q_u8};
+        unsafe {
+          // This trick duplicates the lowest byte index of each 16-bit element
+          // across each 2 bytes.
+          let splatted_indices = idxs * const { u16x32::splat((2 << 8) + 2) };
+
+          // Apply an offset to higher bytes of each element to target their
+          // correct bytes instead of their lowest byte.
+          #[cfg(target_endian = "little")]
+          let byte_indices = splatted_indices + const { u16x32::splat(1 << 8) };
+          #[cfg(target_endian = "big")]
+          let byte_indices = splatted_indices + u16x32::ONE;
+
+          let table = uint8x16x4_t(
+            vreinterpretq_u8_u16(self.a.a.neon),
+            vreinterpretq_u8_u16(self.a.b.neon),
+            vreinterpretq_u8_u16(self.b.a.neon),
+            vreinterpretq_u8_u16(self.b.b.neon),
+          );
+          cast([
+            u16x8 { neon: vreinterpretq_u16_u8(vqtbl4q_u8(table, vreinterpretq_u8_u16(byte_indices.a.a.neon))) },
+            u16x8 { neon: vreinterpretq_u16_u8(vqtbl4q_u8(table, vreinterpretq_u8_u16(byte_indices.a.b.neon))) },
+            u16x8 { neon: vreinterpretq_u16_u8(vqtbl4q_u8(table, vreinterpretq_u8_u16(byte_indices.b.a.neon))) },
+            u16x8 { neon: vreinterpretq_u16_u8(vqtbl4q_u8(table, vreinterpretq_u8_u16(byte_indices.b.b.neon))) },
+          ])
+        }
+      } else {
+        let sixteen = u16x16::splat(16);
+        let [self_a, self_b] = cast::<u16x32, [u16x16; 2]>(self);
+        let [idxs_a, idxs_b] = cast::<u16x32, [u16x16; 2]>(idxs);
+        // Use zeroing swizzle to ignore overflowing subtraction.
+        cast([
+          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - sixteen),
+          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - sixteen),
+        ])
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x32) -> Self {
-    todo!()
+    // All implementations do not have the masking behavior we want
+    self.swizzle_dyn(idxs) & idxs.simd_lt(32)
   }
 
   ///

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -219,8 +219,18 @@ impl_simd! {
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x32) -> Self {
-    // All implementations do not have the masking behavior we want
-    self.swizzle_dyn(idxs) & idxs.simd_lt(32)
+    pick! {
+      if #[cfg(any(
+        target_feature = "avx512bw",
+        all(target_arch = "aarch64", target_feature = "neon"),
+      ))] {
+        // These implementations do not have the masking behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(32)
+      } else {
+        // The fallback automatically handles overflows
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u16x32_.rs
+++ b/src/u16x32_.rs
@@ -166,6 +166,16 @@ impl_simd! {
     i16x32::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x32) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x32) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -281,12 +281,67 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u16x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature = "avx512bw", target_feature = "avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm_permutexvar_epi16;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm_permutexvar_epi16;
+
+        // TODO(safe_arch): Add `_mm_permutexvar_epi16`
+        Self { sse: unsafe { m128i(_mm_permutexvar_epi16(idxs.sse.0, self.sse.0)) } }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // This trick duplicates the lowest byte index of each 16-bit element
+        // across each 2 bytes.
+        let splatted_indices = idxs * const { u16x8::splat((2 << 8) + 2) };
+
+        // Apply an offset to higher bytes of each element to target their
+        // correct bytes instead of their lowest byte.
+        #[cfg(target_endian = "little")]
+        let byte_indices = splatted_indices + const { u16x8::splat(1 << 8) };
+        #[cfg(target_endian = "big")]
+        let byte_indices = splatted_indices + u16x8::ONE;
+
+        let self_bytes = cast::<u16x8, u8x16>(self);
+        let byte_indices = cast::<u16x8, u8x16>(byte_indices);
+
+        cast::<u8x16, u16x8>(self_bytes.swizzle_dyn(byte_indices))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 8];
+        for i in 0..8 {
+          let idx = idxs_array[i] as usize;
+          if idx < 8 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u16x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(8)
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u16x8_.rs
+++ b/src/u16x8_.rs
@@ -279,6 +279,16 @@ impl_simd! {
     i16x8::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u16x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u16x8) -> Self {
+    todo!()
+  }
+
   ///
   /// This function is accelerated on multiple target architectures.
   #[inline]

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -216,8 +216,18 @@ impl_simd! {
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
-    // All implementations do not have the masking behavior we want
-    self.swizzle_dyn(idxs) & idxs.simd_lt(16)
+    pick! {
+      if #[cfg(any(
+        target_feature = "avx512f",
+        all(target_arch = "aarch64", target_feature = "neon"),
+      ))] {
+        // These implementations do not have the masking behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(16)
+      } else {
+        // The fallback automatically handles overflows
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -170,12 +170,7 @@ impl_simd! {
   pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
     pick! {
       if #[cfg(all(target_feature="avx512f"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm512_permutexvar_epi32;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm512_permutexvar_epi32;
-        // TODO(safe_arch): Add `_mm512_permutexvar_epi32`.
-        Self { avx512: m512i(unsafe { _mm512_permutexvar_epi32(idxs.avx512.0, self.avx512.0) }) }
+        Self { avx512: permute_i32_m512i(idxs.avx512, self.avx512) }
       } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         // vqtbl2 zeroes out-of-range anyway; identical to strict.
         use core::arch::aarch64::{uint8x16x4_t, vreinterpretq_u32_u8, vreinterpretq_u8_u32, vqtbl4q_u8};

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -168,12 +168,61 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_permutexvar_epi32;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_permutexvar_epi32;
+        // TODO(safe_arch): Add `_mm512_permutexvar_epi32`.
+        Self { avx512: m512i(unsafe { _mm512_permutexvar_epi32(idxs.avx512.0, self.avx512.0) }) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // vqtbl2 zeroes out-of-range anyway; identical to strict.
+        use core::arch::aarch64::{uint8x16x4_t, vreinterpretq_u32_u8, vreinterpretq_u8_u32, vqtbl4q_u8};
+        unsafe {
+          // This trick duplicates the lowest byte index of each 32-bit element
+          // across each 4 bytes.
+          let splatted_indices = idxs * const { u32x16::splat((4 << 24) + (4 << 16) + (4 << 8) + 4) };
+
+          // Apply an offset to higher bytes of each element to target their
+          // correct bytes instead of their lowest byte.
+          #[cfg(target_endian = "little")]
+          let byte_indices = splatted_indices + const {
+            u32x16::splat((1 << 8) + (2 << 16) + (3 << 24))
+          };
+          #[cfg(target_endian = "big")]
+          let byte_indices = splatted_indices + const { u32x16::splat((1 << 16) + (2 << 8) + 3) };
+
+          let table = uint8x16x4_t(
+            vreinterpretq_u8_u32(self.a.a.neon),
+            vreinterpretq_u8_u32(self.a.b.neon),
+            vreinterpretq_u8_u32(self.b.a.neon),
+            vreinterpretq_u8_u32(self.b.b.neon),
+          );
+          cast([
+            u32x4 { neon: vreinterpretq_u32_u8(vqtbl4q_u8(table, vreinterpretq_u8_u32(byte_indices.a.a.neon))) },
+            u32x4 { neon: vreinterpretq_u32_u8(vqtbl4q_u8(table, vreinterpretq_u8_u32(byte_indices.a.b.neon))) },
+            u32x4 { neon: vreinterpretq_u32_u8(vqtbl4q_u8(table, vreinterpretq_u8_u32(byte_indices.b.a.neon))) },
+            u32x4 { neon: vreinterpretq_u32_u8(vqtbl4q_u8(table, vreinterpretq_u8_u32(byte_indices.b.b.neon))) },
+          ])
+        }
+      } else {
+        let eight = u32x8::splat(8);
+        let [self_a, self_b] = cast::<u32x16, [u32x8; 2]>(self);
+        let [idxs_a, idxs_b] = cast::<u32x16, [u32x8; 2]>(idxs);
+        // Use zeroing swizzle to ignore overflowing subtraction.
+        cast([
+          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - eight),
+          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - eight),
+        ])
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
-    todo!()
+    // All implementations do not have the masking behavior we want
+    self.swizzle_dyn(idxs) & idxs.simd_lt(16)
   }
 
   ///

--- a/src/u32x16_.rs
+++ b/src/u32x16_.rs
@@ -166,6 +166,16 @@ impl_simd! {
     i32x16::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -264,6 +264,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `sse`.
   #[inline]

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -266,12 +266,61 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // This trick duplicates the lowest byte index of each 32-bit element
+        // across each 4 bytes.
+        let splatted_indices = idxs * const { u32x4::splat((4 << 24) + (4 << 16) + (4 << 8) + 4) };
+
+        // Apply an offset to higher bytes of each element to target their
+        // correct bytes instead of their lowest byte.
+        #[cfg(target_endian = "little")]
+        let byte_indices = splatted_indices + const {
+          u32x4::splat((1 << 8) + (2 << 16) + (3 << 24))
+        };
+        #[cfg(target_endian = "big")]
+        let byte_indices = splatted_indices + const { u32x4::splat((1 << 16) + (2 << 8) + 3) };
+
+        let self_bytes = cast::<u32x4, u8x16>(self);
+        let byte_indices = cast::<u32x4, u8x16>(byte_indices);
+
+        cast::<u8x16, u32x4>(self_bytes.swizzle_dyn(byte_indices))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 4];
+        for i in 0..4 {
+          let idx = idxs_array[i] as usize;
+          if idx < 4 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(4)
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u32x4_.rs
+++ b/src/u32x4_.rs
@@ -273,8 +273,17 @@ impl_simd! {
         target_feature = "simd128",
       ))] {
         // This trick duplicates the lowest byte index of each 32-bit element
-        // across each 4 bytes.
+        // across each 4 bytes. x86 native multiplication requires sse4.1, so
+        // without it its better to use shifts and adds.
+        #[cfg(any(target_feature = "sse4.1", not(target_feature = "sse2")))]
         let splatted_indices = idxs * const { u32x4::splat((4 << 24) + (4 << 16) + (4 << 8) + 4) };
+        #[cfg(all(not(target_feature = "sse4.1"), target_feature = "sse2"))]
+        let splatted_indices = {
+          let mut splatted_indices = idxs << 2;
+          splatted_indices += splatted_indices << 8;
+          splatted_indices += splatted_indices << 16;
+          splatted_indices
+        };
 
         // Apply an offset to higher bytes of each element to target their
         // correct bytes instead of their lowest byte.

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -145,6 +145,16 @@ impl_simd! {
     }
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx2`.
   #[inline]

--- a/src/u32x8_.rs
+++ b/src/u32x8_.rs
@@ -147,12 +147,68 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi32;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi32;
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi32`.
+        Self { avx2: m256i(unsafe { _mm256_permutexvar_epi32(idxs.avx2.0, self.avx2.0) }) }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // This trick duplicates the lowest byte index of each 32-bit element
+        // across each 4 bytes.
+        let splatted_indices = idxs * const { u32x8::splat((4 << 24) + (4 << 16) + (4 << 8) + 4) };
+
+        // Apply an offset to higher bytes of each element to target their
+        // correct bytes instead of their lowest byte.
+        #[cfg(target_endian = "little")]
+        let byte_indices = splatted_indices + const {
+          u32x8::splat((1 << 8) + (2 << 16) + (3 << 24))
+        };
+        #[cfg(target_endian = "big")]
+        let byte_indices = splatted_indices + const { u32x8::splat((1 << 16) + (2 << 8) + 3) };
+
+        let self_bytes = cast::<u32x8, u8x32>(self);
+        let byte_indices = cast::<u32x8, u8x32>(byte_indices);
+
+        cast::<u8x32, u32x8>(self_bytes.swizzle_dyn(byte_indices))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 8];
+        for i in 0..8 {
+          let idx = idxs_array[i] as usize;
+          if idx < 8 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u32x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(8)
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -246,12 +246,43 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(target_feature="sse2")] {
+        let e0 = Self { sse: shuffle_ai_f32_all_m128i::<0b01_00_01_00>(self.sse) };
+        let e1 = Self { sse: shuffle_ai_f32_all_m128i::<0b11_10_11_10>(self.sse) };
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        (-idxs).select(e1, e0)
+      } else if #[cfg(target_feature="simd128")] {
+        let e0 = Self { simd: u64x2_shuffle::<0, 0>(self.simd, self.simd) };
+        let e1 = Self { simd: u64x2_shuffle::<1, 1>(self.simd, self.simd) };
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        (-idxs).select(e1, e0)
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))]{
+        let e0 = unsafe { Self { neon: vdupq_n_u64(vget_lane_u64::<0>(vget_low_u64(self.neon))) } };
+        let e1 = unsafe { Self { neon: vdupq_n_u64(vget_lane_u64::<0>(vget_high_u64(self.neon))) } };
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        (-idxs).select(e1, e0)
+      } else {
+        let e0 = Self::splat(self.as_array()[0]);
+        let e1 = Self::splat(self.as_array()[1]);
+
+        // We can assume that each index is either `0` or `1`, and negating that
+        // always gives us either all bits zero or all bits one.
+        (-idxs).select(e1, e0)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
-    todo!()
+    // Since all implementations use the `select` trick, we always need to mask
+    self.swizzle_dyn(idxs) & idxs.simd_lt(2)
   }
 
   ///

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -244,6 +244,16 @@ impl_simd! {
     i64x2::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x2) -> Self {
+    todo!()
+  }
+
   ///
   /// This function is accelerated on multiple target architectures.
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -162,12 +162,78 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi64;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi64;
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi64`.
+        Self { avx2: m256i(unsafe { _mm256_permutexvar_epi64(idxs.avx2.0, self.avx2.0) }) }
+      } else if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // This trick duplicates the lowest byte index of each 64-bit element
+        // across each 8 bytes.
+        let splatted_indices = idxs * const {
+          u64x4::splat(
+            (8 << 56) + (8 << 48) + (8 << 40) + (8 << 32) + (8 << 24) + (8 << 16) + (8 << 8) + 8,
+          )
+        };
+
+        // Apply an offset to higher bytes of each element to target their
+        // correct bytes instead of their lowest byte.
+        #[cfg(target_endian = "little")]
+        let byte_indices = splatted_indices + const {
+          u64x4::splat(
+            (1 << 8) + (2 << 16) + (3 << 24) + (4 << 32) + (5 << 40) + (6 << 48) + (7 << 56),
+          )
+        };
+        #[cfg(target_endian = "big")]
+        let byte_indices = splatted_indices + const {
+          u64x4::splat(
+            (1 << 48) + (2 << 40) + (3 << 32) + (4 << 24) + (5 << 16) + (6 << 8) + 7,
+          )
+        };
+
+        let self_bytes = cast::<u64x4, u8x32>(self);
+        let byte_indices = cast::<u64x4, u8x32>(byte_indices);
+
+        cast::<u8x32, u64x4>(self_bytes.swizzle_dyn(byte_indices))
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 4];
+        for i in 0..4 {
+          let idx = idxs_array[i] as usize;
+          if idx < 4 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(any(
+        target_feature = "sse2",
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "simd128",
+      ))] {
+        // All implementations except for the fallback do not have the masking
+        // behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(4)
+      } else {
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -160,6 +160,16 @@ impl_simd! {
     i64x4::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x4) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is only accelerated on `avx2`.
   #[inline]

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -176,11 +176,21 @@ impl_simd! {
         target_feature = "simd128",
       ))] {
         // This trick duplicates the lowest byte index of each 64-bit element
-        // across each 8 bytes.
+        // across each 8 bytes. Only wasm supports native multiplication, so
+        // without it its better to use shifts and adds.
+        #[cfg(target_feature = "simd128")]
         let splatted_indices = idxs * const {
           u64x4::splat(
             (8 << 56) + (8 << 48) + (8 << 40) + (8 << 32) + (8 << 24) + (8 << 16) + (8 << 8) + 8,
           )
+        };
+        #[cfg(not(target_feature = "simd128"))]
+        let splatted_indices = {
+          let mut splatted_indices = idxs << 3;
+          splatted_indices += splatted_indices << 8;
+          splatted_indices += splatted_indices << 16;
+          splatted_indices += splatted_indices << 32;
+          splatted_indices
         };
 
         // Apply an offset to higher bytes of each element to target their

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -186,8 +186,15 @@ impl_simd! {
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
-    // All implementations do not have the masking behavior we want
-    self.swizzle_dyn(idxs) & idxs.simd_lt(8)
+    pick! {
+      if #[cfg(target_feature = "avx512f")] {
+        // The avx512 implementation does not have the masking behavior we want
+        self.swizzle_dyn(idxs) & idxs.simd_lt(8)
+      } else {
+        // The fallback automatically handles overflows
+        self.swizzle_dyn(idxs)
+      }
+    }
   }
 
   ///

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -166,6 +166,16 @@ impl_simd! {
     i64x8::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -168,12 +168,31 @@ impl_simd! {
 
   #[inline]
   pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512f"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm512_permutexvar_epi64;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm512_permutexvar_epi64;
+        // TODO(safe_arch): Add `_mm512_permutexvar_epi64`.
+        Self { avx512: m512i(unsafe { _mm512_permutexvar_epi64(idxs.avx512.0, self.avx512.0) }) }
+      } else {
+        let four = u64x4::splat(4);
+        let [self_a, self_b] = cast::<u64x8, [u64x4; 2]>(self);
+        let [idxs_a, idxs_b] = cast::<u64x8, [u64x4; 2]>(idxs);
+        // Use zeroing swizzle to ignore overflowing subtraction.
+        cast([
+          self_a.zeroing_swizzle_dyn(idxs_a) | self_b.zeroing_swizzle_dyn(idxs_a - four),
+          self_a.zeroing_swizzle_dyn(idxs_b) | self_b.zeroing_swizzle_dyn(idxs_b - four),
+        ])
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u64x8) -> Self {
-    todo!()
+    // All implementations do not have the masking behavior we want
+    self.swizzle_dyn(idxs) & idxs.simd_lt(8)
   }
 
   ///

--- a/src/u64x8_.rs
+++ b/src/u64x8_.rs
@@ -170,12 +170,7 @@ impl_simd! {
   pub fn swizzle_dyn(self, idxs: u64x8) -> Self {
     pick! {
       if #[cfg(all(target_feature="avx512f"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm512_permutexvar_epi64;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm512_permutexvar_epi64;
-        // TODO(safe_arch): Add `_mm512_permutexvar_epi64`.
-        Self { avx512: m512i(unsafe { _mm512_permutexvar_epi64(idxs.avx512.0, self.avx512.0) }) }
+        Self { avx512: permute_i64_m512i(idxs.avx512, self.avx512) }
       } else {
         let four = u64x4::splat(4);
         let [self_a, self_b] = cast::<u64x8, [u64x4; 2]>(self);

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -356,12 +356,56 @@ impl_simd! {
   /// returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        Self { sse: shuffle_av_i8z_all_m128i(self.sse, idxs.sse) }
+      } else if #[cfg(target_feature="relaxed-simd")] {
+        Self { simd: u8x16_relaxed_swizzle(self.simd, idxs.simd) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: u8x16_swizzle(self.simd, idxs.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vqtbl1q_u8(self.neon, idxs.neon) } }
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 16];
+        for i in 0..16 {
+          let idx = idxs_array[i] as usize;
+          if idx < 16 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u8x16) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(target_feature="ssse3")] {
+        Self { sse: shuffle_av_i8z_all_m128i(self.sse, add_saturating_u8_m128i(idxs.sse, set_splat_i8_m128i(0x70))) }
+      } else if #[cfg(target_feature="simd128")] {
+        Self { simd: i8x16_swizzle(self.simd, idxs.simd) }
+      } else if #[cfg(all(target_feature="neon",target_arch="aarch64"))] {
+        unsafe { Self { neon: vqtbl1q_u8(self.neon, idxs.neon) } }
+      } else {
+        let self_array = self.to_array();
+        let idxs_array = idxs.to_array();
+
+        let mut result = [0; 16];
+        for i in 0..16 {
+          let idx = idxs_array[i] as usize;
+          if idx < 16 {
+            result[i] = self_array[idx];
+          }
+        }
+
+        Self::new(result)
+      }
+    }
   }
 
   ///

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -1502,9 +1502,16 @@ impl u8x16 {
   /// * Index values in the range `[0, 15]` select the i-th element of `self`.
   /// * Index values that are out of range will cause that output lane to be
   ///   `0`.
+  ///
+  /// This function has been replaced by [`zeroing_swizzle_dyn`], which has the
+  /// same semantics and guarantees.
+  ///
+  /// [`zeroing_swizzle_dyn`]: Self::zeroing_swizzle_dyn
   #[inline]
-  pub fn swizzle(self, rhs: i8x16) -> i8x16 {
-    cast(i8x16::swizzle(cast(self), rhs))
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `zeroing_swizzle_dyn`")]
+  pub fn swizzle(self, idxs: Self) -> Self {
+    self.zeroing_swizzle_dyn(idxs)
   }
 
   /// Works like [`swizzle`](Self::swizzle) with the following additional
@@ -1515,8 +1522,15 @@ impl u8x16 {
   ///   negative), then the corresponding output lane is guaranteed to be zero.
   /// * Otherwise the output lane is either `0` or `self[rhs[i] % 16]`,
   ///   depending on the implementation.
+  ///
+  /// This function has been replaced by [`swizzle_dyn`], which has the same
+  /// semantics and guarantees.
+  ///
+  /// [`swizzle_dyn`]: Self::swizzle_dyn
   #[inline]
-  pub fn swizzle_relaxed(self, rhs: u8x16) -> u8x16 {
-    cast(i8x16::swizzle_relaxed(cast(self), cast(rhs)))
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `swizzle_dyn`")]
+  pub fn swizzle_relaxed(self, idxs: Self) -> Self {
+    self.swizzle_dyn(idxs)
   }
 }

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -350,6 +350,16 @@ impl_simd! {
     i8x16::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u8x16) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u8x16_.rs
+++ b/src/u8x16_.rs
@@ -350,6 +350,10 @@ impl_simd! {
     i8x16::all(cast(self))
   }
 
+  ///
+  /// For [`u8x16`] specifically it is guaranteed that for overflows, if the high
+  /// bit of the index is set, zero is returned. Otherwise, either zero is
+  /// returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x16) -> Self {
     todo!()

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -514,8 +514,9 @@ impl u8x32 {
   /// two halves of the vector, and the indexes each refer to the
   /// corresponding half.
   #[inline]
-  pub fn swizzle_half(self, rhs: i8x32) -> i8x32 {
-    cast(i8x32::swizzle_half(cast(self), cast(rhs)))
+  #[must_use]
+  pub fn swizzle_half(self, idxs: Self) -> Self {
+    cast(i8x32::swizzle_half(cast(self), cast(idxs)))
   }
 
   /// Indices in the range `[0, 15]` will select the i-th element of `self`. If
@@ -528,21 +529,36 @@ impl u8x32 {
   /// halves of the vector, and the indexes each refer to their corresponding
   /// half.
   #[inline]
-  pub fn swizzle_half_relaxed(self, rhs: u8x32) -> u8x32 {
-    cast(i8x32::swizzle_half_relaxed(cast(self), cast(rhs)))
+  #[must_use]
+  pub fn swizzle_half_relaxed(self, idxs: Self) -> Self {
+    cast(i8x32::swizzle_half_relaxed(cast(self), cast(idxs)))
   }
 
   /// Full 32-entry byte table lookup. An index in `[0, 31]` selects
   /// `self[index]`; any index `>= 32` yields `0`.
+  ///
+  /// This function has been replaced by [`zeroing_swizzle_dyn`], which has the
+  /// same semantics and guarantees.
+  ///
+  /// [`zeroing_swizzle_dyn`]: Self::zeroing_swizzle_dyn
   #[inline]
-  pub fn swizzle(self, rhs: u8x32) -> u8x32 {
-    cast(i8x32::swizzle(cast(self), cast(rhs)))
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `zeroing_swizzle_dyn`")]
+  pub fn swizzle(self, idxs: Self) -> Self {
+    self.zeroing_swizzle_dyn(idxs)
   }
 
   /// Like [`swizzle`](Self::swizzle), but out-of-range indices yield an
   /// implementation-defined result (`0` or `self[index % 32]`).
+  ///
+  /// This function has been replaced by [`swizzle_dyn`], which has the same
+  /// semantics and guarantees.
+  ///
+  /// [`swizzle_dyn`]: Self::swizzle_dyn
   #[inline]
-  pub fn swizzle_relaxed(self, rhs: u8x32) -> u8x32 {
-    cast(i8x32::swizzle_relaxed(cast(self), cast(rhs)))
+  #[must_use]
+  #[deprecated(since = "1.7.0", note = "replaced by `swizzle_dyn`")]
+  pub fn swizzle_relaxed(self, idxs: Self) -> Self {
+    self.swizzle_dyn(idxs)
   }
 }

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -177,12 +177,91 @@ impl_simd! {
   /// zero is returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi8;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi8;
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
+        Self { avx: m256i(unsafe { _mm256_permutexvar_epi8(idxs.avx.0, self.avx.0) }) }
+      } else if #[cfg(target_feature="avx2")] {
+        // Same broadcast+blend as strict, but skip the 0x60 zeroing fold.
+        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
+        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
+        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, idxs.avx);
+        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, idxs.avx);
+        let sel = shl_imm_u16_m256i::<3>(idxs.avx);
+        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        // vqtbl2 zeroes out-of-range anyway; identical to strict.
+        use core::arch::aarch64::{uint8x16x2_t, vqtbl2q_u8};
+        unsafe {
+          let table = uint8x16x2_t(self.a.neon, self.b.neon);
+          Self {
+            a: u8x16 { neon: vqtbl2q_u8(table, idxs.a.neon) },
+            b: u8x16 { neon: vqtbl2q_u8(table, idxs.b.neon) },
+          }
+        }
+      } else {
+        // Strict fallback is a valid relaxed implementation (it zeroes OOR).
+        let sixteen = u8x16::splat(16);
+        Self {
+          a: self.a.zeroing_swizzle_dyn(idxs.a) | self.b.zeroing_swizzle_dyn(idxs.a - sixteen),
+          b: self.a.zeroing_swizzle_dyn(idxs.b) | self.b.zeroing_swizzle_dyn(idxs.b - sixteen),
+        }
+      }
+    }
   }
 
   #[inline]
   pub fn zeroing_swizzle_dyn(self, idxs: u8x32) -> Self {
-    todo!()
+    pick! {
+      if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::_mm256_permutexvar_epi8;
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::_mm256_permutexvar_epi8;
+        // vpermb takes the index mod 32 and never zeroes, so zero the
+        // out-of-range lanes ourselves: (idxs & 0xE0) == 0  <=>  idxs < 32.
+        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
+        let permuted = m256i(unsafe { _mm256_permutexvar_epi8(idxs.avx.0, self.avx.0) });
+        let hi_bits = bitand_m256i(idxs.avx, set_splat_i8_m256i(0xE0_u8 as i8));
+        let in_range = cmp_eq_mask_i8_m256i(hi_bits, zeroed_m256i());
+        Self { avx: bitand_m256i(permuted, in_range) }
+      } else if #[cfg(target_feature="avx2")] {
+        // Broadcast each 16-byte table half into both 128-bit lanes, pshufb
+        // each by the index, blend by index bit 4. Fold the >=32 zeroing into
+        // pshufb with an unsigned saturating add of 0x60 (0x60 + 32 = 0x80).
+        let idx = add_saturating_u8_m256i(idxs.avx, set_splat_i8_m256i(0x60));
+        let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
+        let tbl_hi = shuffle_abi_i128z_all_m256i::<0x11>(self.avx, self.avx);
+        let res_lo = shuffle_av_i8z_half_m256i(tbl_lo, idx);
+        let res_hi = shuffle_av_i8z_half_m256i(tbl_hi, idx);
+        // move index bit 4 into the sign bit (bit 7) for blendv.
+        let sel = shl_imm_u16_m256i::<3>(idxs.avx);
+        Self { avx: blend_varying_i8_m256i(res_lo, res_hi, sel) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        use core::arch::aarch64::{uint8x16x2_t, vqtbl2q_u8};
+        unsafe {
+          let table = uint8x16x2_t(self.a.neon, self.b.neon);
+          Self {
+            a: u8x16 { neon: vqtbl2q_u8(table, idxs.a.neon) },
+            b: u8x16 { neon: vqtbl2q_u8(table, idxs.b.neon) },
+          }
+        }
+      } else {
+        // Generic {a,b}: each output half pulls from either table half.
+        // a.swizzle / b.swizzle are STRICT (zero index >= 16), and their
+        // nonzero domains are disjoint, so a bitwise OR selects correctly and
+        // out-of-range (>=32) falls out as 0 with no extra mask.
+        let sixteen = u8x16::splat(16);
+        Self {
+          a: self.a.zeroing_swizzle_dyn(idxs.a) | self.b.zeroing_swizzle_dyn(idxs.a - sixteen),
+          b: self.a.zeroing_swizzle_dyn(idxs.b) | self.b.zeroing_swizzle_dyn(idxs.b - sixteen),
+        }
+      }
+    }
   }
 
   ///

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -172,6 +172,16 @@ impl_simd! {
     i8x32::all(cast(self))
   }
 
+  #[inline]
+  pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
+    todo!()
+  }
+
+  #[inline]
+  pub fn zeroing_swizzle_dyn(self, idxs: u8x32) -> Self {
+    todo!()
+  }
+
   ///
   /// Currently this function is never accelerated.
   #[inline]

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -172,6 +172,9 @@ impl_simd! {
     i8x32::all(cast(self))
   }
 
+  ///
+  /// For [`u8x32`] specifically it is guaranteed that for overflows, either
+  /// zero is returned or indices wrap around, non-deterministically.
   #[inline]
   pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
     todo!()

--- a/src/u8x32_.rs
+++ b/src/u8x32_.rs
@@ -179,12 +179,7 @@ impl_simd! {
   pub fn swizzle_dyn(self, idxs: u8x32) -> Self {
     pick! {
       if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_epi8;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_epi8;
-        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
-        Self { avx: m256i(unsafe { _mm256_permutexvar_epi8(idxs.avx.0, self.avx.0) }) }
+        Self { avx: permute_i8_m256i(idxs.avx, self.avx) }
       } else if #[cfg(target_feature="avx2")] {
         // Same broadcast+blend as strict, but skip the 0x60 zeroing fold.
         let tbl_lo = shuffle_abi_i128z_all_m256i::<0x00>(self.avx, self.avx);
@@ -218,14 +213,9 @@ impl_simd! {
   pub fn zeroing_swizzle_dyn(self, idxs: u8x32) -> Self {
     pick! {
       if #[cfg(all(target_feature="avx512vbmi", target_feature="avx512vl"))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::_mm256_permutexvar_epi8;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::_mm256_permutexvar_epi8;
         // vpermb takes the index mod 32 and never zeroes, so zero the
         // out-of-range lanes ourselves: (idxs & 0xE0) == 0  <=>  idxs < 32.
-        // TODO(safe_arch): Add `_mm256_permutexvar_epi8`.
-        let permuted = m256i(unsafe { _mm256_permutexvar_epi8(idxs.avx.0, self.avx.0) });
+        let permuted = permute_i8_m256i(idxs.avx, self.avx);
         let hi_bits = bitand_m256i(idxs.avx, set_splat_i8_m256i(0xE0_u8 as i8));
         let in_range = cmp_eq_mask_i8_m256i(hi_bits, zeroed_m256i());
         Self { avx: bitand_m256i(permuted, in_range) }

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -2406,7 +2406,7 @@ fn test_zeroing_swizzle_dyn() {
       }));
       let actual = simd.zeroing_swizzle_dyn(SimdUnsigned::new(idxs));
 
-      assert_eq!(actual, expected);
+      assert_eq!(actual, expected, "\n  simd: {simd:?}\n  idxs: {idxs:?}");
     }
   });
 }

--- a/tests/simd.rs
+++ b/tests/simd.rs
@@ -1,6 +1,7 @@
 use core::ops::{BitOr, Neg, Not};
 use std::{convert::identity, iter::once};
 
+use bytemuck::checked::cast;
 use wide::{
   AlignTo, f32x4, f32x8, f32x16, f64x2, f64x4, f64x8, i8x16, i8x32, i16x8,
   i16x16, i16x32, i32x4, i32x8, i32x16, i64x2, i64x4, i64x8, u8x16, u8x32,
@@ -2324,6 +2325,86 @@ fn test_reduce_mul() {
     {
       let expected = value.into_iter().fold(1, T::wrapping_mul);
       let actual = Simd::new(value).reduce_mul();
+
+      assert_eq!(actual, expected);
+    }
+  });
+}
+
+#[test]
+fn test_swizzle_dyn() {
+  for_simd_types!(|T, N| {
+    // The values themselves do not matter here, as long as each lane is
+    // different
+    let simd = Simd::new(std::array::from_fn(|i| (i * 3 + 4) as T));
+
+    for idxs in random_iter::<[Unsigned; N]>().map(|idxs| {
+      // We need both in bounds and out of bounds indices, so wrap indices half
+      // of the time
+      idxs.map(|idx| if idx & 0b1000 != 0 { idx % N as Unsigned } else { idx })
+    }) {
+      let expected_zeroing = Simd::new(std::array::from_fn(|i| {
+        simd.as_array().get(idxs[i] as usize).copied().unwrap_or_default()
+      }));
+      let expected_wrapping = Simd::new(std::array::from_fn(|i| {
+        simd.as_array()[idxs[i] as usize % N]
+      }));
+
+      let idxs = SimdUnsigned::new(idxs);
+      let actual = simd.swizzle_dyn(idxs);
+
+      if size_of::<T>() == 1 && N == 16 {
+        // `i/u8x16` make the most guarantees
+
+        let high_bit_set =
+          cast::<SimdSigned, Simd>(idxs.cast_signed().is_negative());
+
+        assert!(
+          high_bit_set
+            .select(
+              actual.simd_eq(expected_zeroing),
+              actual.simd_eq(expected_zeroing)
+                | actual.simd_eq(expected_wrapping)
+            )
+            .all()
+        );
+      } else if size_of::<T>() == 1 {
+        // `i/u8x32` also make additional guarantees
+
+        assert!(
+          (actual.simd_eq(expected_zeroing)
+            | actual.simd_eq(expected_wrapping))
+          .all()
+        );
+      } else {
+        // We have to do this manually since `BITS` is unstable for floats
+        const T_BITS: usize = size_of::<T>() * 8;
+
+        let overflow =
+          cast::<SimdUnsigned, Simd>(idxs.simd_ge(T_BITS as Unsigned));
+
+        assert!((actual.simd_eq(expected_zeroing) | overflow).all());
+      }
+    }
+  });
+}
+
+#[test]
+fn test_zeroing_swizzle_dyn() {
+  for_simd_types!(|T, N| {
+    // The values themselves do not matter here, as long as each lane is
+    // different
+    let simd = Simd::new(std::array::from_fn(|i| (i * 3 + 4) as T));
+
+    for idxs in random_iter::<[Unsigned; N]>().map(|idxs| {
+      // We need both in bounds and out of bounds indices, so wrap indices half
+      // of the time
+      idxs.map(|idx| if idx & 0b1000 != 0 { idx % N as Unsigned } else { idx })
+    }) {
+      let expected = Simd::new(std::array::from_fn(|i| {
+        simd.as_array().get(idxs[i] as usize).copied().unwrap_or_default()
+      }));
+      let actual = simd.zeroing_swizzle_dyn(SimdUnsigned::new(idxs));
 
       assert_eq!(actual, expected);
     }

--- a/tests/simd_integer.rs
+++ b/tests/simd_integer.rs
@@ -2,7 +2,7 @@
 
 use wide::{
   f32x4, f32x8, f32x16, i8x16, i8x32, i16x8, i16x16, i32x4, i32x8, i32x16,
-  u8x16, u8x32, u16x8,
+  u8x16, u16x8,
 };
 
 use crate::utils::{for_simd_types, random_iter, simd_chunks};
@@ -1131,54 +1131,6 @@ fn test_round_float() {
 }
 
 #[test]
-fn test_swizzle() {
-  // `swizzle` is inconsistently missing from types.
-
-  for (value, indices, expected) in [
-    (
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-      [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-    ),
-    (
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      [15, 17, -13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, -1, 0],
-      [16, 0, 0, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 0, 1],
-    ),
-  ] {
-    let value = i8x16::new(value);
-    let indices = i8x16::new(indices);
-    let expected = i8x16::new(expected);
-    let actual = value.swizzle(indices);
-    assert_eq!(actual, expected);
-  }
-}
-
-#[test]
-fn test_swizzle_relaxed() {
-  // `swizzle_relaxed` is inconsistently missing from types.
-
-  for (value, indices, expected) in [
-    (
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
-      [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-    ),
-    (
-      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      [15, -17, -13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, -1, 0],
-      [16, 0, 0, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 0, 1],
-    ),
-  ] {
-    let value = i8x16::new(value);
-    let indices = i8x16::new(indices);
-    let expected = i8x16::new(expected);
-    let actual = value.swizzle_relaxed(indices);
-    assert_eq!(actual, expected);
-  }
-}
-
-#[test]
 fn test_swizzle_half() {
   // `swizzle_half` is inconsistently missing from types.
 
@@ -1196,81 +1148,6 @@ fn test_swizzle_half() {
   ]);
   let actual = value.swizzle_half(indices);
   assert_eq!(actual, expected);
-}
-
-/// Scalar reference: unsigned index in [0,31] selects table[idx], else 0.
-fn ref_swizzle32(table: [i8; 32], idx: [i8; 32]) -> [i8; 32] {
-  let mut out = [0i8; 32];
-  for i in 0..32 {
-    let ix = idx[i] as u8 as usize; // unsigned interpretation
-    out[i] = if ix < 32 { table[ix] } else { 0 };
-  }
-  out
-}
-
-#[test]
-fn test_i8x32_swizzle() {
-  let table_arr: [i8; 32] = core::array::from_fn(|i| (i as i8) + 1); // 1..=32
-  let table = i8x32::new(table_arr);
-  let cases: [[i8; 32]; 4] = [
-    core::array::from_fn(|i| i as i8), // identity
-    core::array::from_fn(|i| 31 - i as i8), // reverse
-    core::array::from_fn(|i| ((i + 16) % 32) as i8), // cross-half rotate by 16
-    {
-      let mut a = [3i8; 32];
-      a[0] = 32; // out of range -> 0
-      a[1] = 100; // out of range -> 0
-      a[2] = -1; // 255 unsigned -> 0
-      a
-    },
-  ];
-  for idx_arr in cases {
-    let expected = i8x32::new(ref_swizzle32(table_arr, idx_arr));
-    let actual = table.swizzle(i8x32::new(idx_arr));
-    assert_eq!(actual, expected, "idx={:?}", idx_arr);
-  }
-}
-
-#[test]
-fn test_i8x32_swizzle_relaxed() {
-  let table_arr: [i8; 32] = core::array::from_fn(|i| (i as i8) + 1);
-  let table = i8x32::new(table_arr);
-  let cases: [[i8; 32]; 3] = [
-    core::array::from_fn(|i| i as i8), // identity
-    core::array::from_fn(|i| 31 - i as i8), // reverse
-    core::array::from_fn(|i| ((i + 16) % 32) as i8), // cross-half
-  ];
-  for idx_arr in cases {
-    let expected = i8x32::new(ref_swizzle32(table_arr, idx_arr)); // all in-range here
-    let actual = table.swizzle_relaxed(i8x32::new(idx_arr));
-    assert_eq!(actual, expected, "idx={:?}", idx_arr);
-  }
-}
-
-#[test]
-fn test_u8x32_swizzle() {
-  let table_arr: [u8; 32] = core::array::from_fn(|i| (i as u8) + 1); // 1..=32
-  let table = u8x32::new(table_arr);
-  // strict: unsigned indices, out-of-range (incl. 128 and 255) -> 0
-  let mut idx_arr = [4u8; 32];
-  idx_arr[0] = 0;
-  idx_arr[1] = 31;
-  idx_arr[2] = 32; // OOR -> 0
-  idx_arr[3] = 128; // OOR -> 0 (would be negative i8 after cast)
-  idx_arr[4] = 255; // OOR -> 0
-  let mut expected = [0u8; 32];
-  for i in 0..32 {
-    let ix = idx_arr[i] as usize;
-    expected[i] = if ix < 32 { table_arr[ix] } else { 0 };
-  }
-  let actual = table.swizzle(u8x32::new(idx_arr));
-  assert_eq!(actual, u8x32::new(expected), "idx={:?}", idx_arr);
-
-  // relaxed: in-range only, must match table lookup
-  let rev: [u8; 32] = core::array::from_fn(|i| 31 - i as u8);
-  let rev_expected: [u8; 32] =
-    core::array::from_fn(|i| table_arr[(31 - i) as usize]);
-  assert_eq!(table.swizzle_relaxed(u8x32::new(rev)), u8x32::new(rev_expected));
 }
 
 #[test]

--- a/tests/utils/for_simd_types.rs
+++ b/tests/utils/for_simd_types.rs
@@ -46,12 +46,12 @@ macro_rules! for_simd_types {
     for_simd_types!(|T: Integer, N| $expr);
   };
   (|T: Float, N| $expr:expr) => {
-    for_simd_types!(float!(f32, 4, f32x4, i32, i32x4, $expr));
-    for_simd_types!(float!(f32, 8, f32x8, i32, i32x8, $expr));
-    for_simd_types!(float!(f32, 16, f32x16, i32, i32x16, $expr));
-    for_simd_types!(float!(f64, 2, f64x2, i64, i64x2, $expr));
-    for_simd_types!(float!(f64, 4, f64x4, i64, i64x4, $expr));
-    for_simd_types!(float!(f64, 8, f64x8, i64, i64x8, $expr));
+    for_simd_types!(float!(f32, 4, f32x4, i32, i32x4, u32, u32x4, $expr));
+    for_simd_types!(float!(f32, 8, f32x8, i32, i32x8, u32, u32x8, $expr));
+    for_simd_types!(float!(f32, 16, f32x16, i32, i32x16, u32, u32x16, $expr));
+    for_simd_types!(float!(f64, 2, f64x2, i64, i64x2, u64, u64x2, $expr));
+    for_simd_types!(float!(f64, 4, f64x4, i64, i64x4, u64, u64x4, $expr));
+    for_simd_types!(float!(f64, 8, f64x8, i64, i64x8, u64, u64x8, $expr));
   };
   (|T: Integer, N| $expr:expr) => {
     for_simd_types!(|T: Signed, N| $expr);
@@ -84,32 +84,41 @@ macro_rules! for_simd_types {
     // for_simd_types!(signed!(i64, 8, i64x8, u64, u64x8, i128, (i128x8), $expr));
   };
   (|T: Unsigned, N| $expr:expr) => {
-    for_simd_types!(unsigned!(u8, 16, u8x16, u16, (), $expr));
-    for_simd_types!(unsigned!(u8, 32, u8x32, u16, (), $expr));
-    for_simd_types!(unsigned!(u16, 8, u16x8, u32, (), $expr));
-    for_simd_types!(unsigned!(u16, 16, u16x16, u32, (), $expr));
-    for_simd_types!(unsigned!(u16, 32, u16x32, u32, (), $expr));
-    for_simd_types!(unsigned!(u32, 4, u32x4, u64, (), $expr));
-    for_simd_types!(unsigned!(u32, 8, u32x8, u64, (), $expr));
-    for_simd_types!(unsigned!(u32, 16, u32x16, u64, (), $expr));
-    for_simd_types!(unsigned!(u64, 2, u64x2, u128, (), $expr));
-    for_simd_types!(unsigned!(u64, 4, u64x4, u128, (), $expr));
-    for_simd_types!(unsigned!(u64, 8, u64x8, u128, (), $expr));
+    for_simd_types!(unsigned!(u8, 16, u8x16, i8, i8x16, u16, (), $expr));
+    for_simd_types!(unsigned!(u8, 32, u8x32, i8, i8x32, u16, (), $expr));
+    for_simd_types!(unsigned!(u16, 8, u16x8, i16, i16x8, u32, (), $expr));
+    for_simd_types!(unsigned!(u16, 16, u16x16, i16, i16x16, u32, (), $expr));
+    for_simd_types!(unsigned!(u16, 32, u16x32, i16, i16x32, u32, (), $expr));
+    for_simd_types!(unsigned!(u32, 4, u32x4, i32, i32x4, u64, (), $expr));
+    for_simd_types!(unsigned!(u32, 8, u32x8, i32, i32x8, u64, (), $expr));
+    for_simd_types!(unsigned!(u32, 16, u32x16, i32, i32x16, u64, (), $expr));
+    for_simd_types!(unsigned!(u64, 2, u64x2, i64, i64x2, u128, (), $expr));
+    for_simd_types!(unsigned!(u64, 4, u64x4, i64, i64x4, u128, (), $expr));
+    for_simd_types!(unsigned!(u64, 8, u64x8, i64, i64x8, u128, (), $expr));
   };
   (|T: Unsigned, N, DoubleSizedSimd| $expr:expr) => {
-    for_simd_types!(unsigned!(u8, 16, u8x16, u16, (u16x16), $expr));
-    for_simd_types!(unsigned!(u8, 32, u8x32, u16, (u16x32), $expr));
-    for_simd_types!(unsigned!(u16, 8, u16x8, u32, (u32x8), $expr));
-    for_simd_types!(unsigned!(u16, 16, u16x16, u32, (u32x16), $expr));
-    // for_simd_types!(unsigned!(u16, 32, u16x32, u32, (u32x32), $expr));
-    for_simd_types!(unsigned!(u32, 4, u32x4, u64, (u64x4), $expr));
-    for_simd_types!(unsigned!(u32, 8, u32x8, u64, (u64x8), $expr));
-    // for_simd_types!(unsigned!(u32, 16, u32x16, u64, (u64x16), $expr));
-    // for_simd_types!(unsigned!(u64, 2, u64x2, u128, (u128x2), $expr));
-    // for_simd_types!(unsigned!(u64, 4, u64x4, u128, (u128x4), $expr));
-    // for_simd_types!(unsigned!(u64, 8, u64x8, u128, (u128x8), $expr));
+    for_simd_types!(unsigned!(u8, 16, u8x16, i8, i8x16, u16, (u16x16), $expr));
+    for_simd_types!(unsigned!(u8, 32, u8x32, i8, i8x32, u16, (u16x32), $expr));
+    for_simd_types!(unsigned!(u16, 8, u16x8, i16, i16x8, u32, (u32x8), $expr));
+    for_simd_types!(unsigned!(u16, 16, u16x16, i16, i16x16, u32, (u32x16), $expr));
+    // for_simd_types!(unsigned!(u16, 32, u16x32, i16, i16x32, u32, (u32x32), $expr));
+    for_simd_types!(unsigned!(u32, 4, u32x4, i32, i32x4, u64, (u64x4), $expr));
+    for_simd_types!(unsigned!(u32, 8, u32x8, i32, i32x8, u64, (u64x8), $expr));
+    // for_simd_types!(unsigned!(u32, 16, u32x16, i32, i32x16, u64, (u64x16), $expr));
+    // for_simd_types!(unsigned!(u64, 2, u64x2, i64, i64x2, u128, (u128x2), $expr));
+    // for_simd_types!(unsigned!(u64, 4, u64x4, i64, i64x4, u128, (u128x4), $expr));
+    // for_simd_types!(unsigned!(u64, 8, u64x8, i64, i64x8, u128, (u128x8), $expr));
   };
-  (float!($T:ident, $N:literal, $Simd:ident, $Signed:ident, $SimdSigned:ident, $expr:expr)) => {{
+  (float!(
+    $T:ident,
+    $N:literal,
+    $Simd:ident,
+    $Signed:ident,
+    $SimdSigned:ident,
+    $Unsigned:ident,
+    $SimdUnsigned:ident,
+    $expr:expr
+  )) => {{
     type Simd = wide::$Simd;
     #[allow(dead_code)]
     type T = $T;
@@ -119,6 +128,10 @@ macro_rules! for_simd_types {
     type Signed = $Signed;
     #[allow(dead_code)]
     type SimdSigned = wide::$SimdSigned;
+    #[allow(dead_code)]
+    type Unsigned = $Unsigned;
+    #[allow(dead_code)]
+    type SimdUnsigned = wide::$SimdUnsigned;
     $crate::utils::for_simd_types_helper(|| $expr, stringify!($T), $N);
   }};
   (signed!(
@@ -137,6 +150,10 @@ macro_rules! for_simd_types {
     #[allow(dead_code)]
     const N: usize = $N;
     #[allow(dead_code)]
+    type Signed = $T;
+    #[allow(dead_code)]
+    type SimdSigned = wide::$Simd;
+    #[allow(dead_code)]
     type Unsigned = $Unsigned;
     #[allow(dead_code)]
     type SimdUnsigned = wide::$SimdUnsigned;
@@ -152,6 +169,8 @@ macro_rules! for_simd_types {
     $T:ident,
     $N:literal,
     $Simd:ident,
+    $Signed:ident,
+    $SimdSigned:ident,
     $DoubleSizedT:ident,
     ($($DoubleSizedSimd:ident)?),
     $expr:expr
@@ -161,6 +180,14 @@ macro_rules! for_simd_types {
     type T = $T;
     #[allow(dead_code)]
     const N: usize = $N;
+    #[allow(dead_code)]
+    type Signed = $Signed;
+    #[allow(dead_code)]
+    type SimdSigned = wide::$SimdSigned;
+    #[allow(dead_code)]
+    type Unsigned = $T;
+    #[allow(dead_code)]
+    type SimdUnsigned = wide::$Simd;
     #[allow(dead_code)]
     type DoubleSizedT = $DoubleSizedT;
     $(


### PR DESCRIPTION
Edit: I actually have more changes to make, so don't merge yet.

This PR adds two functions to all SIMD types:

- `swizzle_dyn`: dynamic swizzle from one input vector. Does not specify the result if indices are out of bounds, except for 8-bit element types which make additional guarantees.

- `zeroing_swizzle_dyn`: dynamic swizzle from one input vector. If an index is out of bounds, zero is returned.

These exist for *all* SIMD types, not just `i/u8` ones. Even though these functions mostly don't have hardware support for non-u8 types, they still are more optimal than the user manually indexing arrays, so I think they *should* exist (most implementations use mul+add+8bitshuffle to emulate it).

Unlike the old `swizzle` functions, which for signed integer types take *signed* integers as indices, these new functions always take unsigned integers as indices (for floats, signed integers, unsigned integers). This is one of the reasons I didn't reuse the original function names.

The original `swizzle` and `swizzle_relaxed` functions that exist for 8-bit element types are deprecated. The precise guarantees `swizzle_relaxed` made for each type are kept in `swizzle_dyn` for those types.

Before merging:

- Are there better names for these functions? (the logic behind `swizzle_dyn` is that the `dyn` should be explicit, since dynamic swizzle is more niche than constant swizzle, and the logic behind `zeroing_swizzle_dyn` is that in the future `wrapping_swizzle_dyn` can also be added, since I *think* that on avx512 that is the native behavior).

- (edit: done) I want to make some more optimizations before merge

- (edit: done) I want to make sure I didn't miss any existing `safe_arch` functions, and make sure all implementations are correct

In the future, these can be extended with `swizzle_2_dyn` (like in the open PR #305), and some form of what is currently `swizzle_half` (I am not sure how that should be named).