### PR TITLE
perf: Optimize `signum` and `copysign`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Fixed the `signum` documentation: the docs previously misstated the grammar
   and the set of inputs that map to `1.0`/`-1.0`. The behavior itself was
   already correct and matches [`f32::signum`].
+* Optimized float `signum`. This changes the bit-patterns of returned NaNs.
 
 ## 1.6.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
   and the set of inputs that map to `1.0`/`-1.0`. The behavior itself was
   already correct and matches [`f32::signum`].
 * Optimized float `signum`. This changes the bit-patterns of returned NaNs.
+* Optimized `copysign`.
 
 ## 1.6.1
 

--- a/src/simd_float.rs
+++ b/src/simd_float.rs
@@ -744,8 +744,7 @@ macro_rules! impl_simd_float {
       #[inline]
       #[must_use]
       pub fn copysign(self, sign: Self) -> Self {
-        let magnitude_mask = Self::from($T::from_bits($UnsignedT::MAX >> 1));
-        (self & magnitude_mask) | (sign & Self::from(-0.0))
+        Self::splat(-0.0).bitselect(sign, self)
       }
 
       /// Flips the sign of `self` based on the sign of `sign`.

--- a/src/simd_float.rs
+++ b/src/simd_float.rs
@@ -732,9 +732,7 @@ macro_rules! impl_simd_float {
       #[inline]
       #[must_use]
       pub fn signum(self) -> Self {
-        let result = Self::ONE | self & -Self::ZERO;
-
-        self.is_nan().select(self, result)
+        Self::ONE | self & -Self::ZERO | self.is_nan()
       }
 
       /// Returns numbers composed of the magnitudes of `self` and the signs of

--- a/tests/simd_float.rs
+++ b/tests/simd_float.rs
@@ -63,7 +63,7 @@ fn test_signum() {
       let actual = Simd::new(value).signum();
 
       assert!(
-        actual ^ expected == Simd::ZERO,
+        (actual.simd_eq(expected) | actual.is_nan() & expected.is_nan()).all(),
         "expected: {expected:?}\n  actual: {actual:?}",
       );
     }


### PR DESCRIPTION
This PR makes two simple optimizations:

- in `signum`, use `bitor` instead of `select` to handle NaNs
- in `copysign`, use `bitselect` instead of a manual implementation (since some targets have native support for it)